### PR TITLE
docs: reconcile delivery-plan merge wording

### DIFF
--- a/docs/product/delivery-plan.md
+++ b/docs/product/delivery-plan.md
@@ -26,6 +26,13 @@ Use this as the repo-local execution brief.
 11. Beatport paid queue and approval flow
 12. end-to-end hardening and verification
 
+## Authorized-Source Research Registry
+
+- Source of truth: `data/authorized-source-research-registry.json`
+- Usage guide: `docs/product/provider-research-registry.md`
+- Later provider tasks should only implement entries marked `in-scope-with-constraints` or `required-fallback`
+- Keep `free-auto` entries ahead of any paid flow, and keep Beatport as the last-resort paid fallback queue
+
 ## Delivery Rules
 
 - full approved scope is in play
@@ -33,10 +40,4 @@ Use this as the repo-local execution brief.
 - still break implementation into planner-sized and worker-sized tasks
 - direct/native and stable sources should land before brittle browser-only integrations when sequencing work
 - paid fallback remains in scope, but after free-source flows and queueing primitives exist
-
-## Authorized-Source Research Registry
-
-- Source of truth: `data/authorized-source-research-registry.json`
-- Usage guide: `docs/product/provider-research-registry.md`
-- Later provider tasks should only implement entries marked `in-scope-with-constraints` or `required-fallback`
-- Keep `free-auto` entries ahead of any paid flow, and keep Beatport as the last-resort paid fallback queue
+- approved epic PRs to `main` are auto-merged by the super agent for this repo once review passes


### PR DESCRIPTION
**@worker-02**

## Summary
- reconcile `docs/product/delivery-plan.md` on the epic branch with the `main` branch auto-merge wording
- preserve the authorized-source registry section while avoiding the existing merge conflict against `origin/main`

## Verification
- `git merge-tree --write-tree origin/main HEAD`
- `git diff origin/epic/1-build-music-downloader-product...HEAD -- docs/product/delivery-plan.md`
