### PR TITLE
feat: ingest SoundCloud playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Local web app for authorized-source playlist acquisition, optimized for DJ and e
 npm install
 ```
 
+To enable authorized SoundCloud playlist ingestion through the official API,
+set these env vars before running the app:
+
+```bash
+export SOUNDCLOUD_CLIENT_ID=your-soundcloud-client-id
+export SOUNDCLOUD_CLIENT_SECRET=your-soundcloud-client-secret
+```
+
 ## Run
 
 ```bash

--- a/src/app/api/runs/route.test.ts
+++ b/src/app/api/runs/route.test.ts
@@ -150,6 +150,23 @@ describe("/api/runs", () => {
         expect(createResponse.status).toBe(201);
         expect(fetchSpy).toHaveBeenCalledTimes(2);
 
+        const [tokenUrl, tokenRequest] = fetchSpy.mock.calls[0] ?? [];
+        const tokenHeaders = tokenRequest?.headers as Record<string, string>;
+        const tokenBody = new URLSearchParams(String(tokenRequest?.body ?? ""));
+
+        expect(String(tokenUrl)).toBe("https://api.soundcloud.com/oauth2/token");
+        expect(tokenRequest?.method).toBe("POST");
+        expect(tokenHeaders).toEqual(
+          expect.objectContaining({
+            Accept: "application/json; charset=utf-8",
+            "Content-Type": "application/x-www-form-urlencoded"
+          })
+        );
+        expect(tokenHeaders.Authorization).toBeUndefined();
+        expect(tokenBody.get("client_id")).toBe("soundcloud-client-id");
+        expect(tokenBody.get("client_secret")).toBe("soundcloud-client-secret");
+        expect(tokenBody.get("grant_type")).toBe("client_credentials");
+
         const createdRun = (await createResponse.json()) as {
           id: string;
           playlistTitle: string | null;

--- a/src/app/api/runs/route.test.ts
+++ b/src/app/api/runs/route.test.ts
@@ -73,4 +73,213 @@ describe("/api/runs", () => {
       expect(runStoreModule.getRunStore().listRuns()).toHaveLength(1);
     });
   });
+
+  it("ingests a SoundCloud playlist into persisted run data", async () => {
+    await withTempDatabase(async () => {
+      vi.resetModules();
+
+      const originalClientId = process.env.SOUNDCLOUD_CLIENT_ID;
+      const originalClientSecret = process.env.SOUNDCLOUD_CLIENT_SECRET;
+
+      process.env.SOUNDCLOUD_CLIENT_ID = "soundcloud-client-id";
+      process.env.SOUNDCLOUD_CLIENT_SECRET = "soundcloud-client-secret";
+
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ access_token: "soundcloud-access-token" }), {
+            headers: {
+              "content-type": "application/json"
+            },
+            status: 200
+          })
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              kind: "playlist",
+              permalink_url:
+                "https://soundcloud.com/dj-nova/sets/warehouse-finds",
+              title: "Warehouse Finds",
+              tracks: [
+                {
+                  id: 111,
+                  metadata_artist: "DJ Sealer",
+                  title: "DJ Sealer - Warehouse Tool (Extended Mix) [Free DL]",
+                  urn: "soundcloud:tracks:111",
+                  user: {
+                    username: "dj-sealer"
+                  }
+                },
+                {
+                  id: 222,
+                  title: "Selector Two - Loft Shaker",
+                  user: {
+                    username: "selector-two"
+                  }
+                }
+              ]
+            }),
+            {
+              headers: {
+                "content-type": "application/json"
+              },
+              status: 200
+            }
+          )
+        );
+
+      try {
+        const [{ POST }, runStoreModule] = await Promise.all([
+          import("./route"),
+          import("@/features/runs/run-store")
+        ]);
+
+        const createResponse = await POST(
+          new Request("http://localhost/api/runs", {
+            body: JSON.stringify({
+              playlistUrl: "https://soundcloud.com/dj-nova/sets/warehouse-finds"
+            }),
+            headers: {
+              "content-type": "application/json"
+            },
+            method: "POST"
+          })
+        );
+
+        expect(createResponse.status).toBe(201);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+        const createdRun = (await createResponse.json()) as {
+          id: string;
+          playlistTitle: string | null;
+          sourceType: string;
+          trackCount: number;
+          tracks: Array<{
+            artist: string;
+            title: string;
+            version: string | null;
+          }>;
+        };
+
+        expect(createdRun).toEqual(
+          expect.objectContaining({
+            playlistTitle: "Warehouse Finds",
+            sourceType: "soundcloud",
+            trackCount: 2
+          })
+        );
+        expect(createdRun.tracks).toEqual([
+          expect.objectContaining({
+            artist: "DJ Sealer",
+            title: "Warehouse Tool",
+            version: "Extended Mix"
+          }),
+          expect.objectContaining({
+            artist: "Selector Two",
+            title: "Loft Shaker",
+            version: null
+          })
+        ]);
+        expect(runStoreModule.getRunStore().getRun(createdRun.id)?.tracks).toEqual([
+          expect.objectContaining({
+            artist: "DJ Sealer",
+            title: "Warehouse Tool",
+            version: "Extended Mix"
+          }),
+          expect.objectContaining({
+            artist: "Selector Two",
+            title: "Loft Shaker",
+            version: null
+          })
+        ]);
+      } finally {
+        fetchSpy.mockRestore();
+
+        if (originalClientId === undefined) {
+          delete process.env.SOUNDCLOUD_CLIENT_ID;
+        } else {
+          process.env.SOUNDCLOUD_CLIENT_ID = originalClientId;
+        }
+
+        if (originalClientSecret === undefined) {
+          delete process.env.SOUNDCLOUD_CLIENT_SECRET;
+        } else {
+          process.env.SOUNDCLOUD_CLIENT_SECRET = originalClientSecret;
+        }
+      }
+    });
+  });
+
+  it("returns explicit validation errors for unsupported SoundCloud URLs", async () => {
+    await withTempDatabase(async () => {
+      vi.resetModules();
+
+      const { POST } = await import("./route");
+
+      const response = await POST(
+        new Request("http://localhost/api/runs", {
+          body: JSON.stringify({
+            playlistUrl: "https://soundcloud.com/dj-nova/warehouse-tool"
+          }),
+          headers: {
+            "content-type": "application/json"
+          },
+          method: "POST"
+        })
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error:
+          "SoundCloud URL must point to a playlist set (for example /artist/sets/playlist-name)."
+      });
+    });
+  });
+
+  it("returns explicit setup errors when SoundCloud credentials are missing", async () => {
+    await withTempDatabase(async () => {
+      vi.resetModules();
+
+      const originalClientId = process.env.SOUNDCLOUD_CLIENT_ID;
+      const originalClientSecret = process.env.SOUNDCLOUD_CLIENT_SECRET;
+
+      delete process.env.SOUNDCLOUD_CLIENT_ID;
+      delete process.env.SOUNDCLOUD_CLIENT_SECRET;
+
+      try {
+        const { POST } = await import("./route");
+
+        const response = await POST(
+          new Request("http://localhost/api/runs", {
+            body: JSON.stringify({
+              playlistUrl: "https://soundcloud.com/dj-nova/sets/warehouse-finds"
+            }),
+            headers: {
+              "content-type": "application/json"
+            },
+            method: "POST"
+          })
+        );
+
+        expect(response.status).toBe(500);
+        await expect(response.json()).resolves.toEqual({
+          error:
+            "SoundCloud ingestion requires SOUNDCLOUD_CLIENT_ID and SOUNDCLOUD_CLIENT_SECRET."
+        });
+      } finally {
+        if (originalClientId === undefined) {
+          delete process.env.SOUNDCLOUD_CLIENT_ID;
+        } else {
+          process.env.SOUNDCLOUD_CLIENT_ID = originalClientId;
+        }
+
+        if (originalClientSecret === undefined) {
+          delete process.env.SOUNDCLOUD_CLIENT_SECRET;
+        } else {
+          process.env.SOUNDCLOUD_CLIENT_SECRET = originalClientSecret;
+        }
+      }
+    });
+  });
 });

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -1,25 +1,8 @@
 import { NextResponse } from "next/server";
 
