### PR TITLE
feat: add SQLite run persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules
 playwright-report
 test-results
 coverage
-
+data/*.sqlite
+data/*.sqlite-*

--- a/src/app/api/runs/[runId]/route.ts
+++ b/src/app/api/runs/[runId]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+import { getRunStore } from "@/features/runs/run-store";
+
+type RouteContext = {
+  params: Promise<{
+    runId: string;
+  }>;
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const { runId } = await context.params;
+  const run = getRunStore().getRun(runId);
+
+  if (!run) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(run);
+}

--- a/src/app/api/runs/route.test.ts
+++ b/src/app/api/runs/route.test.ts
@@ -1,0 +1,76 @@
+/* @vitest-environment node */
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+async function withTempDatabase(
+  callback: (databasePath: string) => Promise<void> | void
+) {
+  const tempDirectory = mkdtempSync(path.join(tmpdir(), "music-downloader-api-"));
+  const databasePath = path.join(tempDirectory, "music-downloader.sqlite");
+
+  process.env.MUSIC_DOWNLOADER_DB_PATH = databasePath;
+
+  try {
+    await callback(databasePath);
+  } finally {
+    const runStoreModule = await import("@/features/runs/run-store");
+
+    runStoreModule.resetRunStoreForTests();
+    delete process.env.MUSIC_DOWNLOADER_DB_PATH;
+    rmSync(tempDirectory, { force: true, recursive: true });
+  }
+}
+
+describe("/api/runs", () => {
+  it("creates a queued run and exposes its pollable status", async () => {
+    await withTempDatabase(async (databasePath) => {
+      vi.resetModules();
+
+      const [{ POST }, { GET }, runStoreModule] = await Promise.all([
+        import("./route"),
+        import("../runs/[runId]/route"),
+        import("@/features/runs/run-store")
+      ]);
+
+      const createResponse = await POST(
+        new Request("http://localhost/api/runs", {
+          body: JSON.stringify({
+            playlistUrl:
+              "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9"
+          }),
+          headers: {
+            "content-type": "application/json"
+          },
+          method: "POST"
+        })
+      );
+
+      expect(createResponse.status).toBe(201);
+      expect(existsSync(databasePath)).toBe(true);
+
+      const createdRun = (await createResponse.json()) as { id: string };
+      const pollResponse = await GET(
+        new Request(`http://localhost/api/runs/${createdRun.id}`),
+        {
+          params: Promise.resolve({ runId: createdRun.id })
+        }
+      );
+      const polledRun = (await pollResponse.json()) as {
+        id: string;
+        sourceType: string;
+        status: string;
+      };
+
+      expect(polledRun).toEqual(
+        expect.objectContaining({
+          id: createdRun.id,
+          sourceType: "spotify",
+          status: "queued"
+        })
+      );
+      expect(runStoreModule.getRunStore().listRuns()).toHaveLength(1);
+    });
+  });
+});

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+
+import { getRunStore, type PlaylistSource } from "@/features/runs/run-store";
+
+function detectPlaylistSource(playlistUrl: string): PlaylistSource | null {
+  try {
+    const parsedUrl = new URL(playlistUrl);
+    const hostname = parsedUrl.hostname.toLowerCase();
+
+    if (hostname.includes("spotify.com")) {
+      return "spotify";
+    }
+
+    if (hostname.includes("soundcloud.com")) {
+      return "soundcloud";
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET() {
+  return NextResponse.json(getRunStore().listRuns());
+}
+
+export async function POST(request: Request) {
+  const payload = (await request.json().catch(() => null)) as
+    | { playlistUrl?: string }
+    | null;
+  const playlistUrl = payload?.playlistUrl?.trim();
+
+  if (!playlistUrl) {
+    return NextResponse.json(
+      { error: "playlistUrl is required" },
+      { status: 400 }
+    );
+  }
+
+  const sourceType = detectPlaylistSource(playlistUrl);
+
+  if (!sourceType) {
+    return NextResponse.json(
+      { error: "Only Spotify and SoundCloud playlist URLs are supported." },
+      { status: 400 }
+    );
+  }
+
+  const run = getRunStore().createRun({ playlistUrl, sourceType });
+
+  return NextResponse.json(run, { status: 201 });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -94,6 +94,10 @@ input {
 .field-hint,
 .empty-state p,
 .status-list dd,
+.run-card dd,
+.run-card-url,
+.run-card-source,
+.form-status,
 .panel-caption {
   margin: 0;
   color: rgba(39, 32, 27, 0.74);
@@ -212,6 +216,10 @@ input {
   gap: 0.65rem;
 }
 
+.form-status {
+  font-size: 0.88rem;
+}
+
 .primary-button {
   display: inline-flex;
   align-items: center;
@@ -238,7 +246,8 @@ input {
 
 .field-hint,
 .empty-state p,
-.status-list dd {
+.status-list dd,
+.run-card dd {
   color: var(--text-soft);
 }
 
@@ -303,13 +312,69 @@ input {
   border-top: 1px solid rgba(255, 243, 228, 0.08);
 }
 
-.status-list dt {
+.status-list dt,
+.run-card-stats dt {
   margin: 0 0 0.3rem;
   color: var(--accent);
   font-size: 0.78rem;
   font-family: var(--font-mono);
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.run-list {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.run-card {
+  display: grid;
+  gap: 0.9rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid rgba(255, 243, 228, 0.1);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.run-card-head {
+  display: flex;
+  gap: 0.9rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.run-card-source,
+.run-card-url {
+  margin: 0;
+}
+
+.run-card-source {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.run-card-url {
+  margin-top: 0.35rem;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.run-card-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.run-card-stats div {
+  padding-top: 0.85rem;
+  border-top: 1px solid rgba(255, 243, 228, 0.08);
+}
+
+.run-card dd {
+  margin: 0;
 }
 
 @keyframes lift-in {
@@ -327,7 +392,8 @@ input {
 @media (max-width: 900px) {
   .hero,
   .dashboard-grid,
-  .status-list {
+  .status-list,
+  .run-card-stats {
     grid-template-columns: 1fr;
   }
 
@@ -335,7 +401,8 @@ input {
     max-width: none;
   }
 
-  .panel-header {
+  .panel-header,
+  .run-card-head {
     flex-direction: column;
   }
 }

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,64 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { render, screen } from "@testing-library/react";
+
+async function withTempDatabase(callback: (databasePath: string) => Promise<void>) {
+  const tempDirectory = mkdtempSync(path.join(tmpdir(), "music-downloader-page-"));
+  const databasePath = path.join(tempDirectory, "music-downloader.sqlite");
+
+  process.env.MUSIC_DOWNLOADER_DB_PATH = databasePath;
+
+  try {
+    await callback(databasePath);
+  } finally {
+    const runStoreModule = await import("@/features/runs/run-store");
+
+    runStoreModule.resetRunStoreForTests();
+    delete process.env.MUSIC_DOWNLOADER_DB_PATH;
+    rmSync(tempDirectory, { force: true, recursive: true });
+  }
+}
+
+describe("HomePage", () => {
+  it("renders real recent runs from SQLite-backed data", async () => {
+    await withTempDatabase(async () => {
+      vi.resetModules();
+
+      const runStoreModule = await import("@/features/runs/run-store");
+      const store = runStoreModule.getRunStore();
+      const run = store.createRun({
+        playlistUrl: "https://soundcloud.com/artist/sets/warehouse-test",
+        sourceType: "soundcloud"
+      });
+
+      store.replaceRunTracks(run.id, [
+        {
+          artist: "Artist One",
+          sourcePosition: 1,
+          title: "Warehouse Tool"
+        }
+      ]);
+      store.transitionRunStatus(run.id, "ingesting");
+
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          new Response(JSON.stringify(store.getRun(run.id)), { status: 200 })
+        );
+      const pageModule = await import("./page");
+
+      render(await pageModule.default());
+
+      expect(screen.getByText(/^SoundCloud$/i)).toBeVisible();
+      expect(
+        screen.getByText(/https:\/\/soundcloud\.com\/artist\/sets\/warehouse-test/i)
+      ).toBeVisible();
+      expect(screen.getByText(/ingesting/i)).toBeVisible();
+      expect(screen.getByText(/1 track/i)).toBeVisible();
+
+      fetchSpy.mockRestore();
+    });
+  });
+});

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -22,6 +22,14 @@ async function withTempDatabase(callback: (databasePath: string) => Promise<void
 }
 
 describe("HomePage", () => {
+  it("forces live home-page rendering against the SQLite run store", async () => {
+    vi.resetModules();
+
+    const pageModule = await import("./page");
+
+    expect(pageModule.dynamic).toBe("force-dynamic");
+  });
+
   it("renders real recent runs from SQLite-backed data", async () => {
     await withTempDatabase(async () => {
       vi.resetModules();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import { HomeScreen } from "@/features/home/home-screen";
 import { getRunStore } from "@/features/runs/run-store";
 
+export const dynamic = "force-dynamic";
+
 export default function HomePage() {
   return <HomeScreen initialRuns={getRunStore().listRuns()} />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { HomeScreen } from "@/features/home/home-screen";
+import { getRunStore } from "@/features/runs/run-store";
 
 export default function HomePage() {
-  return <HomeScreen />;
+  return <HomeScreen initialRuns={getRunStore().listRuns()} />;
 }

--- a/src/features/home/home-screen.test.tsx
+++ b/src/features/home/home-screen.test.tsx
@@ -16,5 +16,8 @@ describe("HomeScreen", () => {
     expect(screen.getByRole("heading", { name: /recent runs/i })).toBeVisible();
     expect(screen.getByText(/downloads\.zip/i)).toBeVisible();
     expect(screen.getAllByText(/no runs yet/i)).toHaveLength(2);
+    expect(
+      screen.getByText(/sqlite persistence is active for new acquisition jobs/i)
+    ).toBeVisible();
   });
 });

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -1,10 +1,169 @@
+"use client";
+
+import { startTransition, useEffect, useEffectEvent, useState } from "react";
+
 import { FileBadge } from "@/components/ui/file-badge";
 import { Panel } from "@/components/ui/panel";
 import { StatusBadge } from "@/components/ui/status-badge";
+import type { RunDetail, RunStatus, RunSummary } from "@/features/runs/run-store";
 
 const artifacts = ["downloads.zip", "manifest.json", "misses.txt"];
+const terminalStatuses: RunStatus[] = ["completed", "failed"];
 
-export function HomeScreen() {
+type HomeScreenProps = {
+  initialRuns?: RunSummary[];
+};
+
+function getStatusTone(status: RunStatus) {
+  if (status === "completed") {
+    return "success" as const;
+  }
+
+  if (status === "awaiting-approval" || status === "failed") {
+    return "warning" as const;
+  }
+
+  return "muted" as const;
+}
+
+function formatSourceLabel(sourceType: RunSummary["sourceType"]) {
+  return sourceType === "spotify" ? "Spotify" : "SoundCloud";
+}
+
+function formatTrackCount(trackCount: number) {
+  return `${trackCount} ${trackCount === 1 ? "track" : "tracks"}`;
+}
+
+function getApiUrl(pathname: string) {
+  const baseUrl =
+    typeof window === "undefined" || window.location.origin === "null"
+      ? "http://localhost"
+      : window.location.origin;
+
+  return new URL(pathname, baseUrl).toString();
+}
+
+function toRunSummary(run: RunSummary | RunDetail): RunSummary {
+  return {
+    artifactCount: run.artifactCount,
+    createdAt: run.createdAt,
+    id: run.id,
+    playlistTitle: run.playlistTitle,
+    playlistUrl: run.playlistUrl,
+    resumeAfterStatus: run.resumeAfterStatus,
+    sourceType: run.sourceType,
+    status: run.status,
+    trackCount: run.trackCount,
+    updatedAt: run.updatedAt
+  };
+}
+
+function upsertRun(runs: RunSummary[], incomingRun: RunSummary) {
+  return [incomingRun, ...runs.filter((run) => run.id !== incomingRun.id)].sort(
+    (left, right) => right.updatedAt.localeCompare(left.updatedAt)
+  );
+}
+
+export function HomeScreen({ initialRuns = [] }: HomeScreenProps) {
+  const [playlistUrl, setPlaylistUrl] = useState("");
+  const [recentRuns, setRecentRuns] = useState(initialRuns);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const pollRuns = useEffectEvent(async () => {
+    const activeRuns = recentRuns.filter(
+      (run) => !terminalStatuses.includes(run.status)
+    );
+
+    if (!activeRuns.length) {
+      return;
+    }
+
+    const refreshedRuns = await Promise.all(
+      activeRuns.map(async (run) => {
+        const response = await fetch(getApiUrl(`/api/runs/${run.id}`), {
+          cache: "no-store"
+        });
+
+        if (!response.ok) {
+          return run;
+        }
+
+        const payload = (await response.json()) as RunDetail;
+
+        return toRunSummary(payload);
+      })
+    );
+
+    startTransition(() => {
+      setRecentRuns((currentRuns) => {
+        let nextRuns = currentRuns;
+
+        for (const run of refreshedRuns) {
+          nextRuns = upsertRun(nextRuns, run);
+        }
+
+        return nextRuns;
+      });
+    });
+  });
+
+  useEffect(() => {
+    const activeRuns = recentRuns.filter(
+      (run) => !terminalStatuses.includes(run.status)
+    );
+
+    if (!activeRuns.length) {
+      return;
+    }
+
+    void pollRuns();
+
+    const intervalId = window.setInterval(() => {
+      void pollRuns();
+    }, 5000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [recentRuns]);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const createRunUrl = getApiUrl("/api/runs");
+      const response = await fetch(createRunUrl, {
+        body: JSON.stringify({ playlistUrl }),
+        headers: {
+          "content-type": "application/json"
+        },
+        method: "POST"
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json()) as { error?: string };
+
+        throw new Error(payload.error ?? "Unable to queue playlist.");
+      }
+
+      const createdRun = (await response.json()) as RunDetail;
+
+      startTransition(() => {
+        setRecentRuns((currentRuns) => upsertRun(currentRuns, createdRun));
+        setPlaylistUrl("");
+      });
+    } catch (error) {
+      setSubmitError(
+        error instanceof Error ? error.message : "Unable to queue playlist."
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
   return (
     <main className="app-shell">
       <header className="hero">
@@ -17,10 +176,14 @@ export function HomeScreen() {
           </p>
         </div>
         <div className="hero-sidecar">
-          <StatusBadge>No runs yet</StatusBadge>
+          <StatusBadge tone={recentRuns.length ? "success" : "muted"}>
+            {recentRuns.length
+              ? `${recentRuns.length} recent ${recentRuns.length === 1 ? "run" : "runs"}`
+              : "No runs yet"}
+          </StatusBadge>
           <p className="hero-note">
-            This bootstrap only defines the shared shell. It does not start
-            jobs, rip streams, or simulate provider behavior.
+            Queue authorized playlist runs into the local SQLite job store.
+            Acquisition, matching, and packaging workers land in later tasks.
           </p>
         </div>
       </header>
@@ -29,9 +192,9 @@ export function HomeScreen() {
         <Panel
           eyebrow="Intake"
           title="Playlist Intake"
-          footer={<span className="panel-caption">Shared form baseline</span>}
+          footer={<span className="panel-caption">Creates queued run records</span>}
         >
-          <form className="panel-form">
+          <form className="panel-form" onSubmit={handleSubmit}>
             <label className="field" htmlFor="playlist-url">
               <span className="field-label">Playlist URL</span>
               <input
@@ -40,56 +203,109 @@ export function HomeScreen() {
                 name="playlistUrl"
                 type="url"
                 placeholder="https://open.spotify.com/playlist/..."
+                value={playlistUrl}
+                onChange={(event) => setPlaylistUrl(event.target.value)}
               />
             </label>
 
             <div className="form-actions">
-              <button className="primary-button" type="submit" disabled>
-                Queue Playlist
+              <button
+                className="primary-button"
+                type="submit"
+                disabled={isSubmitting || playlistUrl.trim().length === 0}
+              >
+                {isSubmitting ? "Queueing..." : "Queue Playlist"}
               </button>
               <p className="field-hint">
-                Submission wiring lands in a later issue. This screen stays
-                honest about the current bootstrap scope.
+                Creates a queued local run record and exposes status polling for
+                later background work.
               </p>
             </div>
+
+            {submitError ? (
+              <p className="form-status" role="alert">
+                {submitError}
+              </p>
+            ) : null}
           </form>
         </Panel>
 
         <Panel
           eyebrow="Run Report"
           title="Recent Runs"
-          footer={<span className="panel-caption">Empty state placeholder</span>}
+          footer={
+            <span className="panel-caption">
+              {recentRuns.length
+                ? `SQLite-backed ${recentRuns.length === 1 ? "record" : "records"}`
+                : "Waiting for the first queued run"}
+            </span>
+          }
         >
-          <div className="empty-state">
-            <div className="empty-state-head">
-              <StatusBadge tone="warning">No runs yet</StatusBadge>
-              <p>
-                Completed acquisitions will publish their report, misses, and
-                packaged download artifacts here.
-              </p>
-            </div>
+          {recentRuns.length ? (
+            <div className="run-list" aria-label="Recent runs list">
+              {recentRuns.map((run) => (
+                <article className="run-card" key={run.id}>
+                  <div className="run-card-head">
+                    <div>
+                      <p className="run-card-source">
+                        {formatSourceLabel(run.sourceType)}
+                      </p>
+                      <p className="run-card-url">{run.playlistUrl}</p>
+                    </div>
+                    <StatusBadge tone={getStatusTone(run.status)}>
+                      {run.status}
+                    </StatusBadge>
+                  </div>
 
-            <div className="badge-row" aria-label="Expected output artifacts">
-              {artifacts.map((artifact) => (
-                <FileBadge key={artifact} label={artifact} />
+                  <dl className="run-card-stats">
+                    <div>
+                      <dt>Tracks</dt>
+                      <dd>{formatTrackCount(run.trackCount)}</dd>
+                    </div>
+                    <div>
+                      <dt>Artifacts</dt>
+                      <dd>{run.artifactCount}</dd>
+                    </div>
+                    <div>
+                      <dt>Resume</dt>
+                      <dd>{run.resumeAfterStatus ?? "fresh run"}</dd>
+                    </div>
+                  </dl>
+                </article>
               ))}
             </div>
+          ) : (
+            <div className="empty-state">
+              <div className="empty-state-head">
+                <StatusBadge tone="warning">No runs yet</StatusBadge>
+                <p>
+                  Completed acquisitions will publish their report, misses, and
+                  packaged download artifacts here.
+                </p>
+              </div>
 
-            <dl className="status-list">
-              <div>
-                <dt>Queue</dt>
-                <dd>No review queue entries yet.</dd>
+              <div className="badge-row" aria-label="Expected output artifacts">
+                {artifacts.map((artifact) => (
+                  <FileBadge key={artifact} label={artifact} />
+                ))}
               </div>
-              <div>
-                <dt>Runs</dt>
-                <dd>The background job model is not wired in this issue.</dd>
-              </div>
-              <div>
-                <dt>Artifacts</dt>
-                <dd>Output packaging will populate once jobs exist.</dd>
-              </div>
-            </dl>
-          </div>
+
+              <dl className="status-list">
+                <div>
+                  <dt>Queue</dt>
+                  <dd>Queued runs will appear as soon as intake succeeds.</dd>
+                </div>
+                <div>
+                  <dt>Runs</dt>
+                  <dd>SQLite persistence is active for new acquisition jobs.</dd>
+                </div>
+                <div>
+                  <dt>Artifacts</dt>
+                  <dd>Output packaging will populate once jobs exist.</dd>
+                </div>
+              </dl>
+            </div>
+          )}
         </Panel>
       </div>
     </main>

--- a/src/features/runs/migrations/0001-initial.sql
+++ b/src/features/runs/migrations/0001-initial.sql
@@ -1,0 +1,91 @@
+CREATE TABLE IF NOT EXISTS runs (
+  id TEXT PRIMARY KEY,
+  source_type TEXT NOT NULL CHECK (source_type IN ('spotify', 'soundcloud')),
+  playlist_url TEXT NOT NULL,
+  playlist_title TEXT,
+  status TEXT NOT NULL CHECK (
+    status IN (
+      'queued',
+      'ingesting',
+      'matching',
+      'awaiting-approval',
+      'packaging',
+      'completed',
+      'failed'
+    )
+  ),
+  resume_after_status TEXT CHECK (
+    resume_after_status IS NULL OR resume_after_status IN (
+      'queued',
+      'ingesting',
+      'matching',
+      'awaiting-approval',
+      'packaging',
+      'completed',
+      'failed'
+    )
+  ),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  failed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS runs_updated_at_idx ON runs(updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS run_tracks (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+  source_position INTEGER NOT NULL,
+  source_track_id TEXT,
+  artist TEXT NOT NULL,
+  title TEXT NOT NULL,
+  version TEXT,
+  status TEXT NOT NULL CHECK (
+    status IN (
+      'queued',
+      'matched',
+      'awaiting-approval',
+      'acquired',
+      'missed',
+      'failed'
+    )
+  ),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS run_tracks_run_position_idx
+  ON run_tracks(run_id, source_position);
+
+CREATE TABLE IF NOT EXISTS acquisition_attempts (
+  id TEXT PRIMARY KEY,
+  run_track_id TEXT NOT NULL REFERENCES run_tracks(id) ON DELETE CASCADE,
+  provider_key TEXT NOT NULL,
+  outcome TEXT NOT NULL CHECK (
+    outcome IN ('matched', 'missed', 'skipped', 'failed', 'purchased')
+  ),
+  note TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS acquisition_attempts_track_created_idx
+  ON acquisition_attempts(run_track_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS run_artifacts (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+  artifact_kind TEXT NOT NULL CHECK (
+    artifact_kind IN (
+      'downloads-zip',
+      'manifest-json',
+      'misses-txt',
+      'run-report'
+    )
+  ),
+  relative_path TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS run_artifacts_run_created_idx
+  ON run_artifacts(run_id, created_at DESC);

--- a/src/features/runs/run-store.test.ts
+++ b/src/features/runs/run-store.test.ts
@@ -95,17 +95,25 @@ describe("createRunStore", () => {
     }
   });
 
-  it("requeues interrupted runs without losing per-track progress", () => {
+  it("requeues interrupted runs on store boot without losing per-track progress", () => {
     const tempDatabase = createTempDatabasePath();
+    let initialStore:
+      | ReturnType<typeof createRunStore>
+      | undefined;
+    let resumedStore:
+      | ReturnType<typeof createRunStore>
+      | undefined;
 
     try {
-      const store = createRunStore({ databasePath: tempDatabase.databasePath });
-      const run = store.createRun({
+      initialStore = createRunStore({
+        databasePath: tempDatabase.databasePath
+      });
+      const run = initialStore.createRun({
         playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DWZxZ8T6qM2Yj",
         sourceType: "spotify"
       });
 
-      const tracks = store.replaceRunTracks(run.id, [
+      const tracks = initialStore.replaceRunTracks(run.id, [
         {
           artist: "Artist One",
           sourcePosition: 1,
@@ -120,14 +128,18 @@ describe("createRunStore", () => {
         }
       ]);
 
-      store.transitionRunStatus(run.id, "ingesting");
-      store.transitionRunStatus(run.id, "matching");
-      store.updateRunTrackStatus(tracks[0].id, "matched");
-      store.updateRunTrackStatus(tracks[1].id, "failed");
+      initialStore.transitionRunStatus(run.id, "ingesting");
+      initialStore.transitionRunStatus(run.id, "matching");
+      initialStore.updateRunTrackStatus(tracks[0].id, "matched");
+      initialStore.updateRunTrackStatus(tracks[1].id, "failed");
+      initialStore.close();
+      initialStore = undefined;
 
-      expect(store.resumeInterruptedRuns()).toBe(1);
+      resumedStore = createRunStore({
+        databasePath: tempDatabase.databasePath
+      });
 
-      expect(store.getRunStatusSnapshot(run.id)).toEqual(
+      expect(resumedStore.getRunStatusSnapshot(run.id)).toEqual(
         expect.objectContaining({
           id: run.id,
           resumeAfterStatus: "matching",
@@ -135,7 +147,7 @@ describe("createRunStore", () => {
         })
       );
       expect(
-        store
+        resumedStore
           .getRun(run.id)
           ?.tracks.map((track) => [track.sourcePosition, track.status] satisfies [
             number,
@@ -146,6 +158,8 @@ describe("createRunStore", () => {
         [2, "failed"]
       ]);
     } finally {
+      initialStore?.close();
+      resumedStore?.close();
       tempDatabase.cleanup();
     }
   });

--- a/src/features/runs/run-store.test.ts
+++ b/src/features/runs/run-store.test.ts
@@ -1,0 +1,152 @@
+/* @vitest-environment node */
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  createRunStore,
+  type RunStatus,
+  type RunTrackStatus
+} from "./run-store";
+
+function createTempDatabasePath() {
+  const tempDirectory = mkdtempSync(
+    path.join(tmpdir(), "music-downloader-run-store-")
+  );
+
+  return {
+    databasePath: path.join(tempDirectory, "music-downloader.sqlite"),
+    cleanup() {
+      rmSync(tempDirectory, { force: true, recursive: true });
+    }
+  };
+}
+
+describe("createRunStore", () => {
+  it("creates the local SQLite file and persists queued runs", () => {
+    const tempDatabase = createTempDatabasePath();
+
+    try {
+      const store = createRunStore({ databasePath: tempDatabase.databasePath });
+
+      const run = store.createRun({
+        playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DX4dyzvuaRJ0n",
+        sourceType: "spotify"
+      });
+
+      expect(existsSync(tempDatabase.databasePath)).toBe(true);
+      expect(run.status).toBe("queued");
+      expect(store.listRuns()).toEqual([
+        expect.objectContaining({
+          id: run.id,
+          sourceType: "spotify",
+          status: "queued",
+          trackCount: 0
+        })
+      ]);
+      expect(store.getRun(run.id)).toEqual(
+        expect.objectContaining({
+          id: run.id,
+          status: "queued",
+          tracks: [],
+          artifacts: []
+        })
+      );
+    } finally {
+      tempDatabase.cleanup();
+    }
+  });
+
+  it("allows only explicit lifecycle transitions", () => {
+    const tempDatabase = createTempDatabasePath();
+
+    try {
+      const store = createRunStore({ databasePath: tempDatabase.databasePath });
+      const run = store.createRun({
+        playlistUrl: "https://soundcloud.com/sets/late-night-test-set",
+        sourceType: "soundcloud"
+      });
+
+      const transitions: RunStatus[] = [
+        "ingesting",
+        "matching",
+        "awaiting-approval",
+        "packaging",
+        "completed"
+      ];
+
+      let currentRunId = run.id;
+
+      for (const nextStatus of transitions) {
+        const nextRun = store.transitionRunStatus(currentRunId, nextStatus);
+
+        expect(nextRun.status).toBe(nextStatus);
+        currentRunId = nextRun.id;
+      }
+
+      expect(() =>
+        store.transitionRunStatus(run.id, "queued")
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invalid run status transition: completed -> queued]`
+      );
+    } finally {
+      tempDatabase.cleanup();
+    }
+  });
+
+  it("requeues interrupted runs without losing per-track progress", () => {
+    const tempDatabase = createTempDatabasePath();
+
+    try {
+      const store = createRunStore({ databasePath: tempDatabase.databasePath });
+      const run = store.createRun({
+        playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DWZxZ8T6qM2Yj",
+        sourceType: "spotify"
+      });
+
+      const tracks = store.replaceRunTracks(run.id, [
+        {
+          artist: "Artist One",
+          sourcePosition: 1,
+          title: "Track One",
+          status: "queued"
+        },
+        {
+          artist: "Artist Two",
+          sourcePosition: 2,
+          title: "Track Two",
+          status: "queued"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+      store.updateRunTrackStatus(tracks[0].id, "matched");
+      store.updateRunTrackStatus(tracks[1].id, "failed");
+
+      expect(store.resumeInterruptedRuns()).toBe(1);
+
+      expect(store.getRunStatusSnapshot(run.id)).toEqual(
+        expect.objectContaining({
+          id: run.id,
+          resumeAfterStatus: "matching",
+          status: "queued"
+        })
+      );
+      expect(
+        store
+          .getRun(run.id)
+          ?.tracks.map((track) => [track.sourcePosition, track.status] satisfies [
+            number,
+            RunTrackStatus
+          ])
+      ).toEqual([
+        [1, "matched"],
+        [2, "failed"]
+      ]);
+    } finally {
+      tempDatabase.cleanup();
+    }
+  });
+});

--- a/src/features/runs/run-store.ts
+++ b/src/features/runs/run-store.ts
@@ -343,6 +343,42 @@ export function createRunStore(options: RunStoreOptions = {}) {
     return run;
   }
 
+  function requeueInterruptedRuns() {
+    const now = getTimestamp();
+    const runsToResume = database
+      .prepare(
+        `
+          SELECT id, status
+          FROM runs
+          WHERE status IN (?, ?, ?)
+        `
+      )
+      .all(...resumableRunStatuses) as Array<{
+      id: string;
+      status: RunStatus;
+    }>;
+
+    const updateStatement = database.prepare(
+      `
+        UPDATE runs
+        SET status = ?,
+            resume_after_status = ?,
+            updated_at = ?,
+            completed_at = ?,
+            failed_at = ?
+        WHERE id = ?
+      `
+    );
+
+    for (const run of runsToResume) {
+      updateStatement.run("queued", run.status, now, null, null, run.id);
+    }
+
+    return runsToResume.length;
+  }
+
+  requeueInterruptedRuns();
+
   return {
     close() {
       database.close();
@@ -586,37 +622,7 @@ export function createRunStore(options: RunStoreOptions = {}) {
     },
 
     resumeInterruptedRuns() {
-      const now = getTimestamp();
-      const runsToResume = database
-        .prepare(
-          `
-            SELECT id, status
-            FROM runs
-            WHERE status IN (?, ?, ?)
-          `
-        )
-        .all(...resumableRunStatuses) as Array<{
-        id: string;
-        status: RunStatus;
-      }>;
-
-      const updateStatement = database.prepare(
-        `
-          UPDATE runs
-          SET status = ?,
-              resume_after_status = ?,
-              updated_at = ?,
-              completed_at = ?,
-              failed_at = ?
-          WHERE id = ?
-        `
-      );
-
-      for (const run of runsToResume) {
-        updateStatement.run("queued", run.status, now, null, null, run.id);
-      }
-
-      return runsToResume.length;
+      return requeueInterruptedRuns();
     },
 
     transitionRunStatus(runId: string, nextStatus: RunStatus): RunDetail {

--- a/src/features/runs/run-store.ts
+++ b/src/features/runs/run-store.ts
@@ -1,0 +1,700 @@
+import { mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+export const runStatuses = [
+  "queued",
+  "ingesting",
+  "matching",
+  "awaiting-approval",
+  "packaging",
+  "completed",
+  "failed"
+] as const;
+
+export const runTrackStatuses = [
+  "queued",
+  "matched",
+  "awaiting-approval",
+  "acquired",
+  "missed",
+  "failed"
+] as const;
+
+export type PlaylistSource = "spotify" | "soundcloud";
+export type RunStatus = (typeof runStatuses)[number];
+export type RunTrackStatus = (typeof runTrackStatuses)[number];
+export type ArtifactKind =
+  | "downloads-zip"
+  | "manifest-json"
+  | "misses-txt"
+  | "run-report";
+export type AcquisitionAttemptOutcome =
+  | "matched"
+  | "missed"
+  | "skipped"
+  | "failed"
+  | "purchased";
+
+type RunRow = {
+  id: string;
+  source_type: PlaylistSource;
+  playlist_url: string;
+  playlist_title: string | null;
+  status: RunStatus;
+  resume_after_status: RunStatus | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  failed_at: string | null;
+};
+
+type RunTrackRow = {
+  id: string;
+  run_id: string;
+  source_position: number;
+  source_track_id: string | null;
+  artist: string;
+  title: string;
+  version: string | null;
+  status: RunTrackStatus;
+  created_at: string;
+  updated_at: string;
+};
+
+type RunArtifactRow = {
+  id: string;
+  run_id: string;
+  artifact_kind: ArtifactKind;
+  relative_path: string;
+  created_at: string;
+};
+
+export type RunSummary = {
+  id: string;
+  sourceType: PlaylistSource;
+  playlistUrl: string;
+  playlistTitle: string | null;
+  status: RunStatus;
+  resumeAfterStatus: RunStatus | null;
+  createdAt: string;
+  updatedAt: string;
+  trackCount: number;
+  artifactCount: number;
+};
+
+export type RunTrack = {
+  id: string;
+  runId: string;
+  sourcePosition: number;
+  sourceTrackId: string | null;
+  artist: string;
+  title: string;
+  version: string | null;
+  status: RunTrackStatus;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type RunArtifact = {
+  id: string;
+  runId: string;
+  kind: ArtifactKind;
+  relativePath: string;
+  createdAt: string;
+};
+
+export type RunDetail = RunSummary & {
+  tracks: RunTrack[];
+  artifacts: RunArtifact[];
+};
+
+export type RunStatusSnapshot = Pick<
+  RunSummary,
+  | "id"
+  | "status"
+  | "resumeAfterStatus"
+  | "updatedAt"
+  | "trackCount"
+  | "artifactCount"
+>;
+
+export type CreateRunInput = {
+  playlistUrl: string;
+  sourceType: PlaylistSource;
+  playlistTitle?: string | null;
+};
+
+export type ReplaceRunTrackInput = {
+  sourcePosition: number;
+  artist: string;
+  title: string;
+  status?: RunTrackStatus;
+  sourceTrackId?: string | null;
+  version?: string | null;
+};
+
+export type RecordAcquisitionAttemptInput = {
+  providerKey: string;
+  outcome: AcquisitionAttemptOutcome;
+  note?: string | null;
+  runTrackId: string;
+};
+
+export type RecordRunArtifactInput = {
+  kind: ArtifactKind;
+  relativePath: string;
+  runId: string;
+};
+
+type RunAggregateRow = RunRow & {
+  artifact_count: number;
+  track_count: number;
+};
+
+type RunStoreOptions = {
+  databasePath?: string;
+};
+
+export type RunStore = ReturnType<typeof createRunStore>;
+
+const allowedRunStatusTransitions: Record<RunStatus, RunStatus[]> = {
+  queued: ["ingesting", "failed"],
+  ingesting: ["matching", "failed"],
+  matching: ["awaiting-approval", "packaging", "failed"],
+  "awaiting-approval": ["packaging", "failed"],
+  packaging: ["completed", "failed"],
+  completed: [],
+  failed: ["queued"]
+};
+
+const resumableRunStatuses: RunStatus[] = ["ingesting", "matching", "packaging"];
+
+const migrationName = "0001-initial";
+const migrationPath = path.join(
+  process.cwd(),
+  "src/features/runs/migrations/0001-initial.sql"
+);
+
+let defaultRunStore: ReturnType<typeof createRunStore> | null = null;
+
+function getDefaultDatabasePath() {
+  return (
+    process.env.MUSIC_DOWNLOADER_DB_PATH ??
+    path.join(process.cwd(), "data", "music-downloader.sqlite")
+  );
+}
+
+function getTimestamp() {
+  return new Date().toISOString();
+}
+
+function assertValidRunTrackStatus(
+  status: string
+): asserts status is RunTrackStatus {
+  if (!runTrackStatuses.includes(status as RunTrackStatus)) {
+    throw new Error(`Unsupported run track status: ${status}`);
+  }
+}
+
+function mapRunTrack(row: RunTrackRow): RunTrack {
+  return {
+    artist: row.artist,
+    createdAt: row.created_at,
+    id: row.id,
+    runId: row.run_id,
+    sourcePosition: row.source_position,
+    sourceTrackId: row.source_track_id,
+    status: row.status,
+    title: row.title,
+    updatedAt: row.updated_at,
+    version: row.version
+  };
+}
+
+function mapRunArtifact(row: RunArtifactRow): RunArtifact {
+  return {
+    createdAt: row.created_at,
+    id: row.id,
+    kind: row.artifact_kind,
+    relativePath: row.relative_path,
+    runId: row.run_id
+  };
+}
+
+function mapRunSummary(row: RunAggregateRow): RunSummary {
+  return {
+    artifactCount: Number(row.artifact_count),
+    createdAt: row.created_at,
+    id: row.id,
+    playlistTitle: row.playlist_title,
+    playlistUrl: row.playlist_url,
+    resumeAfterStatus: row.resume_after_status,
+    sourceType: row.source_type,
+    status: row.status,
+    trackCount: Number(row.track_count),
+    updatedAt: row.updated_at
+  };
+}
+
+function ensureAllowedTransition(currentStatus: RunStatus, nextStatus: RunStatus) {
+  if (!allowedRunStatusTransitions[currentStatus].includes(nextStatus)) {
+    throw new Error(
+      `Invalid run status transition: ${currentStatus} -> ${nextStatus}`
+    );
+  }
+}
+
+function createMissingDirectories(databasePath: string) {
+  mkdirSync(path.dirname(databasePath), { recursive: true });
+}
+
+function ensureSchema(database: DatabaseSync) {
+  database.exec("PRAGMA foreign_keys = ON");
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      name TEXT PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    )
+  `);
+
+  const migrationAlreadyApplied = database
+    .prepare("SELECT name FROM schema_migrations WHERE name = ?")
+    .get(migrationName) as { name: string } | undefined;
+
+  if (migrationAlreadyApplied) {
+    return;
+  }
+
+  const schemaSql = readFileSync(migrationPath, "utf8");
+
+  database.exec("BEGIN");
+
+  try {
+    database.exec(schemaSql);
+    database
+      .prepare(
+        "INSERT INTO schema_migrations (name, applied_at) VALUES (?, ?)"
+      )
+      .run(migrationName, getTimestamp());
+    database.exec("COMMIT");
+  } catch (error) {
+    database.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+export function getRunStore() {
+  if (!defaultRunStore) {
+    defaultRunStore = createRunStore();
+  }
+
+  return defaultRunStore;
+}
+
+export function resetRunStoreForTests() {
+  if (!defaultRunStore) {
+    return;
+  }
+
+  defaultRunStore.close();
+  defaultRunStore = null;
+}
+
+export function createRunStore(options: RunStoreOptions = {}) {
+  const databasePath = options.databasePath ?? getDefaultDatabasePath();
+
+  createMissingDirectories(databasePath);
+
+  const database = new DatabaseSync(databasePath);
+
+  ensureSchema(database);
+
+  function readRunAggregate(runId: string) {
+    return database
+      .prepare(
+        `
+          SELECT
+            runs.*,
+            (
+              SELECT COUNT(*)
+              FROM run_tracks
+              WHERE run_tracks.run_id = runs.id
+            ) AS track_count,
+            (
+              SELECT COUNT(*)
+              FROM run_artifacts
+              WHERE run_artifacts.run_id = runs.id
+            ) AS artifact_count
+          FROM runs
+          WHERE runs.id = ?
+        `
+      )
+      .get(runId) as RunAggregateRow | undefined;
+  }
+
+  function getRunOrThrow(runId: string) {
+    const run = readRunAggregate(runId);
+
+    if (!run) {
+      throw new Error(`Run not found: ${runId}`);
+    }
+
+    return run;
+  }
+
+  return {
+    close() {
+      database.close();
+    },
+
+    createRun(input: CreateRunInput): RunDetail {
+      const now = getTimestamp();
+      const id = crypto.randomUUID();
+
+      database
+        .prepare(
+          `
+            INSERT INTO runs (
+              id,
+              source_type,
+              playlist_url,
+              playlist_title,
+              status,
+              resume_after_status,
+              created_at,
+              updated_at,
+              completed_at,
+              failed_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          id,
+          input.sourceType,
+          input.playlistUrl,
+          input.playlistTitle ?? null,
+          "queued",
+          null,
+          now,
+          now,
+          null,
+          null
+        );
+
+      const run = this.getRun(id);
+
+      if (!run) {
+        throw new Error(`Run not found after creation: ${id}`);
+      }
+
+      return run;
+    },
+
+    getRun(runId: string): RunDetail | null {
+      const row = readRunAggregate(runId);
+
+      if (!row) {
+        return null;
+      }
+
+      const tracks = database
+        .prepare(
+          `
+            SELECT *
+            FROM run_tracks
+            WHERE run_id = ?
+            ORDER BY source_position ASC
+          `
+        )
+        .all(runId) as RunTrackRow[];
+      const artifacts = database
+        .prepare(
+          `
+            SELECT *
+            FROM run_artifacts
+            WHERE run_id = ?
+            ORDER BY created_at ASC
+          `
+        )
+        .all(runId) as RunArtifactRow[];
+
+      return {
+        ...mapRunSummary(row),
+        artifacts: artifacts.map(mapRunArtifact),
+        tracks: tracks.map(mapRunTrack)
+      };
+    },
+
+    getRunStatusSnapshot(runId: string): RunStatusSnapshot | null {
+      const row = readRunAggregate(runId);
+
+      if (!row) {
+        return null;
+      }
+
+      const summary = mapRunSummary(row);
+
+      return {
+        artifactCount: summary.artifactCount,
+        id: summary.id,
+        resumeAfterStatus: summary.resumeAfterStatus,
+        status: summary.status,
+        trackCount: summary.trackCount,
+        updatedAt: summary.updatedAt
+      };
+    },
+
+    listRuns(limit = 10): RunSummary[] {
+      const rows = database
+        .prepare(
+          `
+            SELECT
+              runs.*,
+              (
+                SELECT COUNT(*)
+                FROM run_tracks
+                WHERE run_tracks.run_id = runs.id
+              ) AS track_count,
+              (
+                SELECT COUNT(*)
+                FROM run_artifacts
+                WHERE run_artifacts.run_id = runs.id
+              ) AS artifact_count
+            FROM runs
+            ORDER BY updated_at DESC, created_at DESC
+            LIMIT ?
+          `
+        )
+        .all(limit) as RunAggregateRow[];
+
+      return rows.map(mapRunSummary);
+    },
+
+    recordAcquisitionAttempt(input: RecordAcquisitionAttemptInput) {
+      const now = getTimestamp();
+      const id = crypto.randomUUID();
+
+      database
+        .prepare(
+          `
+            INSERT INTO acquisition_attempts (
+              id,
+              run_track_id,
+              provider_key,
+              outcome,
+              note,
+              created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          id,
+          input.runTrackId,
+          input.providerKey,
+          input.outcome,
+          input.note ?? null,
+          now
+        );
+
+      return id;
+    },
+
+    recordRunArtifact(input: RecordRunArtifactInput) {
+      const now = getTimestamp();
+      const id = crypto.randomUUID();
+
+      getRunOrThrow(input.runId);
+
+      database
+        .prepare(
+          `
+            INSERT INTO run_artifacts (
+              id,
+              run_id,
+              artifact_kind,
+              relative_path,
+              created_at
+            )
+            VALUES (?, ?, ?, ?, ?)
+          `
+        )
+        .run(id, input.runId, input.kind, input.relativePath, now);
+
+      database
+        .prepare("UPDATE runs SET updated_at = ? WHERE id = ?")
+        .run(now, input.runId);
+
+      return this.getRun(input.runId)?.artifacts.at(-1) ?? null;
+    },
+
+    replaceRunTracks(runId: string, tracks: ReplaceRunTrackInput[]): RunTrack[] {
+      const now = getTimestamp();
+
+      getRunOrThrow(runId);
+
+      database.exec("BEGIN");
+
+      try {
+        database.prepare("DELETE FROM run_tracks WHERE run_id = ?").run(runId);
+
+        const insertTrack = database.prepare(
+          `
+            INSERT INTO run_tracks (
+              id,
+              run_id,
+              source_position,
+              source_track_id,
+              artist,
+              title,
+              version,
+              status,
+              created_at,
+              updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        );
+
+        for (const track of tracks) {
+          insertTrack.run(
+            crypto.randomUUID(),
+            runId,
+            track.sourcePosition,
+            track.sourceTrackId ?? null,
+            track.artist,
+            track.title,
+            track.version ?? null,
+            track.status ?? "queued",
+            now,
+            now
+          );
+        }
+
+        database
+          .prepare("UPDATE runs SET updated_at = ? WHERE id = ?")
+          .run(now, runId);
+        database.exec("COMMIT");
+      } catch (error) {
+        database.exec("ROLLBACK");
+        throw error;
+      }
+
+      return this.getRun(runId)?.tracks ?? [];
+    },
+
+    resumeInterruptedRuns() {
+      const now = getTimestamp();
+      const runsToResume = database
+        .prepare(
+          `
+            SELECT id, status
+            FROM runs
+            WHERE status IN (?, ?, ?)
+          `
+        )
+        .all(...resumableRunStatuses) as Array<{
+        id: string;
+        status: RunStatus;
+      }>;
+
+      const updateStatement = database.prepare(
+        `
+          UPDATE runs
+          SET status = ?,
+              resume_after_status = ?,
+              updated_at = ?,
+              completed_at = ?,
+              failed_at = ?
+          WHERE id = ?
+        `
+      );
+
+      for (const run of runsToResume) {
+        updateStatement.run("queued", run.status, now, null, null, run.id);
+      }
+
+      return runsToResume.length;
+    },
+
+    transitionRunStatus(runId: string, nextStatus: RunStatus): RunDetail {
+      const currentRun = getRunOrThrow(runId);
+
+      ensureAllowedTransition(currentRun.status, nextStatus);
+
+      const now = getTimestamp();
+      const completedAt = nextStatus === "completed" ? now : null;
+      const failedAt = nextStatus === "failed" ? now : null;
+      const resumeAfterStatus = nextStatus === "queued" ? currentRun.resume_after_status : null;
+
+      database
+        .prepare(
+          `
+            UPDATE runs
+            SET status = ?,
+                resume_after_status = ?,
+                updated_at = ?,
+                completed_at = ?,
+                failed_at = ?
+            WHERE id = ?
+          `
+        )
+        .run(
+          nextStatus,
+          resumeAfterStatus,
+          now,
+          completedAt,
+          failedAt,
+          runId
+        );
+
+      const run = this.getRun(runId);
+
+      if (!run) {
+        throw new Error(`Run not found after transition: ${runId}`);
+      }
+
+      return run;
+    },
+
+    updateRunTrackStatus(trackId: string, nextStatus: RunTrackStatus): RunTrack {
+      const track = database
+        .prepare("SELECT * FROM run_tracks WHERE id = ?")
+        .get(trackId) as RunTrackRow | undefined;
+
+      if (!track) {
+        throw new Error(`Run track not found: ${trackId}`);
+      }
+
+      assertValidRunTrackStatus(nextStatus);
+
+      const now = getTimestamp();
+
+      database
+        .prepare(
+          `
+            UPDATE run_tracks
+            SET status = ?,
+                updated_at = ?
+            WHERE id = ?
+          `
+        )
+        .run(nextStatus, now, trackId);
+      database
+        .prepare("UPDATE runs SET updated_at = ? WHERE id = ?")
+        .run(now, track.run_id);
+
+      const updatedTrack = database
+        .prepare("SELECT * FROM run_tracks WHERE id = ?")
+        .get(trackId) as RunTrackRow | undefined;
+
+      if (!updatedTrack) {
+        throw new Error(`Run track not found after update: ${trackId}`);
+      }
+
+      return mapRunTrack(updatedTrack);
+    }
+  };
+}


### PR DESCRIPTION
**@worker-03**

## Summary
- add a SQLite-backed run store with checked-in schema, explicit lifecycle primitives, and restart-safe resume state
- expose minimal run creation and status polling endpoints for the UI
- replace the recent-runs placeholder with persisted SQLite-backed records on the home page

## Verification
- `npm test`
- `npm run build`

Closes #4
