### PR TITLE
feat: add provider registry contract

### DIFF
--- a/src/features/providers/README.md
+++ b/src/features/providers/README.md
@@ -1,0 +1,62 @@
+# Provider Contract
+
+This module owns the shared provider boundary for acquisition sources.
+
+## Rules
+
+- Put provider-specific selectors, browser flows, and storefront behavior in the provider implementation, not in the shared registry.
+- Copy `priorityRank`, authorization basis, and the free-vs-review split from `data/authorized-source-research-registry.json`.
+- Keep automatic providers in the `free-auto` bucket and keep Beatport-style paid work in `paid-review-queue`.
+
+## Building A Provider
+
+Use the helper that matches the provider mode:
+
+```ts
+const bandcamp = defineAutomaticProvider({
+  id: "bandcamp",
+  displayName: "Bandcamp",
+  authorizationBasis: "rights-holder-storefront",
+  priceTier: "free-or-owned",
+  priorityRank: 20,
+  supportedFormats: ["mp3", "wav", "flac"],
+  search: async ({ track }) => {
+    // provider-specific lookup
+  },
+  acquire: async ({ candidate, track }) => {
+    // provider-specific download flow
+  }
+});
+
+const beatport = defineReviewQueueProvider({
+  id: "beatport",
+  displayName: "Beatport",
+  authorizationBasis: "purchase-entitlement",
+  priorityRank: 90,
+  supportedFormats: ["mp3", "wav", "aiff"],
+  search: async ({ track }) => {
+    // provider-specific lookup
+  },
+  queueForReview: async ({ candidate, track }) => {
+    // provider-specific paid queue flow
+  }
+});
+```
+
+Automatic providers expose `acquire`. Review-only providers expose `queueForReview`.
+
+## Result Shapes
+
+- `ProviderCandidate` carries the shared matching data: provenance, authorization basis, price tier, available formats, duration, and mix confidence.
+- `ProviderAcquiredResult` adds artifact metadata for later manifest and packaging tasks.
+- `ProviderRejectedResult` preserves explicit rejection reasons and can optionally attach the canonical track rejection reason.
+- `ProviderMissResult` preserves provider-level miss context plus the run-level track miss reason.
+
+## Registry
+
+Register providers in a `ProviderRegistry` and read them through `list()`, `listAutomatic()`, or `listReviewQueue()`.
+
+- Ordering is deterministic.
+- `free-auto` always comes before `paid-review-queue`.
+- Within a bucket, lower `priorityRank` wins.
+- `id` is the final tie-breaker.