-import { getRunStore, type PlaylistSource } from "@/features/runs/run-store";
-
-function detectPlaylistSource(playlistUrl: string): PlaylistSource | null {
-  try {
-    const parsedUrl = new URL(playlistUrl);
-    const hostname = parsedUrl.hostname.toLowerCase();
-
-    if (hostname.includes("spotify.com")) {
-      return "spotify";
-    }
-
-    if (hostname.includes("soundcloud.com")) {
-      return "soundcloud";
-    }
-
-    return null;
-  } catch {
-    return null;
-  }
-}
+import { createRunFromPlaylistUrl } from "@/features/ingestion/playlist-intake";
+import { PlaylistIntakeError } from "@/features/ingestion/playlist-intake-error";
+import { getRunStore } from "@/features/runs/run-store";
 
 export async function GET() {
   return NextResponse.json(getRunStore().listRuns());
@@ -38,16 +21,18 @@ export async function POST(request: Request) {
     );
   }
 
-  const sourceType = detectPlaylistSource(playlistUrl);
+  try {
+    return NextResponse.json(await createRunFromPlaylistUrl(playlistUrl), {
+      status: 201
+    });
+  } catch (error) {
+    if (error instanceof PlaylistIntakeError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.statusCode }
+      );
+    }
 
-  if (!sourceType) {
-    return NextResponse.json(
-      { error: "Only Spotify and SoundCloud playlist URLs are supported." },
-      { status: 400 }
-    );
+    throw error;
   }
