### PR TITLE
fix: reject explicit trailing mix labels

### DIFF
--- a/src/features/tracks/canonical-track.test.ts
+++ b/src/features/tracks/canonical-track.test.ts
@@ -123,6 +123,16 @@ describe("extractMixMetadata", () => {
       selectionClass: "reject"
     });
   });
+
+  it("keeps explicit non-approved trailing labels rejected after promotional tags are removed", () => {
+    expect(extractMixMetadata("Consciousness (Live) [Free Download]")).toMatchObject({
+      cleanTitle: "Consciousness",
+      displayLabel: "Live",
+      normalizedLabel: "live",
+      kind: "variant",
+      selectionClass: "reject"
+    });
+  });
 });
 
 describe("parseDurationSeconds", () => {
@@ -169,6 +179,24 @@ describe("evaluateTrackCandidate", () => {
       reason: "mix-version-not-eligible",
       selectedFormat: "mp3",
       details: "Radio Edit is outside the approved mix preference order."
+    });
+  });
+
+  it("does not treat explicit labeled variants as eligible base fallbacks", () => {
+    const decision = evaluateTrackCandidate(
+      canonicalizeTrack({
+        source: "soundcloud",
+        title: "Tinlicker - Fractal (Live)",
+        duration: 301,
+        availableFormats: ["mp3", "wav"]
+      })
+    );
+
+    expect(decision).toEqual({
+      outcome: "rejected",
+      reason: "mix-version-not-eligible",
+      selectedFormat: "mp3",
+      details: "Live is outside the approved mix preference order."
     });
   });
 });

--- a/src/features/tracks/canonical-track.ts
+++ b/src/features/tracks/canonical-track.ts
@@ -139,18 +139,28 @@ export function extractMixMetadata(rawTitle: string): CanonicalMixMetadata {
   if (labelMatch) {
     const displayLabel = cleanDisplayText(labelMatch[1]);
     const classification = classifyMixLabel(displayLabel);
+    const cleanTitle = cleanDisplayText(
+      titleWithoutPromotions.slice(0, titleWithoutPromotions.length - labelMatch[0].length)
+    );
 
     if (classification !== null) {
       return {
-        cleanTitle: cleanDisplayText(
-          titleWithoutPromotions.slice(0, titleWithoutPromotions.length - labelMatch[0].length)
-        ),
+        cleanTitle,
         displayLabel,
         normalizedLabel: normalizeSearchText(displayLabel),
         ...classification,
         confidence: "high"
       };
     }
+
+    return {
+      cleanTitle,
+      displayLabel,
+      normalizedLabel: normalizeSearchText(displayLabel),
+      kind: "variant",
+      selectionClass: "reject",
+      confidence: "high"
+    };
   }
 
   return {


### PR DESCRIPTION
**@worker-02**

## Summary
- reject explicit trailing labels as non-eligible variants instead of versionless fallback candidates
- preserve promotional-label stripping while keeping the explicit trailing label classification
- add regression coverage for `(Live)` fallback rejection and `[Free Download]` stripping behavior

## Testing
- `npx vitest run`
- `npx eslint .`
- `node --test tests/authorized-source-research-registry.test.mjs`

Closes #39
