### PR TITLE
Bootstrap the Next.js app shell and toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+playwright-report
+test-results
+coverage
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
 # music-downloader
 
-Bootstrap repository for the Forge-managed `music-downloader` product.
+Local web app for authorized-source playlist acquisition, optimized for DJ and electronic workflows.
+
+## Product Scope
+
+- Local-only operator workflow
+- Authorized-source acquisition only
+- No stream-ripping, bypass, or unauthorized-source behavior
+- Current state: bootstrap app shell with placeholder intake and recent-run surfaces
+
+## Requirements
+
+- Node.js `24.x` or newer
+- npm `11.x` or newer
+
+## Setup
+
+```bash
+npm install
+```
+
+## Run
+
+```bash
+npm run dev
+```
+
+Open `http://127.0.0.1:3000`.
+
+## Commands
+
+```bash
+npm run build
+npm run lint
+npm run test
+npm run test:e2e
+```
+
+## Notes
+
+- The landing page currently establishes the shared shell, form controls, and placeholder recent-runs area for later tasks.
+- Background jobs, provider matching, manifests, misses, and artifact packaging land in later issues.

--- a/docs/superpowers/plans/2026-03-31-bootstrap-app-shell.md
+++ b/docs/superpowers/plans/2026-03-31-bootstrap-app-shell.md
@@ -1,0 +1,66 @@
+# Bootstrap App Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bootstrap the repo into a working Next.js App Router app with the first shared shell primitives, smoke tests, and local developer scripts.
+
+**Architecture:** Use a manual Next.js scaffold with `src/app` for routing, `src/components` for reusable shell primitives, and repo-local CSS variables for the shared visual baseline. Add Vitest for component smoke tests and Playwright for browser smoke tests, then wire the scripts and docs around that baseline.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript 6, ESLint 9 with `eslint-config-next`, Vitest 4, Testing Library, Playwright 1.58
+
+---
+
+## Chunk 1: Tooling and Red Tests
+
+### Task 1: Create the runtime and test configuration
+
+**Files:**
+- Create: `package.json`
+- Create: `tsconfig.json`
+- Create: `next-env.d.ts`
+- Create: `next.config.ts`
+- Create: `eslint.config.mjs`
+- Create: `vitest.config.ts`
+- Create: `vitest.setup.ts`
+- Create: `playwright.config.ts`
+
+- [ ] **Step 1: Add the package and config files without production UI code**
+- [ ] **Step 2: Install dependencies and generate the lockfile**
+- [ ] **Step 3: Add a failing Vitest smoke test for the landing screen**
+- [ ] **Step 4: Run the Vitest smoke test and confirm it fails because the screen is not implemented yet**
+- [ ] **Step 5: Add a failing Playwright smoke test for `/`**
+- [ ] **Step 6: Run the Playwright smoke test and confirm it fails because the page shell is not implemented yet**
+
+## Chunk 2: App Shell Green Phase
+
+### Task 2: Implement the first shared shell primitives and landing page
+
+**Files:**
+- Create: `src/app/layout.tsx`
+- Create: `src/app/page.tsx`
+- Create: `src/app/globals.css`
+- Create: `src/components/ui/panel.tsx`
+- Create: `src/components/ui/status-badge.tsx`
+- Create: `src/components/ui/file-badge.tsx`
+- Create: `src/features/home/home-screen.tsx`
+
+- [ ] **Step 1: Implement the minimal shell and landing page needed to satisfy the Vitest smoke test**
+- [ ] **Step 2: Run the Vitest smoke test and confirm it passes**
+- [ ] **Step 3: Wire the page through the App Router entrypoint**
+- [ ] **Step 4: Run the Playwright smoke test and confirm it passes**
+- [ ] **Step 5: Refine the CSS variables and layout details until the shell matches the approved visual baseline without adding fake functionality**
+
+## Chunk 3: Finish and Verify
+
+### Task 3: Document and verify the bootstrap
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update the README with setup, run, lint, unit test, and e2e test commands**
+- [ ] **Step 2: Note the authorized-source-only product scope in the README**
+- [ ] **Step 3: Run `npm run lint`**
+- [ ] **Step 4: Run `npm run test`**
+- [ ] **Step 5: Run `npm run build`**
+- [ ] **Step 6: Run `npm run test:e2e`**
+- [ ] **Step 7: Commit the completed issue work**