-
-  const run = getRunStore().createRun({ playlistUrl, sourceType });
-
-  return NextResponse.json(run, { status: 201 });
 }

--- a/src/features/ingestion/playlist-intake-error.ts
+++ b/src/features/ingestion/playlist-intake-error.ts
@@ -1,0 +1,9 @@
+export class PlaylistIntakeError extends Error {
+  constructor(
+    message: string,
+    readonly statusCode: number
+  ) {
+    super(message);
+    this.name = "PlaylistIntakeError";
+  }
+}

--- a/src/features/ingestion/playlist-intake.ts
+++ b/src/features/ingestion/playlist-intake.ts
@@ -1,0 +1,67 @@
+import { getRunStore, type RunDetail, type RunStore } from "@/features/runs/run-store";
+
+import { PlaylistIntakeError } from "./playlist-intake-error";
+import { fetchSoundCloudPlaylistSnapshot } from "./soundcloud-playlist";
+
+type PlaylistIntakeDependencies = {
+  fetchSoundCloudPlaylistSnapshot?: typeof fetchSoundCloudPlaylistSnapshot;
+  runStore?: Pick<RunStore, "createRun" | "getRun" | "replaceRunTracks">;
+};
+
+function detectPlaylistSource(playlistUrl: string) {
+  try {
+    const hostname = new URL(playlistUrl).hostname.toLowerCase();
+
+    if (hostname.includes("spotify.com")) {
+      return "spotify" as const;
+    }
+
+    if (hostname.includes("soundcloud.com")) {
+      return "soundcloud" as const;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function createRunFromPlaylistUrl(
+  playlistUrl: string,
+  dependencies: PlaylistIntakeDependencies = {}
+): Promise<RunDetail> {
+  const sourceType = detectPlaylistSource(playlistUrl);
+
+  if (!sourceType) {
+    throw new PlaylistIntakeError(
+      "Only Spotify and SoundCloud playlist URLs are supported.",
+      400
+    );
+  }
+
+  const runStore = dependencies.runStore ?? getRunStore();
+
+  if (sourceType === "spotify") {
+    return runStore.createRun({ playlistUrl, sourceType });
+  }
+
+  const snapshot = await (
+    dependencies.fetchSoundCloudPlaylistSnapshot ??
+    fetchSoundCloudPlaylistSnapshot
+  )(playlistUrl);
+  const run = runStore.createRun({
+    playlistTitle: snapshot.playlistTitle,
+    playlistUrl: snapshot.playlistUrl,
+    sourceType: "soundcloud"
+  });
+
+  runStore.replaceRunTracks(run.id, snapshot.tracks);
+
+  const hydratedRun = runStore.getRun(run.id);
+
+  if (!hydratedRun) {
+    throw new Error(`Run not found after SoundCloud ingestion: ${run.id}`);
+  }
+
+  return hydratedRun;
+}

--- a/src/features/ingestion/soundcloud-playlist.test.ts
+++ b/src/features/ingestion/soundcloud-playlist.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment node */
 
 import {
+  fetchSoundCloudPlaylistSnapshot,
   mapSoundCloudPlaylistSnapshot,
   parseSoundCloudPlaylistUrl
 } from "./soundcloud-playlist";
@@ -74,5 +75,72 @@ describe("mapSoundCloudPlaylistSnapshot", () => {
         }
       ]
     });
+  });
+});
+
+describe("fetchSoundCloudPlaylistSnapshot", () => {
+  it("uses the documented SoundCloud OAuth2 client-credentials contract", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: "soundcloud-access-token" }), {
+          headers: {
+            "content-type": "application/json"
+          },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            kind: "playlist",
+            permalink_url:
+              "https://soundcloud.com/dj-nova/sets/warehouse-finds",
+            title: "Warehouse Finds",
+            tracks: [
+              {
+                id: 111,
+                metadata_artist: "DJ Sealer",
+                title: "DJ Sealer - Warehouse Tool (Extended Mix)",
+                urn: "soundcloud:tracks:111"
+              }
+            ]
+          }),
+          {
+            headers: {
+              "content-type": "application/json"
+            },
+            status: 200
+          }
+        )
+      );
+
+    await fetchSoundCloudPlaylistSnapshot(
+      "https://soundcloud.com/dj-nova/sets/warehouse-finds",
+      {
+        clientId: "soundcloud-client-id",
+        clientSecret: "soundcloud-client-secret",
+        fetchImpl
+      }
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    const [tokenUrl, tokenRequest] = fetchImpl.mock.calls[0] ?? [];
+    const tokenHeaders = tokenRequest?.headers as Record<string, string>;
+    const tokenBody = new URLSearchParams(String(tokenRequest?.body ?? ""));
+
+    expect(String(tokenUrl)).toBe("https://api.soundcloud.com/oauth2/token");
+    expect(tokenRequest?.method).toBe("POST");
+    expect(tokenHeaders).toEqual(
+      expect.objectContaining({
+        Accept: "application/json; charset=utf-8",
+        "Content-Type": "application/x-www-form-urlencoded"
+      })
+    );
+    expect(tokenHeaders.Authorization).toBeUndefined();
+    expect(tokenBody.get("client_id")).toBe("soundcloud-client-id");
+    expect(tokenBody.get("client_secret")).toBe("soundcloud-client-secret");
+    expect(tokenBody.get("grant_type")).toBe("client_credentials");
   });
 });

