### PR TITLE
fix: address SQLite persistence review findings

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -22,6 +22,14 @@ async function withTempDatabase(callback: (databasePath: string) => Promise<void
 }
 
 describe("HomePage", () => {
+  it("forces live home-page rendering against the SQLite run store", async () => {
+    vi.resetModules();
+
+    const pageModule = await import("./page");
+
+    expect(pageModule.dynamic).toBe("force-dynamic");
+  });
+
   it("renders real recent runs from SQLite-backed data", async () => {
     await withTempDatabase(async () => {
       vi.resetModules();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import { HomeScreen } from "@/features/home/home-screen";
 import { getRunStore } from "@/features/runs/run-store";
 
+export const dynamic = "force-dynamic";
+
 export default function HomePage() {
   return <HomeScreen initialRuns={getRunStore().listRuns()} />;
 }

--- a/src/features/runs/run-store.test.ts
+++ b/src/features/runs/run-store.test.ts
@@ -95,17 +95,25 @@ describe("createRunStore", () => {
     }
   });
 
-  it("requeues interrupted runs without losing per-track progress", () => {
+  it("requeues interrupted runs on store boot without losing per-track progress", () => {
     const tempDatabase = createTempDatabasePath();
+    let initialStore:
+      | ReturnType<typeof createRunStore>
+      | undefined;
+    let resumedStore:
+      | ReturnType<typeof createRunStore>
+      | undefined;
 
     try {
-      const store = createRunStore({ databasePath: tempDatabase.databasePath });
-      const run = store.createRun({
+      initialStore = createRunStore({
+        databasePath: tempDatabase.databasePath
+      });
+      const run = initialStore.createRun({
         playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DWZxZ8T6qM2Yj",
         sourceType: "spotify"
       });
 
-      const tracks = store.replaceRunTracks(run.id, [
+      const tracks = initialStore.replaceRunTracks(run.id, [
         {
           artist: "Artist One",
           sourcePosition: 1,
@@ -120,14 +128,18 @@ describe("createRunStore", () => {
         }
       ]);
 
-      store.transitionRunStatus(run.id, "ingesting");
-      store.transitionRunStatus(run.id, "matching");
-      store.updateRunTrackStatus(tracks[0].id, "matched");
-      store.updateRunTrackStatus(tracks[1].id, "failed");
+      initialStore.transitionRunStatus(run.id, "ingesting");
+      initialStore.transitionRunStatus(run.id, "matching");
+      initialStore.updateRunTrackStatus(tracks[0].id, "matched");
+      initialStore.updateRunTrackStatus(tracks[1].id, "failed");
+      initialStore.close();
+      initialStore = undefined;
 
-      expect(store.resumeInterruptedRuns()).toBe(1);
+      resumedStore = createRunStore({
+        databasePath: tempDatabase.databasePath
+      });
 
-      expect(store.getRunStatusSnapshot(run.id)).toEqual(
+      expect(resumedStore.getRunStatusSnapshot(run.id)).toEqual(
         expect.objectContaining({
           id: run.id,
           resumeAfterStatus: "matching",
@@ -135,7 +147,7 @@ describe("createRunStore", () => {
         })
       );
       expect(
-        store
+        resumedStore
           .getRun(run.id)
           ?.tracks.map((track) => [track.sourcePosition, track.status] satisfies [
             number,
@@ -146,6 +158,8 @@ describe("createRunStore", () => {
         [2, "failed"]
       ]);
     } finally {
+      initialStore?.close();
+      resumedStore?.close();
       tempDatabase.cleanup();
     }
   });

--- a/src/features/runs/run-store.ts
+++ b/src/features/runs/run-store.ts
@@ -343,6 +343,42 @@ export function createRunStore(options: RunStoreOptions = {}) {
     return run;
   }
 
+  function requeueInterruptedRuns() {
+    const now = getTimestamp();
+    const runsToResume = database
+      .prepare(
+        `
+          SELECT id, status
+          FROM runs
+          WHERE status IN (?, ?, ?)
+        `
+      )
+      .all(...resumableRunStatuses) as Array<{
+      id: string;
+      status: RunStatus;
+    }>;
+
+    const updateStatement = database.prepare(
+      `
+        UPDATE runs
+        SET status = ?,
+            resume_after_status = ?,
+            updated_at = ?,
+            completed_at = ?,
+            failed_at = ?
+        WHERE id = ?
+      `
+    );
+
+    for (const run of runsToResume) {
+      updateStatement.run("queued", run.status, now, null, null, run.id);
+    }
+
+    return runsToResume.length;
+  }
+
+  requeueInterruptedRuns();
+
   return {
     close() {
       database.close();
@@ -586,37 +622,7 @@ export function createRunStore(options: RunStoreOptions = {}) {
     },
 
     resumeInterruptedRuns() {
-      const now = getTimestamp();
-      const runsToResume = database
-        .prepare(
-          `
-            SELECT id, status
-            FROM runs
-            WHERE status IN (?, ?, ?)
-          `
-        )
-        .all(...resumableRunStatuses) as Array<{
-        id: string;
-        status: RunStatus;
-      }>;
-
-      const updateStatement = database.prepare(
-        `
-          UPDATE runs
-          SET status = ?,
-              resume_after_status = ?,
-              updated_at = ?,
-              completed_at = ?,
-              failed_at = ?
-          WHERE id = ?
-        `
-      );
-
-      for (const run of runsToResume) {
-        updateStatement.run("queued", run.status, now, null, null, run.id);
-      }
-
-      return runsToResume.length;
+      return requeueInterruptedRuns();
     },
 
     transitionRunStatus(runId: string, nextStatus: RunStatus): RunDetail {


### PR DESCRIPTION
**@worker-02**

## Summary
- force `/` to render dynamically so recent runs come from live SQLite state after restart/build
- requeue interrupted runs automatically when the store boots, preserving `resumeAfterStatus`
- add regression coverage for both review findings

## Verification
- `npm run lint`
- `npm test`
- `npm run build`