--- a/src/features/providers/provider-registry.test.ts
+++ b/src/features/providers/provider-registry.test.ts
@@ -1,0 +1,207 @@
+import {
+  DuplicateProviderRegistrationError,
+  ProviderRegistry,
+  buildProviderMissResult,
+  buildProviderRejectedResult,
+  defineAutomaticProvider,
+  defineReviewQueueProvider
+} from "./provider-registry";
+
+describe("ProviderRegistry", () => {
+  it("orders automatic providers before review queue providers", () => {
+    const registry = new ProviderRegistry();
+
+    registry.register(
+      defineReviewQueueProvider({
+        id: "beatport",
+        displayName: "Beatport",
+        authorizationBasis: "purchase-entitlement",
+        priorityRank: 90,
+        supportedFormats: ["mp3", "wav", "aiff"],
+        search: async () =>
+          buildProviderMissResult({
+            detail: "No Beatport candidate queued yet.",
+            providerId: "beatport",
+            providerName: "Beatport",
+            reason: "no-search-results",
+            trackMissReason: "no-authorized-source-match"
+          }),
+        queueForReview: async ({ candidate }) => ({
+          outcome: "queued-for-review",
+          candidate,
+          review: {
+            queueName: "beatport-review",
+            summary: "Queued for later operator approval."
+          }
+        })
+      })
+    );
+
+    registry.register(
+      defineAutomaticProvider({
+        id: "bandcamp",
+        displayName: "Bandcamp",
+        authorizationBasis: "rights-holder-storefront",
+        priceTier: "free-or-owned",
+        priorityRank: 20,
+        supportedFormats: ["mp3", "wav", "flac", "aiff", "alac"],
+        search: async () =>
+          buildProviderMissResult({
+            detail: "No Bandcamp result for the requested track.",
+            providerId: "bandcamp",
+            providerName: "Bandcamp",
+            reason: "no-search-results",
+            trackMissReason: "no-authorized-source-match"
+          }),
+        acquire: async ({ candidate }) =>
+          buildProviderRejectedResult({
+            candidate,
+            detail: "Fixture provider is not wired to acquire assets in tests.",
+            providerId: "bandcamp",
+            providerName: "Bandcamp",
+            reason: "provider-error"
+          })
+      })
+    );
+
+    registry.register(
+      defineAutomaticProvider({
+        id: "soundcloud-direct-downloads",
+        displayName: "SoundCloud Direct Downloads",
+        authorizationBasis: "uploader-enabled-download",
+        priceTier: "free",
+        priorityRank: 10,
+        supportedFormats: ["original-upload-format"],
+        search: async () =>
+          buildProviderMissResult({
+            detail: "No SoundCloud direct download is available for the requested track.",
+            providerId: "soundcloud-direct-downloads",
+            providerName: "SoundCloud Direct Downloads",
+            reason: "no-authorized-candidate",
+            trackMissReason: "no-authorized-source-match"
+          }),
+        acquire: async ({ candidate }) =>
+          buildProviderRejectedResult({
+            candidate,
+            detail: "Fixture provider is not wired to acquire assets in tests.",
+            providerId: "soundcloud-direct-downloads",
+            providerName: "SoundCloud Direct Downloads",
+            reason: "provider-error"
+          })
+      })
+    );
+
+    expect(registry.list().map((provider) => provider.id)).toEqual([
+      "soundcloud-direct-downloads",
+      "bandcamp",
+      "beatport"
+    ]);
+    expect(registry.listAutomatic().map((provider) => provider.id)).toEqual([
+      "soundcloud-direct-downloads",
+      "bandcamp"
+    ]);
+    expect(registry.listReviewQueue().map((provider) => provider.id)).toEqual([
+      "beatport"
+    ]);
+  });
+
+  it("registers providers by id and rejects duplicate registrations", () => {
+    const registry = new ProviderRegistry();
+    const provider = defineAutomaticProvider({
+      id: "bandcamp",
+      displayName: "Bandcamp",
+      authorizationBasis: "rights-holder-storefront",
+      priceTier: "free-or-owned",
+      priorityRank: 20,
+      supportedFormats: ["mp3", "wav"],
+      search: async () =>
+        buildProviderMissResult({
+          detail: "No Bandcamp result for the requested track.",
+          providerId: "bandcamp",
+          providerName: "Bandcamp",
+          reason: "no-search-results",
+          trackMissReason: "no-authorized-source-match"
+        }),
+      acquire: async ({ candidate }) =>
+        buildProviderRejectedResult({
+          candidate,
+          detail: "Fixture provider is not wired to acquire assets in tests.",
+          providerId: "bandcamp",
+          providerName: "Bandcamp",
+          reason: "provider-error"
+        })
+    });
+
+    registry.register(provider);
+
+    expect(registry.get("bandcamp")).toBe(provider);
+    expect(() => registry.register(provider)).toThrowError(
+      DuplicateProviderRegistrationError
+    );
+  });
+});
+
+describe("provider result helpers", () => {
+  it("preserves structured rejection and miss context for later matching and reporting", () => {
+    const candidate = {
+      artistName: "Anyma",
+      authorizationBasis: "uploader-enabled-download" as const,
+      availableFormats: ["mp3"] as const,
+      candidateId: "soundcloud-track-42",
+      durationSeconds: 392,
+      mixConfidence: "high" as const,
+      mixLabel: "Radio Edit",
+      priceTier: "free" as const,
+      providerId: "soundcloud-direct-downloads",
+      providerName: "SoundCloud Direct Downloads",
+      provenance: {
+        discoveredVia: "search" as const,
+        providerTrackId: "42",
+        providerUrl: "https://soundcloud.com/artist/track"
+      },
+      title: "Consciousness"
+    };
+
+    expect(
+      buildProviderRejectedResult({
+        candidate,
+        detail: "Radio Edit is outside the approved mix preference order.",
+        providerId: "soundcloud-direct-downloads",
+        providerName: "SoundCloud Direct Downloads",
+        reason: "candidate-mix-rejected",
+        trackDecisionReason: "mix-version-not-eligible"
+      })
+    ).toEqual({
+      outcome: "rejected",
+      candidate,
+      rejection: {
+        detail: "Radio Edit is outside the approved mix preference order.",
+        providerId: "soundcloud-direct-downloads",
+        providerName: "SoundCloud Direct Downloads",
+        reason: "candidate-mix-rejected",
+        retryable: false,
+        trackDecisionReason: "mix-version-not-eligible"
+      }
+    });
+
+    expect(
+      buildProviderMissResult({
+        detail: "No authorized download was exposed for the matched SoundCloud track.",
+        providerId: "soundcloud-direct-downloads",
+        providerName: "SoundCloud Direct Downloads",
+        reason: "no-authorized-candidate",
+        trackMissReason: "no-authorized-source-match"
+      })
+    ).toEqual({
+      outcome: "miss",
+      miss: {
+        detail:
+          "No authorized download was exposed for the matched SoundCloud track.",
+        providerId: "soundcloud-direct-downloads",
+        providerName: "SoundCloud Direct Downloads",
+        reason: "no-authorized-candidate",
+        trackMissReason: "no-authorized-source-match"
+      }
+    });
+  });
+});