--- a/src/features/ingestion/soundcloud-playlist.test.ts
+++ b/src/features/ingestion/soundcloud-playlist.test.ts
@@ -1,0 +1,78 @@
+/* @vitest-environment node */
+
+import {
+  mapSoundCloudPlaylistSnapshot,
+  parseSoundCloudPlaylistUrl
+} from "./soundcloud-playlist";
+
+describe("parseSoundCloudPlaylistUrl", () => {
+  it("normalizes supported SoundCloud set URLs", () => {
+    const playlistUrl = parseSoundCloudPlaylistUrl(
+      "https://m.soundcloud.com/dj-nova/sets/warehouse-finds?si=abc123#cue"
+    );
+
+    expect(playlistUrl.toString()).toBe(
+      "https://soundcloud.com/dj-nova/sets/warehouse-finds"
+    );
+  });
+
+  it("rejects non-playlist SoundCloud URLs with an explicit error", () => {
+    expect(() =>
+      parseSoundCloudPlaylistUrl("https://soundcloud.com/dj-nova/warehouse-tool")
+    ).toThrowError(
+      "SoundCloud URL must point to a playlist set (for example /artist/sets/playlist-name)."
+    );
+  });
+});
+
+describe("mapSoundCloudPlaylistSnapshot", () => {
+  it("maps resolved playlist payloads into run-track inputs", () => {
+    const snapshot = mapSoundCloudPlaylistSnapshot(
+      {
+        kind: "playlist",
+        permalink_url: "https://soundcloud.com/dj-nova/sets/warehouse-finds",
+        title: "Warehouse Finds",
+        tracks: [
+          {
+            id: 111,
+            metadata_artist: "DJ Sealer",
+            title: "DJ Sealer - Warehouse Tool (Extended Mix) [Free DL]",
+            urn: "soundcloud:tracks:111",
+            user: {
+              username: "dj-sealer"
+            }
+          },
+          {
+            id: 222,
+            title: "Selector Two - Loft Shaker",
+            user: {
+              username: "selector-two"
+            }
+          }
+        ]
+      },
+      "https://soundcloud.com/dj-nova/sets/warehouse-finds"
+    );
+
+    expect(snapshot).toEqual({
+      playlistTitle: "Warehouse Finds",
+      playlistUrl: "https://soundcloud.com/dj-nova/sets/warehouse-finds",
+      tracks: [
+        {
+          artist: "DJ Sealer",
+          sourcePosition: 1,
+          sourceTrackId: "soundcloud:tracks:111",
+          title: "Warehouse Tool",
+          version: "Extended Mix"
+        },
+        {
+          artist: "Selector Two",
+          sourcePosition: 2,
+          sourceTrackId: "222",
+          title: "Loft Shaker",
+          version: null
+        }
+      ]
+    });
+  });
+});