--- a/docs/superpowers/specs/2026-03-31-bootstrap-app-shell-design.md
+++ b/docs/superpowers/specs/2026-03-31-bootstrap-app-shell-design.md
@@ -1,0 +1,41 @@
+# Bootstrap App Shell Design
+
+## Context
+
+Issue `#3` is the repository bootstrap task for the `music-downloader` product. The repo currently contains only product docs, so this change needs to establish the application baseline that later playlist ingestion, matching, job, and artifact work can extend.
+
+## Goals
+
+- Create a working Next.js App Router application in the repo root.
+- Establish shared shell primitives that match the approved local-tool visual language:
+  - warm gray page background
+  - dark panel surfaces
+  - compact spacing
+  - dense form and table controls
+  - reusable file and status badges
+- Add an honest landing page with one playlist URL field, one submit button, and a recent-runs placeholder section.
+- Add local Vitest and Playwright smoke coverage.
+- Document install, run, and test commands in the README.
+
+## Approach
+
+Use a lean manual scaffold instead of a generated app template. That keeps the repo focused on the exact runtime, test, and styling files required by the issue while still following the approved stack: Next.js App Router, React, TypeScript, Vitest, Playwright, and lint/build scripts.
+
+The UI baseline will be built from repo-local components and CSS variables rather than a component library. The first reusable primitives will be:
+
+- a shell wrapper for the main page structure
+- dark panel containers for grouped content
+- status badges for run state
+- file badges for expected outputs
+
+## User Experience
+
+The landing page should feel like a dense local operator tool, not a marketing page. It will open with a compact masthead, a job-intake panel containing the playlist URL input and submit button, and a recent-runs panel that clearly states the queue and artifact generation flows are still placeholders at this stage.
+
+The page must remain honest about scope: no fake job submission, no simulated progress, and no unauthorized-source language.
+
+## Testing
+
+- Vitest smoke coverage will render the landing screen component and assert the URL field, submit button, placeholder copy, and reusable badges.
+- Playwright smoke coverage will load `/` and confirm the main app shell renders in a browser session.
+- Build and lint scripts must pass locally before handoff.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,15 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypeScript from "eslint-config-next/typescript";
+
+export default defineConfig([
+  ...nextCoreWebVitals,
+  ...nextTypeScript,
+  globalIgnores([
+    ".next/**",
+    "coverage/**",
+    "playwright-report/**",
+    "test-results/**",
+    "next-env.d.ts"
+  ])
+]);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "music-downloader",
+  "version": "0.1.0",
+  "private": true,
+  "packageManager": "npm@11.3.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "next": "16.2.1",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.2",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "14.6.1",
+    "@types/node": "25.5.0",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.1",
+    "eslint": "9.39.1",
+    "eslint-config-next": "16.2.1",
+    "jsdom": "29.0.1",
+    "typescript": "6.0.2",
+    "vitest": "4.1.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "next dev",
     "build": "next build",
     "lint": "eslint .",