--- a/src/features/providers/provider-registry.ts
+++ b/src/features/providers/provider-registry.ts
@@ -1,0 +1,377 @@
+import type {
+  CanonicalConfidence,
+  CanonicalTrack,
+  TrackDecision,
+  TrackMissReason
+} from "../tracks/canonical-track";
+
+export const PROVIDER_PRICE_TIERS = ["free", "free-or-owned", "paid"] as const;
+export type ProviderPriceTier = (typeof PROVIDER_PRICE_TIERS)[number];
+
+export const PROVIDER_AUTHORIZATION_BASES = [
+  "uploader-enabled-download",
+  "rights-holder-storefront",
+  "purchase-entitlement"
+] as const;
+export type ProviderAuthorizationBasis =
+  (typeof PROVIDER_AUTHORIZATION_BASES)[number];
+
+export const PROVIDER_IMPLEMENTATION_BUCKETS = [
+  "free-auto",
+  "paid-review-queue"
+] as const;
+export type ProviderImplementationBucket =
+  (typeof PROVIDER_IMPLEMENTATION_BUCKETS)[number];
+
+export const PROVIDER_ARTIFACT_FORMATS = [
+  "mp3",
+  "wav",
+  "aiff",
+  "flac",
+  "aac",
+  "ogg-vorbis",
+  "alac",
+  "original-upload-format",
+  "unknown"
+] as const;
+export type ProviderArtifactFormat = (typeof PROVIDER_ARTIFACT_FORMATS)[number];
+
+export const PROVIDER_REJECTION_REASONS = [
+  "auth-required",
+  "provider-session-expired",
+  "candidate-format-unavailable",
+  "candidate-mix-rejected",
+  "candidate-duration-too-short",
+  "manual-review-required",
+  "no-download-entitlement",
+  "download-artifact-missing",
+  "provider-error"
+] as const;
+export type ProviderRejectionReason = (typeof PROVIDER_REJECTION_REASONS)[number];
+
+export const PROVIDER_MISS_REASONS = [
+  "no-search-results",
+  "no-authorized-candidate",
+  "provider-not-configured"
+] as const;
+export type ProviderMissReason = (typeof PROVIDER_MISS_REASONS)[number];
+
+export type ProviderTrackDecisionReason = Extract<
+  TrackDecision,
+  { outcome: "rejected" }
+>["reason"];
+
+export interface ProviderProvenance {
+  discoveredVia:
+    | "catalog"
+    | "download-history"
+    | "library"
+    | "operator-input"
+    | "search";
+  providerTrackId?: string;
+  providerUrl?: string;
+  searchQuery?: string;
+  sourcePageUrl?: string;
+}
+
+export interface ProviderCandidate {
+  artistName: string;
+  authorizationBasis: ProviderAuthorizationBasis;
+  availableFormats: readonly ProviderArtifactFormat[];
+  candidateId: string;
+  durationSeconds: number | null;
+  mixConfidence: CanonicalConfidence;
+  mixLabel: string | null;
+  priceTier: ProviderPriceTier;
+  providerId: string;
+  providerName: string;
+  provenance: ProviderProvenance;
+  title: string;
+}
+
+export interface ProviderArtifactMetadata {
+  contentType?: string | null;
+  fileExtension: string | null;
+  fileName: string;
+  format: ProviderArtifactFormat;
+  sha256?: string | null;
+  sizeBytes: number | null;
+}
+
+export interface ProviderReviewMetadata {
+  queueName: string;
+  summary: string;
+}
+
+export interface ProviderMiss {
+  detail: string;
+  providerId: string;
+  providerName: string;
+  reason: ProviderMissReason;
+  trackMissReason: TrackMissReason;
+}
+
+export interface ProviderRejection {
+  detail: string;
+  providerId: string;
+  providerName: string;
+  reason: ProviderRejectionReason;
+  retryable: boolean;
+  trackDecisionReason?: ProviderTrackDecisionReason;
+}
+
+export interface ProviderCandidatesResult {
+  outcome: "candidates";
+  candidates: readonly ProviderCandidate[];
+}
+
+export interface ProviderMissResult {
+  outcome: "miss";
+  miss: ProviderMiss;
+}
+
+export interface ProviderRejectedResult {
+  outcome: "rejected";
+  candidate?: ProviderCandidate;
+  rejection: ProviderRejection;
+}
+
+export interface ProviderAcquiredResult {
+  outcome: "acquired";
+  artifact: ProviderArtifactMetadata;
+  candidate: ProviderCandidate;
+}
+
+export interface ProviderQueuedForReviewResult {
+  outcome: "queued-for-review";
+  candidate: ProviderCandidate;
+  review: ProviderReviewMetadata;
+}
+
+export type ProviderSearchResult =
+  | ProviderCandidatesResult
+  | ProviderMissResult
+  | ProviderRejectedResult;
+
+export type ProviderAcquisitionResult =
+  | ProviderAcquiredResult
+  | ProviderMissResult
+  | ProviderRejectedResult;
+
+export type ProviderReviewQueueResult =
+  | ProviderMissResult
+  | ProviderQueuedForReviewResult
+  | ProviderRejectedResult;
+
+export interface ProviderSearchInput {
+  track: CanonicalTrack;
+}
+
+export interface ProviderAcquireInput {
+  candidate: ProviderCandidate;
+  track: CanonicalTrack;
+}
+
+export interface ProviderReviewQueueInput {
+  candidate: ProviderCandidate;
+  track: CanonicalTrack;
+}
+
+interface BaseProviderDefinition<
+  TMode extends ProviderRunMode,
+  TPriceTier extends ProviderPriceTier,
+  TBucket extends ProviderImplementationBucket
+> {
+  authorizationBasis: ProviderAuthorizationBasis;
+  displayName: string;
+  id: string;
+  implementationBucket: TBucket;
+  mode: TMode;
+  priorityRank: number;
+  priceTier: TPriceTier;
+  search(input: ProviderSearchInput): Promise<ProviderSearchResult>;
+  supportedFormats: readonly ProviderArtifactFormat[];
+}
+
+export interface AutomaticProviderDefinition
+  extends BaseProviderDefinition<
+    "automatic",
+    Exclude<ProviderPriceTier, "paid">,
+    "free-auto"
+  > {
+  acquire(input: ProviderAcquireInput): Promise<ProviderAcquisitionResult>;
+}
+
+export interface ReviewQueueProviderDefinition
+  extends BaseProviderDefinition<"review", "paid", "paid-review-queue"> {
+  queueForReview(
+    input: ProviderReviewQueueInput
+  ): Promise<ProviderReviewQueueResult>;
+}
+
+export type ProviderDefinition =
+  | AutomaticProviderDefinition
+  | ReviewQueueProviderDefinition;
+
+export class DuplicateProviderRegistrationError extends Error {
+  readonly providerId: string;
+
+  constructor(providerId: string) {
+    super(`Provider "${providerId}" is already registered.`);
+    this.name = "DuplicateProviderRegistrationError";
+    this.providerId = providerId;
+  }
+}
+
+const IMPLEMENTATION_BUCKET_ORDER: Record<ProviderImplementationBucket, number> = {
+  "free-auto": 0,
+  "paid-review-queue": 1
+};
+
+const RETRYABLE_REJECTION_REASONS = new Set<ProviderRejectionReason>([
+  "auth-required",
+  "provider-session-expired",
+  "download-artifact-missing",
+  "provider-error"
+]);
+
+type ProviderRunMode = "automatic" | "review";
+
+type AutomaticProviderOptions = Omit<
+  AutomaticProviderDefinition,
+  "implementationBucket" | "mode"
+>;
+
+type ReviewQueueProviderOptions = Omit<
+  ReviewQueueProviderDefinition,
+  "implementationBucket" | "mode" | "priceTier"
+>;
+
+export function defineAutomaticProvider(
+  options: AutomaticProviderOptions
+): AutomaticProviderDefinition {
+  return {
+    ...options,
+    implementationBucket: "free-auto",
+    mode: "automatic"
+  };
+}
+
+export function defineReviewQueueProvider(
+  options: ReviewQueueProviderOptions
+): ReviewQueueProviderDefinition {
+  return {
+    ...options,
+    implementationBucket: "paid-review-queue",
+    mode: "review",
+    priceTier: "paid"
+  };
+}
+
+export function isAutomaticProvider(
+  provider: ProviderDefinition
+): provider is AutomaticProviderDefinition {
+  return provider.mode === "automatic";
+}
+
+export function isReviewQueueProvider(
+  provider: ProviderDefinition
+): provider is ReviewQueueProviderDefinition {
+  return provider.mode === "review";
+}
+
+export function compareProviders(
+  left: ProviderDefinition,
+  right: ProviderDefinition
+) {
+  const bucketDifference =
+    IMPLEMENTATION_BUCKET_ORDER[left.implementationBucket] -
+    IMPLEMENTATION_BUCKET_ORDER[right.implementationBucket];
+
+  if (bucketDifference !== 0) {
+    return bucketDifference;
+  }
+
+  if (left.priorityRank !== right.priorityRank) {
+    return left.priorityRank - right.priorityRank;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+export class ProviderRegistry {
+  readonly #providers = new Map<string, ProviderDefinition>();
+
+  constructor(providers: readonly ProviderDefinition[] = []) {
+    for (const provider of providers) {
+      this.register(provider);
+    }
+  }
+
+  get(providerId: string) {
+    return this.#providers.get(providerId) ?? null;
+  }
+
+  list() {
+    return [...this.#providers.values()].sort(compareProviders);
+  }
+
+  listAutomatic() {
+    return this.list().filter(isAutomaticProvider);
+  }
+
+  listReviewQueue() {
+    return this.list().filter(isReviewQueueProvider);
+  }
+
+  register(provider: ProviderDefinition) {
+    if (this.#providers.has(provider.id)) {
+      throw new DuplicateProviderRegistrationError(provider.id);
+    }
+
+    this.#providers.set(provider.id, provider);
+
+    return provider;
+  }
+}
+
+export function buildProviderMissResult(input: {
+  detail: string;
+  providerId: string;
+  providerName: string;
+  reason: ProviderMissReason;
+  trackMissReason: TrackMissReason;
+}): ProviderMissResult {
+  return {
+    outcome: "miss",
+    miss: {
+      detail: input.detail,
+      providerId: input.providerId,
+      providerName: input.providerName,
+      reason: input.reason,
+      trackMissReason: input.trackMissReason
+    }
+  };
+}
+
+export function buildProviderRejectedResult(input: {
+  candidate?: ProviderCandidate;
+  detail: string;
+  providerId: string;
+  providerName: string;
+  reason: ProviderRejectionReason;
+  trackDecisionReason?: ProviderTrackDecisionReason;
+}): ProviderRejectedResult {
+  return {
+    outcome: "rejected",
+    candidate: input.candidate,
+    rejection: {
+      detail: input.detail,
+      providerId: input.providerId,
+      providerName: input.providerName,
+      reason: input.reason,
+      retryable: RETRYABLE_REJECTION_REASONS.has(input.reason),
+      trackDecisionReason: input.trackDecisionReason
+    }
+  };
+}


### PR DESCRIPTION
**@worker-02**

## Summary
- add a shared provider contract for automatic and Beatport-style review providers
- add a deterministic registry with registration helpers and duplicate protection
- add contract documentation and registry/rejection tests

## Verification
- npm run test
- npm run lint
- npm run build

## Issue
- #8