--- a/src/features/ingestion/soundcloud-playlist.ts
+++ b/src/features/ingestion/soundcloud-playlist.ts
@@ -129,7 +129,7 @@ export async function fetchSoundCloudPlaylistSnapshot(
     clientSecret,
     fetchImpl,
     tokenUrl:
-      dependencies.tokenUrl ?? "https://secure.soundcloud.com/oauth/token"
+      dependencies.tokenUrl ?? "https://api.soundcloud.com/oauth2/token"
   });
   const resolveUrl = new URL(
     "/resolve",
@@ -166,13 +166,12 @@ async function fetchSoundCloudAccessToken(input: {
 }) {
   const response = await input.fetchImpl(input.tokenUrl, {
     body: new URLSearchParams({
+      client_id: input.clientId,
+      client_secret: input.clientSecret,
       grant_type: "client_credentials"
     }).toString(),
     headers: {
       Accept: "application/json; charset=utf-8",
-      Authorization: `Basic ${Buffer.from(
-        `${input.clientId}:${input.clientSecret}`
-      ).toString("base64")}`,
       "Content-Type": "application/x-www-form-urlencoded"
     },
     method: "POST"

--- a/src/features/ingestion/soundcloud-playlist.ts
+++ b/src/features/ingestion/soundcloud-playlist.ts
@@ -1,0 +1,305 @@
+import type { ReplaceRunTrackInput } from "@/features/runs/run-store";
+import { canonicalizeTrack } from "@/features/tracks/canonical-track";
+
+import { PlaylistIntakeError } from "./playlist-intake-error";
+
+type FetchLike = typeof fetch;
+
+type SoundCloudTrackPayload = {
+  id?: number | string | null;
+  metadata_artist?: string | null;
+  title?: string | null;
+  urn?: string | null;
+  user?: {
+    username?: string | null;
+  } | null;
+};
+
+type SoundCloudPlaylistPayload = {
+  kind?: string | null;
+  permalink_url?: string | null;
+  title?: string | null;
+  tracks?: SoundCloudTrackPayload[] | null;
+};
+
+type SoundCloudTokenPayload = {
+  access_token?: string;
+};
+
+type SoundCloudPlaylistSnapshot = {
+  playlistTitle: string | null;
+  playlistUrl: string;
+  tracks: ReplaceRunTrackInput[];
+};
+
+type SoundCloudPlaylistDependencies = {
+  apiBaseUrl?: string;
+  clientId?: string;
+  clientSecret?: string;
+  fetchImpl?: FetchLike;
+  tokenUrl?: string;
+};
+
+const soundCloudHosts = new Set([
+  "m.soundcloud.com",
+  "soundcloud.com",
+  "www.soundcloud.com"
+]);
+
+export function parseSoundCloudPlaylistUrl(playlistUrl: string) {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(playlistUrl);
+  } catch {
+    throw new PlaylistIntakeError("SoundCloud URL is invalid.", 400);
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+  const pathSegments = parsedUrl.pathname.split("/").filter(Boolean);
+
+  if (!soundCloudHosts.has(hostname)) {
+    throw new PlaylistIntakeError(
+      "SoundCloud URL must use soundcloud.com playlist/set links.",
+      400
+    );
+  }
+
+  if (
+    pathSegments.length !== 3 ||
+    pathSegments[1] !== "sets" ||
+    !pathSegments[0] ||
+    !pathSegments[2]
+  ) {
+    throw new PlaylistIntakeError(
+      "SoundCloud URL must point to a playlist set (for example /artist/sets/playlist-name).",
+      400
+    );
+  }
+
+  return new URL(
+    `https://soundcloud.com/${pathSegments[0]}/sets/${pathSegments[2]}`
+  );
+}
+
+export function mapSoundCloudPlaylistSnapshot(
+  payload: SoundCloudPlaylistPayload,
+  playlistUrl: string
+): SoundCloudPlaylistSnapshot {
+  if (payload.kind !== "playlist") {
+    throw new PlaylistIntakeError(
+      "SoundCloud URL did not resolve to a playlist.",
+      502
+    );
+  }
+
+  if (!Array.isArray(payload.tracks)) {
+    throw new PlaylistIntakeError(
+      "SoundCloud playlist response did not include track data.",
+      502
+    );
+  }
+
+  return {
+    playlistTitle: cleanValue(payload.title),
+    playlistUrl: cleanValue(payload.permalink_url) ?? playlistUrl,
+    tracks: payload.tracks.map((track, index) => mapSoundCloudTrack(track, index))
+  };
+}
+
+export async function fetchSoundCloudPlaylistSnapshot(
+  playlistUrl: string,
+  dependencies: SoundCloudPlaylistDependencies = {}
+) {
+  const normalizedPlaylistUrl = parseSoundCloudPlaylistUrl(playlistUrl).toString();
+  const clientId = dependencies.clientId ?? process.env.SOUNDCLOUD_CLIENT_ID;
+  const clientSecret =
+    dependencies.clientSecret ?? process.env.SOUNDCLOUD_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    throw new PlaylistIntakeError(
+      "SoundCloud ingestion requires SOUNDCLOUD_CLIENT_ID and SOUNDCLOUD_CLIENT_SECRET.",
+      500
+    );
+  }
+
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const accessToken = await fetchSoundCloudAccessToken({
+    clientId,
+    clientSecret,
+    fetchImpl,
+    tokenUrl:
+      dependencies.tokenUrl ?? "https://secure.soundcloud.com/oauth/token"
+  });
+  const resolveUrl = new URL(
+    "/resolve",
+    dependencies.apiBaseUrl ?? "https://api.soundcloud.com"
+  );
+
+  resolveUrl.searchParams.set("url", normalizedPlaylistUrl);
+
+  const response = await fetchImpl(resolveUrl, {
+    headers: {
+      Accept: "application/json; charset=utf-8",
+      Authorization: `OAuth ${accessToken}`
+    }
+  });
+
+  if (!response.ok) {
+    throw new PlaylistIntakeError(
+      (await readErrorMessage(response)) ?? "SoundCloud playlist lookup failed.",
+      502
+    );
+  }
+
+  return mapSoundCloudPlaylistSnapshot(
+    (await response.json()) as SoundCloudPlaylistPayload,
+    normalizedPlaylistUrl
+  );
+}
+
+async function fetchSoundCloudAccessToken(input: {
+  clientId: string;
+  clientSecret: string;
+  fetchImpl: FetchLike;
+  tokenUrl: string;
+}) {
+  const response = await input.fetchImpl(input.tokenUrl, {
+    body: new URLSearchParams({
+      grant_type: "client_credentials"
+    }).toString(),
+    headers: {
+      Accept: "application/json; charset=utf-8",
+      Authorization: `Basic ${Buffer.from(
+        `${input.clientId}:${input.clientSecret}`
+      ).toString("base64")}`,
+      "Content-Type": "application/x-www-form-urlencoded"
+    },
+    method: "POST"
+  });
+
+  if (!response.ok) {
+    throw new PlaylistIntakeError(
+      (await readErrorMessage(response)) ?? "SoundCloud authentication failed.",
+      502
+    );
+  }
+
+  const payload = (await response.json()) as SoundCloudTokenPayload;
+
+  if (!payload.access_token) {
+    throw new PlaylistIntakeError(
+      "SoundCloud authentication response did not include an access token.",
+      502
+    );
+  }
+
+  return payload.access_token;
+}
+
+function cleanValue(value: string | null | undefined) {
+  const trimmedValue = value?.trim();
+
+  return trimmedValue ? trimmedValue : null;
+}
+
+function mapSoundCloudTrack(
+  track: SoundCloudTrackPayload,
+  index: number
+): ReplaceRunTrackInput {
+  const rawTitle = cleanValue(track.title);
+
+  if (!rawTitle) {
+    throw new PlaylistIntakeError(
+      `SoundCloud playlist track ${index + 1} is missing a title.`,
+      502
+    );
+  }
+
+  const explicitArtist = cleanValue(track.metadata_artist);
+  const sourceTrackId = resolveSourceTrackId(track);
+  const canonicalTrack = canonicalizeTrack({
+    ...(explicitArtist ? { artistName: explicitArtist } : {}),
+    source: "soundcloud",
+    sourceTrackId: sourceTrackId ?? undefined,
+    title: stripLeadingArtistPrefix(rawTitle, explicitArtist)
+  });
+  const artist =
+    explicitArtist ??
+    canonicalTrack.primaryArtist ??
+    inferArtistFromTitle(rawTitle) ??
+    cleanValue(track.user?.username);
+
+  if (!artist) {
+    throw new PlaylistIntakeError(
+      `SoundCloud playlist track ${index + 1} is missing artist metadata.`,
+      502
+    );
+  }
+
+  return {
+    artist,
+    sourcePosition: index + 1,
+    sourceTrackId,
+    title: canonicalTrack.title,
+    version: canonicalTrack.mix.displayLabel
+  };
+}
+
+function inferArtistFromTitle(rawTitle: string) {
+  const separatorIndex = rawTitle.search(/\s[-–—]\s/);
+
+  if (separatorIndex < 0) {
+    return null;
+  }
+
+  const artistSegment = rawTitle.slice(0, separatorIndex).trim();
+
+  return artistSegment || null;
+}
+
+function stripLeadingArtistPrefix(rawTitle: string, artist: string | null) {
+  if (!artist) {
+    return rawTitle;
+  }
+
+  for (const separator of [" - ", " – ", " — "]) {
+    const candidatePrefix = `${artist}${separator}`;
+
+    if (rawTitle.toLowerCase().startsWith(candidatePrefix.toLowerCase())) {
+      return rawTitle.slice(candidatePrefix.length);
+    }
+  }
+
+  return rawTitle;
+}
+
+function resolveSourceTrackId(track: SoundCloudTrackPayload) {
+  const urn = cleanValue(track.urn);
+
+  if (urn) {
+    return urn;
+  }
+
+  if (typeof track.id === "number") {
+    return String(track.id);
+  }
+
+  return cleanValue(track.id);
+}
+
+async function readErrorMessage(response: Response) {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    const payload = (await response.json().catch(() => null)) as
+      | { error?: string; error_description?: string }
+      | null;
+
+    return payload?.error_description ?? payload?.error ?? null;
+  }
+
+  const text = await response.text().catch(() => "");
+
+  return text.trim() || null;
+}


### PR DESCRIPTION
**@worker-02**

## Summary
- add a SoundCloud playlist intake path that validates playlist/set URLs, authenticates through the official API, resolves playlist metadata, and persists canonicalized track rows into the run store
- keep Spotify intake behavior unchanged while routing both sources through a shared playlist-intake entry point
- document required SoundCloud client credentials for local setup

## Testing
- `npm run test -- src/app/api/runs/route.test.ts src/features/ingestion/soundcloud-playlist.test.ts`
- attempted broader lint/test verification, but the worker wrapper repeatedly detached the worktree and intermittently hid repo files/tooling after the focused pass

Refs #6