-    "test": "vitest run",
+    "test": "npm run test:registry && npm run test:unit",
+    "test:registry": "node --test tests/authorized-source-research-registry.test.mjs",
+    "test:unit": "vitest run",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  reporter: "list",
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "on-first-retry"
+  },
+  webServer: {
+    command: "npm run dev -- --hostname 127.0.0.1 --port 3000",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ]
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,361 @@
+:root {
+  --bg: #d9d1c7;
+  --bg-shadow: rgba(32, 27, 23, 0.14);
+  --panel: rgba(35, 34, 32, 0.94);
+  --panel-soft: rgba(54, 50, 45, 0.88);
+  --line: rgba(248, 234, 214, 0.14);
+  --text: #f5eee5;
+  --text-soft: #c8beaf;
+  --accent: #f2ba62;
+  --accent-soft: rgba(242, 186, 98, 0.12);
+  --warning: #d98d47;
+  --success: #7fc7b5;
+  --shadow: 0 22px 48px rgba(17, 16, 14, 0.22);
+  --radius-xl: 24px;
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  --font-sans: "Avenir Next", "Trebuchet MS", "Segoe UI", sans-serif;
+  --font-mono: "IBM Plex Mono", "SFMono-Regular", "Menlo", monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  font-family: var(--font-sans);
+  color: var(--text);
+  background:
+    radial-gradient(circle at top left, rgba(255, 245, 224, 0.5), transparent 32%),
+    linear-gradient(145deg, #d7cec4 0%, #c6beb5 52%, #bcb4aa 100%);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(110deg, rgba(40, 34, 29, 0.06), transparent 30%),
+    linear-gradient(transparent 0, transparent calc(100% - 1px), rgba(58, 48, 42, 0.05) calc(100% - 1px));
+  background-size: 100% 100%, 100% 18px;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.app-shell {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 2rem 0 2.5rem;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(260px, 0.9fr);
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1rem;
+}
+
+.hero-kicker,
+.panel-eyebrow {
+  margin: 0 0 0.4rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  color: rgba(47, 37, 28, 0.72);
+  font-family: var(--font-mono);
+}
+
+.hero h1,
+.panel h2 {
+  margin: 0;
+  line-height: 0.94;
+  letter-spacing: -0.04em;
+}
+
+.hero h1 {
+  max-width: 12ch;
+  font-size: clamp(3.1rem, 7vw, 5.9rem);
+  color: #201b17;
+}
+
+.hero-copy,
+.hero-note,
+.field-hint,
+.empty-state p,
+.status-list dd,
+.panel-caption {
+  margin: 0;
+  color: rgba(39, 32, 27, 0.74);
+  line-height: 1.45;
+}
+
+.hero-copy {
+  max-width: 48rem;
+  margin-top: 0.9rem;
+  font-size: 1.02rem;
+}
+
+.hero-sidecar {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(46, 39, 34, 0.12);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 247, 236, 0.54);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(300px, 0.95fr);
+  gap: 1rem;
+}
+
+.panel {
+  display: grid;
+  gap: 1.15rem;
+  padding: 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xl);
+  background:
+    linear-gradient(180deg, rgba(63, 56, 50, 0.96), rgba(31, 30, 28, 0.96)),
+    var(--panel);
+  box-shadow: var(--shadow);
+  animation: lift-in 0.45s ease both;
+}
+
+.panel:nth-child(2) {
+  animation-delay: 0.08s;
+}
+
+.panel-header {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.panel h2 {
+  font-size: 1.5rem;
+}
+
+.panel-caption {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0 0.7rem;
+  border: 1px solid rgba(242, 186, 98, 0.16);
+  border-radius: 999px;
+  background: rgba(242, 186, 98, 0.08);
+  color: var(--text-soft);
+  font-size: 0.82rem;
+}
+
+.panel-body,
+.panel-form,
+.empty-state {
+  display: grid;
+  gap: 0.95rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.field-label {
+  font-size: 0.88rem;
+  color: var(--text-soft);
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.field-input {
+  width: 100%;
+  min-height: 3.25rem;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid rgba(255, 243, 228, 0.14);
+  border-radius: var(--radius-md);
+  background: rgba(14, 14, 13, 0.45);
+  color: var(--text);
+  outline: none;
+  transition:
+    border-color 140ms ease,
+    transform 140ms ease,
+    background-color 140ms ease;
+}
+
+.field-input::placeholder {
+  color: rgba(200, 190, 175, 0.54);
+}
+
+.field-input:focus {
+  border-color: rgba(242, 186, 98, 0.82);
+  background: rgba(14, 14, 13, 0.62);
+  transform: translateY(-1px);
+}
+
+.form-actions {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.primary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.85rem;
+  width: fit-content;
+  padding: 0 1rem;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: linear-gradient(180deg, #f2ba62 0%, #d39241 100%);
+  color: #191613;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.26),
+    0 14px 26px rgba(12, 11, 10, 0.24);
+}
+
+.primary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.68;
+  filter: saturate(0.65);
+}
+
+.field-hint,
+.empty-state p,
+.status-list dd {
+  color: var(--text-soft);
+}
+
+.empty-state-head {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.status-badge,
+.file-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0 0.72rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;
+}
+
+.status-badge {
+  border: 1px solid rgba(242, 186, 98, 0.18);
+}
+
+.status-badge--muted {
+  background: var(--accent-soft);
+  color: #2e2010;
+}
+
+.status-badge--warning {
+  background: rgba(217, 141, 71, 0.14);
+  color: #f4c38f;
+}
+
+.status-badge--success {
+  background: rgba(127, 199, 181, 0.14);
+  color: #a9e7d9;
+}
+
+.file-badge {
+  border: 1px solid rgba(255, 243, 228, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+}
+
+.status-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.status-list div {
+  padding-top: 0.85rem;
+  border-top: 1px solid rgba(255, 243, 228, 0.08);
+}
+
+.status-list dt {
+  margin: 0 0 0.3rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+@keyframes lift-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 900px) {
+  .hero,
+  .dashboard-grid,
+  .status-list {
+    grid-template-columns: 1fr;
+  }
+
+  .hero h1 {
+    max-width: none;
+  }
+
+  .panel-header {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    width: min(100% - 1rem, 100%);
+    padding-top: 1.2rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.5rem, 14vw, 4rem);
+  }
+
+  .panel,
+  .hero-sidecar {
+    border-radius: 20px;
+  }
+
+  .primary-button {
+    width: 100%;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Music Downloader",
+  description:
+    "Local authorized-source playlist acquisition workspace for DJ and electronic workflows."
+};
+
+type RootLayoutProps = {
+  children: ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { HomeScreen } from "@/features/home/home-screen";
+
+export default function HomePage() {
+  return <HomeScreen />;
+}

--- a/src/components/ui/file-badge.tsx
+++ b/src/components/ui/file-badge.tsx
@@ -1,0 +1,7 @@
+type FileBadgeProps = {
+  label: string;
+};
+
+export function FileBadge({ label }: FileBadgeProps) {
+  return <span className="file-badge">{label}</span>;
+}

--- a/src/components/ui/panel.tsx
+++ b/src/components/ui/panel.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+
+type PanelProps = {
+  title: string;
+  eyebrow?: string;
+  footer?: ReactNode;
+  className?: string;
+  children: ReactNode;
+};
+
+export function Panel({
+  title,
+  eyebrow,
+  footer,
+  className,
+  children
+}: PanelProps) {
+  const classes = ["panel", className].filter(Boolean).join(" ");
+
+  return (
+    <section className={classes}>
+      <div className="panel-header">
+        <div>
+          {eyebrow ? <p className="panel-eyebrow">{eyebrow}</p> : null}
+          <h2>{title}</h2>
+        </div>
+        {footer ? <div className="panel-footer">{footer}</div> : null}
+      </div>
+      <div className="panel-body">{children}</div>
+    </section>
+  );
+}

--- a/src/components/ui/status-badge.tsx
+++ b/src/components/ui/status-badge.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+type StatusBadgeProps = {
+  children: ReactNode;
+  tone?: "muted" | "success" | "warning";
+};
+
+export function StatusBadge({
+  children,
+  tone = "muted"
+}: StatusBadgeProps) {
+  return (
+    <span className={`status-badge status-badge--${tone}`}>{children}</span>
+  );
+}

--- a/src/features/home/home-screen.test.tsx
+++ b/src/features/home/home-screen.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+
+import { HomeScreen } from "./home-screen";
+
+describe("HomeScreen", () => {
+  it("renders the intake shell and empty run state", () => {
+    render(<HomeScreen />);
+
+    expect(
+      screen.getByRole("heading", { name: /authorized-source acquisition/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/playlist url/i)).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /queue playlist/i })
+    ).toBeDisabled();
+    expect(screen.getByRole("heading", { name: /recent runs/i })).toBeVisible();
+    expect(screen.getByText(/downloads\.zip/i)).toBeVisible();
+    expect(screen.getAllByText(/no runs yet/i)).toHaveLength(2);
+  });
+});

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -1,0 +1,97 @@
+import { FileBadge } from "@/components/ui/file-badge";
+import { Panel } from "@/components/ui/panel";
+import { StatusBadge } from "@/components/ui/status-badge";
+
+const artifacts = ["downloads.zip", "manifest.json", "misses.txt"];
+
+export function HomeScreen() {
+  return (
+    <main className="app-shell">
+      <header className="hero">
+        <div>
+          <p className="hero-kicker">Local operator shell</p>
+          <h1>Authorized-source acquisition</h1>
+          <p className="hero-copy">
+            Intake one Spotify or SoundCloud playlist URL, then hand the
+            background job, matching, and artifact work off to later tasks.
+          </p>
+        </div>
+        <div className="hero-sidecar">
+          <StatusBadge>No runs yet</StatusBadge>
+          <p className="hero-note">
+            This bootstrap only defines the shared shell. It does not start
+            jobs, rip streams, or simulate provider behavior.
+          </p>
+        </div>
+      </header>
+
+      <div className="dashboard-grid">
+        <Panel
+          eyebrow="Intake"
+          title="Playlist Intake"
+          footer={<span className="panel-caption">Shared form baseline</span>}
+        >
+          <form className="panel-form">
+            <label className="field" htmlFor="playlist-url">
+              <span className="field-label">Playlist URL</span>
+              <input
+                id="playlist-url"
+                className="field-input"
+                name="playlistUrl"
+                type="url"
+                placeholder="https://open.spotify.com/playlist/..."
+              />
+            </label>
+
+            <div className="form-actions">
+              <button className="primary-button" type="submit" disabled>
+                Queue Playlist
+              </button>
+              <p className="field-hint">
+                Submission wiring lands in a later issue. This screen stays
+                honest about the current bootstrap scope.
+              </p>
+            </div>
+          </form>
+        </Panel>
+
+        <Panel
+          eyebrow="Run Report"
+          title="Recent Runs"
+          footer={<span className="panel-caption">Empty state placeholder</span>}
+        >
+          <div className="empty-state">
+            <div className="empty-state-head">
+              <StatusBadge tone="warning">No runs yet</StatusBadge>
+              <p>
+                Completed acquisitions will publish their report, misses, and
+                packaged download artifacts here.
+              </p>
+            </div>
+
+            <div className="badge-row" aria-label="Expected output artifacts">
+              {artifacts.map((artifact) => (
+                <FileBadge key={artifact} label={artifact} />
+              ))}
+            </div>
+
+            <dl className="status-list">
+              <div>
+                <dt>Queue</dt>
+                <dd>No review queue entries yet.</dd>
+              </div>
+              <div>
+                <dt>Runs</dt>
+                <dd>The background job model is not wired in this issue.</dd>
+              </div>
+              <div>
+                <dt>Artifacts</dt>
+                <dd>Output packaging will populate once jobs exist.</dd>
+              </div>
+            </dl>
+          </div>
+        </Panel>
+      </div>
+    </main>
+  );
+}

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("renders the intake shell", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: /authorized-source acquisition/i })
+  ).toBeVisible();
+  await expect(page.getByLabel(/playlist url/i)).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /queue playlist/i })
+  ).toBeVisible();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["vitest/globals"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -23,6 +23,12 @@
     },
     "types": ["vitest/globals"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src")
+    }
+  },
+  test: {
+    css: true,
+    environment: "jsdom",
+    globals: true,
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    setupFiles: "./vitest.setup.ts"
+  }
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
**@worker-01**

## Summary
- bootstrap the repo into a Next.js App Router app with shared shell primitives and the initial intake/recent-runs landing page
- add lint, build, unit, registry, and Playwright smoke coverage for the new baseline
- document local setup and command usage while keeping the authorized-source guardrails explicit

## Test Plan
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run test:e2e`

## Notes
- Verification was run from a temporary export of this branch because the assigned worktree is being auto-reset to detached `origin/main` by an external process.
- Closes #3
