### PR TITLE
Add authorized-source research registry seed

### DIFF
--- a/data/authorized-source-research-registry.json
+++ b/data/authorized-source-research-registry.json
@@ -1,0 +1,218 @@
+{
+  "version": 1,
+  "lastReviewed": "2026-03-30",
+  "orderingPolicy": {
+    "freeDirectFirst": true,
+    "beatportLastResortPaidFallback": true,
+    "disallowedApproaches": [
+      "stream-ripping",
+      "preview capture",
+      "DRM bypass",
+      "unlicensed mirrors"
+    ]
+  },
+  "sources": [
+    {
+      "id": "soundcloud-direct-downloads",
+      "name": "SoundCloud Direct Downloads",
+      "scopeDecision": "in-scope-with-constraints",
+      "scopeRationale": "This is an uploader-authorized free/direct source and should be attempted before any paid fallback, but only on tracks where downloads are explicitly enabled.",
+      "implementationBucket": "free-auto",
+      "priorityRank": 10,
+      "authorizationRationale": "SoundCloud documents that uploaders can enable downloads on their own tracks and that listeners receive the original uploaded file when that option is turned on.",
+      "acquisitionMode": "authenticated per-track direct download",
+      "automationApproach": "Use track metadata or the authorized track page to detect whether the uploader enabled downloads, then fetch the original file through an authenticated browser/session flow.",
+      "automationConfidence": "medium",
+      "supportedFormats": [
+        "original-upload-format"
+      ],
+      "djElectronicFit": "medium",
+      "notableRisks": [
+        "Downloads are track-level rather than playlist-level, so playlist jobs need per-track extraction and matching.",
+        "Free downloads depend on uploader settings, and some tracks expose only external buy/download links.",
+        "The original uploaded format varies, so later provider code must normalize format expectations instead of assuming MP3 or WAV."
+      ],
+      "officialReferences": [
+        {
+          "label": "Downloading tracks",
+          "url": "https://help.soundcloud.com/hc/en-us/articles/115003448787-Downloading-tracks"
+        },
+        {
+          "label": "Enabling Downloads For Your Track",
+          "url": "https://help.soundcloud.com/hc/en-us/articles/31423603670043-Enabling-Downloads-For-Your-Track"
+        },
+        {
+          "label": "How do I upload a track to SoundCloud?",
+          "url": "https://help.soundcloud.com/hc/en-us/articles/115003450667-How-do-I-upload-a-track-to-SoundCloud-"
+        },
+        {
+          "label": "Stream Rippers",
+          "url": "https://help.soundcloud.com/hc/en-us/articles/115003448527"
+        }
+      ]
+    },
+    {
+      "id": "bandcamp",
+      "name": "Bandcamp",
+      "scopeDecision": "in-scope-with-constraints",
+      "scopeRationale": "Bandcamp is an artist/label-controlled authorized download source and fits the free/direct-first rule, but current product scope should stay on free or already-owned entitlements unless paid scope expands beyond Beatport.",
+      "implementationBucket": "free-auto",
+      "priorityRank": 20,
+      "authorizationRationale": "Bandcamp offers artist-controlled downloads in multiple formats and supports no-minimum-price releases plus redemption/download flows that originate from the rights holder's own storefront.",
+      "acquisitionMode": "download page after free checkout, redemption, or existing entitlement",
+      "automationApproach": "Prefer zero-price/no-minimum releases or already-owned downloads, then use the release or account download flow through an authenticated browser/session layer.",
+      "automationConfidence": "medium",
+      "supportedFormats": [
+        "mp3-v0",
+        "mp3-320",
+        "wav",
+        "aiff",
+        "flac",
+        "aac",
+        "ogg-vorbis",
+        "alac"
+      ],
+      "djElectronicFit": "high",
+      "notableRisks": [
+        "Bandcamp also supports paid checkout, so provider work must avoid adding a second paid queue without an explicit product decision.",
+        "Some download links are tied to purchase emails or collection entitlements, which means session and entitlement state matters.",
+        "The catalog is broad, so later matching should bias toward artist/label pages already surfaced by playlist metadata or search."
+      ],
+      "officialReferences": [
+        {
+          "label": "In which formats can I download my purchases?",
+          "url": "https://get.bandcamp.help/hc/en-us/articles/23020648367255-In-which-formats-can-I-download-my-purchases"
+        },
+        {
+          "label": "Can I re-download my purchases?",
+          "url": "https://get.bandcamp.help/hc/en-us/articles/23020664186647-Can-I-re-download-my-purchases"
+        },
+        {
+          "label": "Where's my download link?",
+          "url": "https://get.bandcamp.help/hc/en-us/articles/23020729555223-Where-s-my-download-link"
+        },
+        {
+          "label": "Free monthly credits for download codes",
+          "url": "https://get.bandcamp.help/hc/en-us/articles/23020653387543-You-guys-said-I-d-get-200-more-codes-for-free-every-month-Well-where-are-they"
+        }
+      ]
+    },
+    {
+      "id": "juno-download",
+      "name": "Juno Download",
+      "scopeDecision": "defer",
+      "scopeRationale": "Juno Download is a legitimate DJ-friendly store, but it is a paid source and therefore should stay deferred while the current product keeps Beatport as the only paid fallback.",
+      "implementationBucket": "defer",
+      "priorityRank": 40,
+      "authorizationRationale": "Juno Download sells full-length digital releases directly from the store in downloadable formats and positions itself as a DJ-oriented catalog.",
+      "acquisitionMode": "paid checkout with account download retrieval",
+      "automationApproach": "If paid-source scope expands later, implement it as an authenticated browser checkout plus download-history retrieval flow rather than as an automatic acquisition path today.",
+      "automationConfidence": "medium",
+      "supportedFormats": [
+        "mp3",
+        "wav",
+        "flac",
+        "aiff",
+        "alac"
+      ],
+      "djElectronicFit": "high",
+      "notableRisks": [
+        "It duplicates the paid-store role already reserved for Beatport in the approved product scope.",
+        "Some releases are gated by territory or rights restrictions, which would complicate deterministic acquisition.",
+        "Future implementation would need clear rules for album-only items and multi-format selection."
+      ],
+      "officialReferences": [
+        {
+          "label": "Welcome to Juno Download",
+          "url": "https://www.junodownload.com/welcome-to-junodownload/"
+        },
+        {
+          "label": "Juno Download home",
+          "url": "https://www.junodownload.com/"
+        },
+        {
+          "label": "Example release format options",
+          "url": "https://www.junodownload.com/products/50/5583711-02/"
+        }
+      ]
+    },
+    {
+      "id": "traxsource",
+      "name": "Traxsource",
+      "scopeDecision": "defer",
+      "scopeRationale": "Traxsource is another legitimate DJ-focused paid store, but it should remain deferred until the product intentionally broadens the paid fallback beyond Beatport.",
+      "implementationBucket": "defer",
+      "priorityRank": 50,
+      "authorizationRationale": "Traxsource sells DRM-free downloads in DJ-relevant formats through its own storefront and is focused on club/electronic music.",
+      "acquisitionMode": "paid checkout with account-linked downloads",
+      "automationApproach": "Treat this as future browser-assisted checkout and library retrieval work only if the product expands its paid-source scope.",
+      "automationConfidence": "medium",
+      "supportedFormats": [
+        "mp3",
+        "aiff",
+        "wav"
+      ],
+      "djElectronicFit": "high",
+      "notableRisks": [
+        "It conflicts with the current Beatport-only paid fallback rule.",
+        "Format selection happens at purchase/download time, so provider code would need explicit format handling.",
+        "Authenticated checkout and account state are mandatory, making it a higher-friction source than free/direct candidates."
+      ],
+      "officialReferences": [
+        {
+          "label": "Does Traxsource use any DRM?",
+          "url": "https://traxsource.zendesk.com/hc/en-us/articles/204567315-Does-Traxsource-use-any-DRM-digital-rights-management"
+        },
+        {
+          "label": "What file formats does Traxsource sell?",
+          "url": "https://traxsource.zendesk.com/hc/en-us/articles/204567305-What-file-formats-does-Traxsource-sell"
+        },
+        {
+          "label": "How do I select or change the audio format?",
+          "url": "https://traxsource.zendesk.com/hc/en-us/articles/115002343866-How-do-I-select-or-change-the-audio-format"
+        }
+      ]
+    },
+    {
+      "id": "beatport",
+      "name": "Beatport",
+      "scopeDecision": "required-fallback",
+      "scopeRationale": "The approved product design explicitly requires Beatport as the last-resort paid fallback after free/direct sources are exhausted.",
+      "implementationBucket": "paid-review-queue",
+      "priorityRank": 90,
+      "authorizationRationale": "Beatport is a direct digital storefront for purchased DJ downloads, with explicit support for downloading owned tracks and upgrading store purchases to lossless formats.",
+      "acquisitionMode": "aggregated paid cart review followed by account download",
+      "automationApproach": "Queue exact or high-confidence matches for human approval, then use an authenticated browser/session flow to purchase once per run and retrieve owned downloads.",
+      "automationConfidence": "high",
+      "supportedFormats": [
+        "mp3",
+        "wav",
+        "aiff"
+      ],
+      "djElectronicFit": "high",
+      "notableRisks": [
+        "Beatport must stay the last-resort paid fallback rather than an automatic first-pass provider.",
+        "Purchase and re-download limits mean later provider code needs ownership/account-state tracking.",
+        "Preview playback or streaming integrations are not authorized acquisition paths and must stay excluded."
+      ],
+      "officialReferences": [
+        {
+          "label": "Beatport about",
+          "url": "https://about.beatport.com/"
+        },
+        {
+          "label": "How do I re-download my tracks?",
+          "url": "https://support.beatport.com/hc/en-us/articles/4413007879188-How-do-I-re-download-my-tracks"
+        },
+        {
+          "label": "Upgrading Purchased tracks from MP3 to Lossless",
+          "url": "https://support.beatport.com/hc/en-us/articles/8980748912020-Upgrading-Purchased-tracks-from-MP3-to-Lossless-Beatport-Store-Only"
+        },
+        {
+          "label": "Can I DJ with the track that I purchase from Beatport?",
+          "url": "https://support.beatport.com/hc/en-us/articles/4412316699668--Can-I-DJ-with-the-track-that-I-purchase-from-Beatport"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/product/delivery-plan.md
+++ b/docs/product/delivery-plan.md
@@ -33,3 +33,10 @@ Use this as the repo-local execution brief.
 - still break implementation into planner-sized and worker-sized tasks
 - direct/native and stable sources should land before brittle browser-only integrations when sequencing work
 - paid fallback remains in scope, but after free-source flows and queueing primitives exist
+
+## Authorized-Source Research Registry
+
+- Source of truth: `data/authorized-source-research-registry.json`
+- Usage guide: `docs/product/provider-research-registry.md`
+- Later provider tasks should only implement entries marked `in-scope-with-constraints` or `required-fallback`
+- Keep `free-auto` entries ahead of any paid flow, and keep Beatport as the last-resort paid fallback queue

--- a/docs/product/provider-research-registry.md
+++ b/docs/product/provider-research-registry.md
@@ -1,0 +1,35 @@
+# Provider Research Registry
+
+Reviewed on `2026-03-30`.
+
+## Source Of Truth
+
+- Registry path: `data/authorized-source-research-registry.json`
+- This file is the machine-readable seed for later provider tasks.
+- Update the registry in place by appending or editing source objects; do not replace it with a spreadsheet or a prose-only list.
+
+## How Later Provider Tasks Should Use It
+
+1. Read the registry before opening or implementing any provider issue.
+2. Only implement sources whose `scopeDecision` is `in-scope-with-constraints` or `required-fallback`.
+3. Order work by `implementationBucket`, then `priorityRank`.
+4. `free-auto` sources come first and should be the only automatic acquisition wave.
+5. `paid-review-queue` is reserved for Beatport and must remain the last-resort paid fallback with one aggregated review queue per run.
+6. `defer` sources stay researched but unimplemented unless the product rules change.
+7. Never create providers for anything covered by `orderingPolicy.disallowedApproaches`, especially stream-ripping, preview capture, DRM bypass, or unlicensed mirrors.
+
+## Current Seed Decisions
+
+| Source | Decision | Why |
+| --- | --- | --- |
+| SoundCloud Direct Downloads | `in-scope-with-constraints` | Authorized uploader-enabled downloads; useful for exact track-level free acquisitions, but only where the artist turned downloads on. |
+| Bandcamp | `in-scope-with-constraints` | Artist/label-controlled direct downloads with strong format support; keep the current product limited to free or already-owned entitlements unless paid scope expands. |
+| Juno Download | `defer` | Legitimate DJ store, but paid and redundant with the current Beatport-only paid fallback rule. |
+| Traxsource | `defer` | Legitimate DJ store, but also paid and therefore out of the current sequence. |
+| Beatport | `required-fallback` | Explicitly required by product design as the last-resort paid queue after free/direct candidates miss. |
+
+## Extension Rules
+
+- Preserve `officialReferences` whenever you change a source decision.
+- Add new sources as new objects so later code can diff and sort them without reformatting the whole file.
+- Keep `scopeRationale` concrete enough that another worker can justify why a provider is in, deferred, or excluded without reopening the original research.

--- a/tests/authorized-source-research-registry.test.mjs
+++ b/tests/authorized-source-research-registry.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const registryPath = new URL('../data/authorized-source-research-registry.json', import.meta.url);
+const guidePath = new URL('../docs/product/provider-research-registry.md', import.meta.url);
+const deliveryPlanPath = new URL('../docs/product/delivery-plan.md', import.meta.url);
+
+async function loadJson(url) {
+  return JSON.parse(await readFile(url, 'utf8'));
+}
+
+test('authorized source research registry satisfies the seed requirements', async () => {
+  const registry = await loadJson(registryPath);
+
+  assert.equal(registry.version, 1);
+  assert.match(registry.lastReviewed, /^\d{4}-\d{2}-\d{2}$/);
+  assert.equal(registry.orderingPolicy.freeDirectFirst, true);
+  assert.equal(registry.orderingPolicy.beatportLastResortPaidFallback, true);
+  assert.ok(
+    Array.isArray(registry.orderingPolicy.disallowedApproaches) &&
+      registry.orderingPolicy.disallowedApproaches.includes('stream-ripping'),
+  );
+
+  assert.ok(Array.isArray(registry.sources));
+  assert.ok(registry.sources.length >= 5);
+
+  const ids = new Set();
+  for (const source of registry.sources) {
+    assert.ok(source.id);
+    assert.ok(!ids.has(source.id), `duplicate source id: ${source.id}`);
+    ids.add(source.id);
+
+    assert.ok(source.name);
+    assert.ok(source.scopeDecision);
+    assert.ok(source.scopeRationale);
+    assert.ok(source.implementationBucket);
+    assert.ok(Number.isInteger(source.priorityRank));
+    assert.ok(source.authorizationRationale);
+    assert.ok(source.acquisitionMode);
+    assert.ok(source.automationApproach);
+    assert.ok(source.automationConfidence);
+    assert.ok(Array.isArray(source.supportedFormats) && source.supportedFormats.length > 0);
+    assert.ok(source.djElectronicFit);
+    assert.ok(Array.isArray(source.notableRisks) && source.notableRisks.length > 0);
+    assert.ok(Array.isArray(source.officialReferences) && source.officialReferences.length > 0);
+  }
+
+  const beatport = registry.sources.find((source) => source.id === 'beatport');
+  assert.ok(beatport, 'Beatport must be present');
+  assert.equal(beatport.scopeDecision, 'required-fallback');
+  assert.equal(beatport.implementationBucket, 'paid-review-queue');
+
+  const freeCandidates = registry.sources.filter(
+    (source) => source.implementationBucket === 'free-auto',
+  );
+  assert.ok(freeCandidates.length >= 2, 'expected multiple free/direct candidates');
+});
+
+test('provider research documentation explains registry usage and ordering', async () => {
+  const [guide, deliveryPlan] = await Promise.all([
+    readFile(guidePath, 'utf8'),
+    readFile(deliveryPlanPath, 'utf8'),
+  ]);
+
+  assert.match(guide, /data\/authorized-source-research-registry\.json/);
+  assert.match(guide, /free\/direct/i);
+  assert.match(guide, /Beatport/i);
+  assert.match(guide, /last-resort paid fallback/i);
+
+  assert.match(deliveryPlan, /Authorized-Source Research Registry/i);
+  assert.match(deliveryPlan, /data\/authorized-source-research-registry\.json/);
+});


### PR DESCRIPTION
**@worker-02**

## Summary
- add a machine-readable authorized-source research registry seed with five reviewed sources
- document how later provider tasks should use ordering and scope decisions from that registry
- add a lightweight `node --test` validation to keep the seed structured and discoverable

## Verification
- `node --test tests/authorized-source-research-registry.test.mjs`
