### PR TITLE
feat: add deterministic track matcher

### DIFF
--- a/src/features/matching/track-matcher.test.ts
+++ b/src/features/matching/track-matcher.test.ts
@@ -1,0 +1,291 @@
+import { canonicalizeTrack } from "@/features/tracks/canonical-track";
+import type { ProviderCandidate } from "@/features/providers/provider-registry";
+
+import { matchTrackCandidates } from "./track-matcher";
+
+describe("matchTrackCandidates", () => {
+  const targetTrack = canonicalizeTrack({
+    source: "spotify",
+    artistNames: ["Anyma"],
+    title: "Consciousness (Extended Mix)",
+    duration: 392
+  });
+
+  it.each([
+    {
+      name: "prefers a free extended mix over a free original mix",
+      candidates: [
+        buildCandidate({
+          candidateId: "soundcloud-original",
+          mixLabel: "Original Mix",
+          title: "Consciousness"
+        }),
+        buildCandidate({
+          candidateId: "soundcloud-extended",
+          mixLabel: "Extended Mix",
+          title: "Consciousness"
+        })
+      ],
+      expected: {
+        outcome: "selected",
+        selected: {
+          candidateId: "soundcloud-extended",
+          reason: "accepted-extended-mix",
+          selectedFormat: "mp3"
+        },
+        rejected: [
+          {
+            candidateId: "soundcloud-original",
+            reason: "superseded-by-higher-ranked-candidate",
+            selectedFormat: "mp3"
+          }
+        ]
+      }
+    },
+    {
+      name: "prefers mp3 over wav when mix priority is tied",
+      candidates: [
+        buildCandidate({
+          availableFormats: ["wav"],
+          candidateId: "bandcamp-wav",
+          mixLabel: "Original Mix",
+          providerId: "bandcamp",
+          providerName: "Bandcamp",
+          title: "Consciousness"
+        }),
+        buildCandidate({
+          availableFormats: ["wav", "mp3"],
+          candidateId: "soundcloud-mp3",
+          mixLabel: "Original Mix",
+          title: "Consciousness"
+        })
+      ],
+      expected: {
+        outcome: "selected",
+        selected: {
+          candidateId: "soundcloud-mp3",
+          reason: "accepted-original-mix",
+          selectedFormat: "mp3"
+        },
+        rejected: [
+          {
+            candidateId: "bandcamp-wav",
+            reason: "superseded-by-higher-ranked-candidate",
+            selectedFormat: "wav"
+          }
+        ]
+      }
+    },
+    {
+      name: "keeps paid fallback candidates behind acceptable free-source matches",
+      candidates: [
+        buildCandidate({
+          availableFormats: ["mp3"],
+          candidateId: "soundcloud-original",
+          mixLabel: "Original Mix",
+          priceTier: "free",
+          title: "Consciousness"
+        }),
+        buildCandidate({
+          availableFormats: ["mp3"],
+          authorizationBasis: "purchase-entitlement",
+          candidateId: "beatport-extended",
+          mixLabel: "Extended Mix",
+          priceTier: "paid",
+          providerId: "beatport",
+          providerName: "Beatport",
+          title: "Consciousness"
+        })
+      ],
+      expected: {
+        outcome: "selected",
+        selected: {
+          candidateId: "soundcloud-original",
+          reason: "accepted-original-mix",
+          selectedFormat: "mp3"
+        },
+        rejected: [
+          {
+            candidateId: "beatport-extended",
+            reason: "superseded-by-higher-ranked-candidate",
+            selectedFormat: "mp3"
+          }
+        ]
+      }
+    },
+    {
+      name: "accepts a high-confidence versionless fallback when it clears four minutes",
+      candidates: [
+        buildCandidate({
+          availableFormats: ["wav"],
+          candidateId: "bandcamp-fallback",
+          durationSeconds: 301,
+          mixConfidence: "high",
+          mixLabel: null,
+          providerId: "bandcamp",
+          providerName: "Bandcamp",
+          title: "Consciousness"
+        })
+      ],
+      expected: {
+        outcome: "selected",
+        selected: {
+          candidateId: "bandcamp-fallback",
+          reason: "accepted-base-version-fallback",
+          selectedFormat: "wav"
+        },
+        rejected: []
+      }
+    }
+  ])("$name", ({ candidates, expected }) => {
+    const result = matchTrackCandidates({
+      candidates,
+      track: targetTrack
+    });
+
+    expect(result.outcome).toBe(expected.outcome);
+
+    if (result.outcome !== "selected") {
+      throw new Error("Expected a selected result for this test case.");
+    }
+
+    expect({
+      outcome: result.outcome,
+      selected: {
+        candidateId: result.selected.candidate.candidateId,
+        reason: result.selected.reason,
+        selectedFormat: result.selected.selectedFormat
+      },
+      rejected: result.rejected.map((rejection) => ({
+        candidateId: rejection.candidate.candidateId,
+        reason: rejection.reason,
+        selectedFormat: rejection.selectedFormat
+      }))
+    }).toEqual(expected);
+  });
+
+  it.each([
+    {
+      name: "rejects low-confidence versionless fallbacks",
+      candidates: [
+        buildCandidate({
+          candidateId: "soundcloud-low-confidence",
+          durationSeconds: 301,
+          mixConfidence: "medium",
+          mixLabel: null,
+          title: "Consciousness"
+        })
+      ],
+      expectedMissReason: "no-eligible-candidate",
+      expectedRejections: [
+        {
+          candidateId: "soundcloud-low-confidence",
+          reason: "fallback-confidence-too-low",
+          selectedFormat: "mp3"
+        }
+      ]
+    },
+    {
+      name: "rejects short versionless fallbacks",
+      candidates: [
+        buildCandidate({
+          candidateId: "soundcloud-too-short",
+          durationSeconds: 239,
+          mixConfidence: "high",
+          mixLabel: null,
+          title: "Consciousness"
+        })
+      ],
+      expectedMissReason: "no-eligible-candidate",
+      expectedRejections: [
+        {
+          candidateId: "soundcloud-too-short",
+          reason: "fallback-duration-too-short",
+          selectedFormat: "mp3"
+        }
+      ]
+    },
+    {
+      name: "treats non-matching candidates as no authorized source match",
+      candidates: [
+        buildCandidate({
+          artistName: "Different Artist",
+          candidateId: "soundcloud-wrong-track",
+          mixLabel: "Extended Mix",
+          title: "Different Song"
+        })
+      ],
+      expectedMissReason: "no-authorized-source-match",
+      expectedRejections: [
+        {
+          candidateId: "soundcloud-wrong-track",
+          reason: "title-and-artist-mismatch",
+          selectedFormat: null
+        }
+      ]
+    }
+  ])("$name", ({ candidates, expectedMissReason, expectedRejections }) => {
+    const result = matchTrackCandidates({
+      candidates,
+      track: targetTrack
+    });
+
+    expect(result).toMatchObject({
+      outcome: "miss",
+      miss: {
+        reason: expectedMissReason
+      },
+      rejected: expectedRejections.map((rejection) => ({
+        candidate: {
+          candidateId: rejection.candidateId
+        },
+        reason: rejection.reason,
+        selectedFormat: rejection.selectedFormat
+      }))
+    });
+  });
+
+  it("returns the same result for the same inputs", () => {
+    const input = {
+      candidates: [
+        buildCandidate({
+          candidateId: "soundcloud-original",
+          mixLabel: "Original Mix",
+          title: "Consciousness"
+        }),
+        buildCandidate({
+          candidateId: "soundcloud-extended",
+          mixLabel: "Extended Mix",
+          title: "Consciousness"
+        })
+      ],
+      track: targetTrack
+    };
+
+    expect(matchTrackCandidates(input)).toEqual(matchTrackCandidates(input));
+  });
+});
+
+function buildCandidate(
+  overrides: Partial<ProviderCandidate> & Pick<ProviderCandidate, "candidateId">
+): ProviderCandidate {
+  return {
+    artistName: "Anyma",
+    authorizationBasis: "uploader-enabled-download",
+    availableFormats: ["mp3"],
+    candidateId: overrides.candidateId,
+    durationSeconds: 392,
+    mixConfidence: "high",
+    mixLabel: "Extended Mix",
+    priceTier: "free",
+    providerId: "soundcloud-direct-downloads",
+    providerName: "SoundCloud Direct Downloads",
+    provenance: {
+      discoveredVia: "search",
+      providerTrackId: overrides.candidateId,
+      providerUrl: `https://example.test/${overrides.candidateId}`
+    },
+    title: "Consciousness",
+    ...overrides
+  };
+}

--- a/src/features/matching/track-matcher.ts
+++ b/src/features/matching/track-matcher.ts
@@ -1,0 +1,275 @@
+import {
+  buildMissDecision,
+  canonicalizeTrack,
+  evaluateTrackCandidate,
+  type CanonicalTrack,
+  type TrackAudioFormat,
+  type TrackDecision
+} from "@/features/tracks/canonical-track";
+import type { ProviderCandidate } from "@/features/providers/provider-registry";
+
+type AcceptedTrackDecision = Extract<TrackDecision, { outcome: "accepted" }>;
+type MissTrackDecision = Extract<TrackDecision, { outcome: "miss" }>;
+
+export const TRACK_MATCH_REJECTION_REASONS = [
+  "artist-mismatch",
+  "title-mismatch",
+  "title-and-artist-mismatch",
+  "fallback-confidence-too-low",
+  "fallback-duration-missing",
+  "fallback-duration-too-short",
+  "format-not-eligible",
+  "mix-version-not-eligible",
+  "superseded-by-higher-ranked-candidate"
+] as const;
+
+export type TrackMatchRejectionReason =
+  (typeof TRACK_MATCH_REJECTION_REASONS)[number];
+
+export interface RejectedTrackCandidate {
+  candidate: ProviderCandidate;
+  details: string;
+  reason: TrackMatchRejectionReason;
+  selectedFormat: TrackAudioFormat | null;
+}
+
+export interface SelectedTrackCandidate {
+  candidate: ProviderCandidate;
+  details: string;
+  reason: AcceptedTrackDecision["reason"];
+  selectedFormat: TrackAudioFormat;
+}
+
+export type TrackMatchResult =
+  | {
+      outcome: "selected";
+      rejected: readonly RejectedTrackCandidate[];
+      selected: SelectedTrackCandidate;
+    }
+  | {
+      miss: MissTrackDecision;
+      outcome: "miss";
+      rejected: readonly RejectedTrackCandidate[];
+    };
+
+interface RankedAcceptedCandidate {
+  candidate: ProviderCandidate;
+  decision: AcceptedTrackDecision;
+  index: number;
+}
+
+export function matchTrackCandidates(input: {
+  candidates: readonly ProviderCandidate[];
+  track: CanonicalTrack;
+}): TrackMatchResult {
+  const rejected: RejectedTrackCandidate[] = [];
+  const accepted: RankedAcceptedCandidate[] = [];
+  let matchedRequestedTrack = false;
+
+  input.candidates.forEach((candidate, index) => {
+    const candidateTrack = canonicalizeProviderCandidate(candidate);
+    const titleMatches = candidateTrack.normalizedTitle === input.track.normalizedTitle;
+    const artistMatches = doesArtistMatch(input.track, candidateTrack);
+
+    if (!titleMatches || !artistMatches) {
+      rejected.push({
+        candidate,
+        details: buildIdentityMismatchDetails(titleMatches, artistMatches),
+        reason: buildIdentityMismatchReason(titleMatches, artistMatches),
+        selectedFormat: null
+      });
+
+      return;
+    }
+
+    matchedRequestedTrack = true;
+
+    const decision = evaluateTrackCandidate(candidateTrack);
+
+    if (
+      decision.outcome === "accepted" &&
+      decision.reason === "accepted-base-version-fallback" &&
+      candidate.mixConfidence !== "high"
+    ) {
+      rejected.push({
+        candidate,
+        details:
+          "Versionless fallback candidates need high mix confidence before they can be accepted.",
+        reason: "fallback-confidence-too-low",
+        selectedFormat: decision.selectedFormat
+      });
+
+      return;
+    }
+
+    if (decision.outcome !== "accepted") {
+      rejected.push({
+        candidate,
+        details: decision.details,
+        reason: decision.reason,
+        selectedFormat: decision.selectedFormat
+      });
+
+      return;
+    }
+
+    accepted.push({
+      candidate,
+      decision,
+      index
+    });
+  });
+
+  if (accepted.length === 0) {
+    return {
+      miss: buildMissDecision(
+        matchedRequestedTrack ? "no-eligible-candidate" : "no-authorized-source-match"
+      ),
+      outcome: "miss",
+      rejected
+    };
+  }
+
+  const rankedAccepted = [...accepted].sort(compareAcceptedCandidates);
+  const [winner, ...nonSelected] = rankedAccepted;
+
+  rejected.push(
+    ...nonSelected
+      .sort((left, right) => left.index - right.index)
+      .map(({ candidate, decision }) => ({
+        candidate,
+        details: `Candidate ranked behind "${winner.candidate.candidateId}" after applying the price, mix, and format preference rules.`,
+        reason: "superseded-by-higher-ranked-candidate" as const,
+        selectedFormat: decision.selectedFormat
+      }))
+  );
+
+  return {
+    outcome: "selected",
+    rejected,
+    selected: {
+      candidate: winner.candidate,
+      details: winner.decision.details,
+      reason: winner.decision.reason,
+      selectedFormat: winner.decision.selectedFormat
+    }
+  };
+}
+
+function canonicalizeProviderCandidate(candidate: ProviderCandidate) {
+  return canonicalizeTrack({
+    artistName: candidate.artistName,
+    availableFormats: [...candidate.availableFormats],
+    duration: candidate.durationSeconds,
+    source: candidate.providerId,
+    sourceTrackId: candidate.candidateId,
+    sourceUrl: candidate.provenance.providerUrl,
+    title: buildCandidateTitle(candidate)
+  });
+}
+
+function buildCandidateTitle(candidate: ProviderCandidate) {
+  const mixLabel = candidate.mixLabel?.trim();
+
+  if (!mixLabel) {
+    return candidate.title;
+  }
+
+  if (candidate.title.toLowerCase().includes(mixLabel.toLowerCase())) {
+    return candidate.title;
+  }
+
+  return `${candidate.title} (${mixLabel})`;
+}
+
+function doesArtistMatch(track: CanonicalTrack, candidateTrack: CanonicalTrack) {
+  const targetArtists = getPrimaryArtists(track);
+  const candidateArtists = getPrimaryArtists(candidateTrack);
+
+  if (targetArtists.length === 0) {
+    return candidateArtists.length === 0;
+  }
+
+  return targetArtists.some((artist) => candidateArtists.includes(artist));
+}
+
+function getPrimaryArtists(track: CanonicalTrack) {
+  return track.artistCredits
+    .filter((credit) => credit.role === "primary")
+    .map((credit) => credit.normalized);
+}
+
+function buildIdentityMismatchReason(
+  titleMatches: boolean,
+  artistMatches: boolean
+): TrackMatchRejectionReason {
+  if (!titleMatches && !artistMatches) {
+    return "title-and-artist-mismatch";
+  }
+
+  if (!titleMatches) {
+    return "title-mismatch";
+  }
+
+  return "artist-mismatch";
+}
+
+function buildIdentityMismatchDetails(titleMatches: boolean, artistMatches: boolean) {
+  if (!titleMatches && !artistMatches) {
+    return "Candidate title and artist did not match the requested canonical track.";
+  }
+
+  if (!titleMatches) {
+    return "Candidate title did not match the requested canonical track.";
+  }
+
+  return "Candidate artist did not match the requested canonical track.";
+}
+
+function compareAcceptedCandidates(
+  left: RankedAcceptedCandidate,
+  right: RankedAcceptedCandidate
+) {
+  const priceDifference =
+    PRICE_TIER_ORDER[left.candidate.priceTier] -
+    PRICE_TIER_ORDER[right.candidate.priceTier];
+
+  if (priceDifference !== 0) {
+    return priceDifference;
+  }
+
+  const mixDifference =
+    ACCEPTED_REASON_ORDER[left.decision.reason] -
+    ACCEPTED_REASON_ORDER[right.decision.reason];
+
+  if (mixDifference !== 0) {
+    return mixDifference;
+  }
+
+  const formatDifference =
+    FORMAT_ORDER[left.decision.selectedFormat] -
+    FORMAT_ORDER[right.decision.selectedFormat];
+
+  if (formatDifference !== 0) {
+    return formatDifference;
+  }
+
+  return left.index - right.index;
+}
+
+const PRICE_TIER_ORDER = {
+  free: 0,
+  "free-or-owned": 1,
+  paid: 2
+} as const;
+
+const ACCEPTED_REASON_ORDER: Record<AcceptedTrackDecision["reason"], number> = {
+  "accepted-extended-mix": 0,
+  "accepted-original-mix": 1,
+  "accepted-base-version-fallback": 2
+};
+
+const FORMAT_ORDER: Record<TrackAudioFormat, number> = {
+  mp3: 0,
+  wav: 1
+};

--- a/src/features/tracks/canonical-track.ts
+++ b/src/features/tracks/canonical-track.ts
@@ -91,6 +91,14 @@ export type TrackDecision =
       details: string;
     };
 
+export type TrackAcceptedDecision = Extract<TrackDecision, { outcome: "accepted" }>;
+export type TrackRejectedDecision = Extract<TrackDecision, { outcome: "rejected" }>;
+export type TrackMissDecision = Extract<TrackDecision, { outcome: "miss" }>;
+
+export type TrackCandidateDecision =
+  | TrackAcceptedDecision
+  | TrackRejectedDecision;
+
 const FEATURED_ARTIST_PATTERN = /\s+(?:feat\.?|ft\.?|featuring)\s+(.+)$/i;
 const TRAILING_LABEL_PATTERN = /\s*[\[(]([^[\]()]+)[\])]\s*$/;
 const CLOCK_DURATION_PATTERN = /^\d{1,2}:\d{2}(?::\d{2})?$/;
@@ -205,7 +213,7 @@ export function parseDurationSeconds(value: number | string | null): number | nu
 export function evaluateTrackCandidate(
   track: CanonicalTrack,
   policy = DEFAULT_TRACK_SELECTION_POLICY
-): TrackDecision {
+): TrackCandidateDecision {
   const selectedFormat = selectPreferredFormat(
     track.availableFormats,
     policy.preferredFormats
@@ -276,7 +284,7 @@ export function evaluateTrackCandidate(
   };
 }
 
-export function buildMissDecision(reason: TrackMissReason): TrackDecision {
+export function buildMissDecision(reason: TrackMissReason): TrackMissDecision {
   return {
     outcome: "miss",
     reason,


### PR DESCRIPTION
**@worker-01**

## Summary
- add a provider-agnostic track matcher that normalizes provider candidates through the canonical track model and returns one selected candidate or a structured miss
- add table-driven coverage for mix preference, format preference, paid fallback ordering, fallback confidence, and explicit miss/rejection reasons
- tighten canonical track decision helper types so accepted, rejected, and miss helpers expose their actual outcomes to later callers

## Verification
- npm run lint
- npm run test
- npm run build

Refs #11
