### PR TITLE
feat: add SoundCloud direct-download provider

### DIFF
--- a/src/features/providers/soundcloud-direct-downloads.test.ts
+++ b/src/features/providers/soundcloud-direct-downloads.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { BrowserSessionService } from "@/features/browser/browser-session-service";
+import { matchTrackCandidates } from "@/features/matching/track-matcher";
 import { canonicalizeTrack } from "@/features/tracks/canonical-track";
 
 import {
@@ -15,7 +16,8 @@ import {
   buildProviderMissResult,
   buildProviderRejectedResult,
   defineAutomaticProvider,
-  defineReviewQueueProvider
+  defineReviewQueueProvider,
+  type ProviderCandidate
 } from "./provider-registry";
 import {
   SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
@@ -102,7 +104,7 @@ describe("createSoundCloudDirectDownloadsProvider", () => {
   });
 
   it(
-    "returns an authorized candidate when a matching track exposes an uploader-enabled download",
+    "returns a matcher-eligible candidate when a matching track exposes an uploader-enabled MP3 download",
     async () => {
       const workspaceRoot = await mkdtemp(
         path.join(os.tmpdir(), "music-downloader-soundcloud-provider-")
@@ -113,10 +115,121 @@ describe("createSoundCloudDirectDownloadsProvider", () => {
           {
             artistName: "DJ Sealer",
             download: {
-              body: "lossless fixture payload\n",
-              contentType: "audio/flac",
-              fileName: "warehouse-tool.flac"
+              body: "mp3 fixture payload\n",
+              contentType: "audio/mpeg",
+              fileName: "warehouse-tool.mp3"
             },
+            durationSeconds: 392,
+            path: "/dj-sealer/warehouse-tool-extended-mix",
+            title: "Warehouse Tool (Extended Mix)",
+            trackId: "111"
+          }
+        ]
+      });
+      const browserSessionService = new BrowserSessionService({ workspaceRoot });
+      const provider = createSoundCloudDirectDownloadsProvider({
+        baseUrl: fixtureServer.origin,
+        browserSessionService
+      });
+
+      try {
+        await seedAuthenticatedSession(browserSessionService);
+        const track = canonicalizeTrack({
+          artistName: "DJ Sealer",
+          source: "spotify",
+          title: "Warehouse Tool (Extended Mix)"
+        });
+
+        const result = await provider.search({ track });
+
+        expect(result).toEqual({
+          outcome: "candidates",
+          candidates: [
+            {
+              artistName: "DJ Sealer",
+              authorizationBasis: "uploader-enabled-download",
+              availableFormats: ["mp3"],
+              candidateId: "111",
+              durationSeconds: 392,
+              mixConfidence: "high",
+              mixLabel: "Extended Mix",
+              priceTier: "free",
+              providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+              providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+              provenance: {
+                discoveredVia: "search",
+                providerTrackId: "111",
+                providerUrl:
+                  `${fixtureServer.origin}/dj-sealer/warehouse-tool-extended-mix`,
+                searchQuery: "DJ Sealer Warehouse Tool Extended Mix",
+                sourcePageUrl:
+                  `${fixtureServer.origin}/dj-sealer/warehouse-tool-extended-mix`
+              },
+              title: "Warehouse Tool"
+            }
+          ]
+        });
+
+        if (result.outcome !== "candidates") {
+          throw new Error("Expected SoundCloud search to produce a candidate.");
+        }
+
+        expect(
+          matchTrackCandidates({
+            candidates: result.candidates,
+            track
+          })
+        ).toMatchObject({
+          outcome: "selected",
+          rejected: [],
+          selected: {
+            candidate: {
+              candidateId: "111"
+            },
+            reason: "accepted-extended-mix",
+            selectedFormat: "mp3"
+          }
+        });
+      } finally {
+        await browserSessionService.shutdown();
+        await fixtureServer.close();
+        await rm(workspaceRoot, { force: true, recursive: true });
+      }
+    },
+    15_000
+  );
+
+  it.each([
+    {
+      detailPattern: /mp3 or wav/i,
+      download: {
+        body: "lossless fixture payload\n",
+        contentType: "audio/flac",
+        fileName: "warehouse-tool.flac"
+      },
+      name: "a FLAC direct download"
+    },
+    {
+      detailPattern: /mp3 or wav/i,
+      download: {
+        body: "opaque fixture payload\n",
+        contentType: "application/octet-stream",
+        fileName: "warehouse-tool"
+      },
+      name: "an indeterminate direct-download format"
+    }
+  ])(
+    "returns a structured miss when the matching track exposes $name",
+    async ({ detailPattern, download }) => {
+      const workspaceRoot = await mkdtemp(
+        path.join(os.tmpdir(), "music-downloader-soundcloud-provider-format-")
+      );
+      const fixtureServer = await startSoundCloudFixtureServer({
+        searchResults: ["/dj-sealer/warehouse-tool-extended-mix"],
+        tracks: [
+          {
+            artistName: "DJ Sealer",
+            download,
             durationSeconds: 392,
             path: "/dj-sealer/warehouse-tool-extended-mix",
             title: "Warehouse Tool (Extended Mix)",
@@ -142,32 +255,18 @@ describe("createSoundCloudDirectDownloadsProvider", () => {
         });
 
         expect(result).toEqual({
-          outcome: "candidates",
-          candidates: [
-            {
-              artistName: "DJ Sealer",
-              authorizationBasis: "uploader-enabled-download",
-              availableFormats: ["original-upload-format"],
-              candidateId: "111",
-              durationSeconds: 392,
-              mixConfidence: "high",
-              mixLabel: "Extended Mix",
-              priceTier: "free",
-              providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
-              providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
-              provenance: {
-                discoveredVia: "search",
-                providerTrackId: "111",
-                providerUrl:
-                  `${fixtureServer.origin}/dj-sealer/warehouse-tool-extended-mix`,
-                searchQuery: "DJ Sealer Warehouse Tool Extended Mix",
-                sourcePageUrl:
-                  `${fixtureServer.origin}/dj-sealer/warehouse-tool-extended-mix`
-              },
-              title: "Warehouse Tool"
-            }
-          ]
+          outcome: "miss",
+          miss: expect.objectContaining({
+            providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+            providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+            reason: "no-authorized-candidate",
+            trackMissReason: "no-authorized-source-match"
+          })
         });
+        if (result.outcome !== "miss") {
+          throw new Error("Expected SoundCloud search to return a provider miss.");
+        }
+        expect(result.miss.detail).toMatch(detailPattern);
       } finally {
         await browserSessionService.shutdown();
         await fixtureServer.close();
@@ -363,20 +462,26 @@ describe("createSoundCloudDirectDownloadsProvider", () => {
       try {
         await seedAuthenticatedSession(browserSessionService);
 
-        const searchResult = await provider.search({
-          track: canonicalizeTrack({
-            artistName: "DJ Sealer",
-            source: "spotify",
-            title: "Warehouse Tool (Extended Mix)"
-          })
-        });
-
-        expect(searchResult.outcome).toBe("candidates");
-        if (searchResult.outcome !== "candidates") {
-          throw new Error("Expected SoundCloud search to produce a candidate.");
-        }
-
-        const candidate = searchResult.candidates[0];
+        const candidate: ProviderCandidate = {
+          artistName: "DJ Sealer",
+          authorizationBasis: "uploader-enabled-download",
+          availableFormats: ["original-upload-format"],
+          candidateId: "111",
+          durationSeconds: 392,
+          mixConfidence: "high",
+          mixLabel: "Extended Mix",
+          priceTier: "free",
+          providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+          providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+          provenance: {
+            discoveredVia: "search",
+            providerTrackId: "111",
+            providerUrl: `${fixtureServer.origin}/dj-sealer/warehouse-tool-extended-mix`,
+            searchQuery: "DJ Sealer Warehouse Tool Extended Mix",
+            sourcePageUrl: `${fixtureServer.origin}/dj-sealer/warehouse-tool-extended-mix`
+          },
+          title: "Warehouse Tool"
+        };
         const acquisition = await provider.acquire({
           candidate,
           track: canonicalizeTrack({
@@ -514,7 +619,7 @@ function handleFixtureRequest(
     const trackUrl = `http://${host}${trackFixture.path}`;
     const downloadMarkup =
       "fileName" in trackFixture.download
-        ? `<a href="/downloads/${trackFixture.trackId}/${trackFixture.download.fileName}" download>Download file</a>`
+        ? `<a data-testid="authorized-download-link" href="/downloads/${trackFixture.trackId}/${trackFixture.download.fileName}" download="${escapeHtml(trackFixture.download.fileName)}" type="${escapeHtml(trackFixture.download.contentType)}">Download file</a>`
         : trackFixture.download.kind === "external"
           ? `<a href="${trackFixture.download.externalUrl}" data-testid="external-download-link">External download</a>`
           : `<p>Downloads are not enabled on this track.</p>`;

--- a/src/features/providers/soundcloud-direct-downloads.test.ts
+++ b/src/features/providers/soundcloud-direct-downloads.test.ts
@@ -1,0 +1,607 @@
+/* @vitest-environment node */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { BrowserSessionService } from "@/features/browser/browser-session-service";
+import { canonicalizeTrack } from "@/features/tracks/canonical-track";
+
+import {
+  ProviderRegistry,
+  buildProviderMissResult,
+  buildProviderRejectedResult,
+  defineAutomaticProvider,
+  defineReviewQueueProvider
+} from "./provider-registry";
+import {
+  SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+  SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+  SOUNDCLOUD_DIRECT_DOWNLOADS_SESSION_NAME,
+  createSoundCloudDirectDownloadsProvider
+} from "./soundcloud-direct-downloads";
+
+describe("createSoundCloudDirectDownloadsProvider", () => {
+  it("registers with the research-mandated metadata and deterministic provider order", () => {
+    const registry = new ProviderRegistry([
+      defineReviewQueueProvider({
+        id: "beatport",
+        displayName: "Beatport",
+        authorizationBasis: "purchase-entitlement",
+        priorityRank: 90,
+        supportedFormats: ["mp3", "wav", "aiff"],
+        search: async () =>
+          buildProviderMissResult({
+            detail: "No Beatport candidate queued yet.",
+            providerId: "beatport",
+            providerName: "Beatport",
+            reason: "no-search-results",
+            trackMissReason: "no-authorized-source-match"
+          }),
+        queueForReview: async ({ candidate }) => ({
+          outcome: "queued-for-review",
+          candidate,
+          review: {
+            queueName: "beatport-review",
+            summary: "Queued for later operator approval."
+          }
+        })
+      }),
+      defineAutomaticProvider({
+        id: "bandcamp",
+        displayName: "Bandcamp",
+        authorizationBasis: "rights-holder-storefront",
+        priceTier: "free-or-owned",
+        priorityRank: 20,
+        supportedFormats: ["mp3", "wav", "flac"],
+        search: async () =>
+          buildProviderMissResult({
+            detail: "No Bandcamp result for the requested track.",
+            providerId: "bandcamp",
+            providerName: "Bandcamp",
+            reason: "no-search-results",
+            trackMissReason: "no-authorized-source-match"
+          }),
+        acquire: async ({ candidate }) =>
+          buildProviderRejectedResult({
+            candidate,
+            detail: "Fixture provider does not acquire assets in this test.",
+            providerId: "bandcamp",
+            providerName: "Bandcamp",
+            reason: "provider-error"
+          })
+      }),
+      createSoundCloudDirectDownloadsProvider({
+        browserSessionService: createUnusedBrowserSessionService()
+      })
+    ]);
+
+    expect(registry.list().map((provider) => provider.id)).toEqual([
+      SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+      "bandcamp",
+      "beatport"
+    ]);
+
+    const provider = registry.get(SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID);
+
+    expect(provider).toEqual(
+      expect.objectContaining({
+        authorizationBasis: "uploader-enabled-download",
+        displayName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+        id: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+        implementationBucket: "free-auto",
+        mode: "automatic",
+        priceTier: "free",
+        priorityRank: 10,
+        supportedFormats: ["original-upload-format"]
+      })
+    );
+  });
+
+  it(
+    "returns an authorized candidate when a matching track exposes an uploader-enabled download",
+    async () => {
+      const workspaceRoot = await mkdtemp(
+        path.join(os.tmpdir(), "music-downloader-soundcloud-provider-")
+      );
+      const fixtureServer = await startSoundCloudFixtureServer({
+        searchResults: ["/dj-sealer/warehouse-tool-extended-mix"],
+        tracks: [
+          {
+            artistName: "DJ Sealer",
+            download: {
+              body: "lossless fixture payload\n",
+              contentType: "audio/flac",
+              fileName: "warehouse-tool.flac"
+            },
+            durationSeconds: 392,
+            path: "/dj-sealer/warehouse-tool-extended-mix",
+            title: "Warehouse Tool (Extended Mix)",
+            trackId: "111"
+          }
+        ]
+      });
+      const browserSessionService = new BrowserSessionService({ workspaceRoot });
+      const provider = createSoundCloudDirectDownloadsProvider({
+        baseUrl: fixtureServer.origin,
+        browserSessionService
+      });
+
+      try {
+        await seedAuthenticatedSession(browserSessionService);
+
+        const result = await provider.search({
+          track: canonicalizeTrack({
+            artistName: "DJ Sealer",
+            source: "spotify",
+            title: "Warehouse Tool (Extended Mix)"
+          })
+        });
+
+        expect(result).toEqual({
+          outcome: "candidates",
+          candidates: [
+            {
+              artistName: "DJ Sealer",
+              authorizationBasis: "uploader-enabled-download",
+              availableFormats: ["original-upload-format"],
+              candidateId: "111",
+              durationSeconds: 392,
+              mixConfidence: "high",
+              mixLabel: "Extended Mix",
+              priceTier: "free",
+              providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+              providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+              provenance: {
+                discoveredVia: "search",
+                providerTrackId: "111",
+                providerUrl:
+                  `${fixtureServer.origin}/dj-sealer/warehouse-tool-extended-mix`,
+                searchQuery: "DJ Sealer Warehouse Tool Extended Mix",
+                sourcePageUrl:
+                  `${fixtureServer.origin}/dj-sealer/warehouse-tool-extended-mix`
+              },
+              title: "Warehouse Tool"
+            }
+          ]
+        });
+      } finally {
+        await browserSessionService.shutdown();
+        await fixtureServer.close();
+        await rm(workspaceRoot, { force: true, recursive: true });
+      }
+    },
+    15_000
+  );
+
+  it.each([
+    {
+      detailPattern: /external download/i,
+      download: {
+        externalUrl: "https://label.example.com/free-download",
+        kind: "external" as const
+      },
+      name: "an external download link"
+    },
+    {
+      detailPattern: /download.*enabled/i,
+      download: {
+        kind: "disabled" as const
+      },
+      name: "no download button"
+    }
+  ])(
+    "returns a structured miss when the matching track exposes $name instead of an uploader-enabled download",
+    async ({ detailPattern, download }) => {
+      const workspaceRoot = await mkdtemp(
+        path.join(os.tmpdir(), "music-downloader-soundcloud-provider-miss-")
+      );
+      const fixtureServer = await startSoundCloudFixtureServer({
+        searchResults: ["/dj-sealer/warehouse-tool-extended-mix"],
+        tracks: [
+          {
+            artistName: "DJ Sealer",
+            download,
+            durationSeconds: 392,
+            path: "/dj-sealer/warehouse-tool-extended-mix",
+            title: "Warehouse Tool (Extended Mix)",
+            trackId: "111"
+          }
+        ]
+      });
+      const browserSessionService = new BrowserSessionService({ workspaceRoot });
+      const provider = createSoundCloudDirectDownloadsProvider({
+        baseUrl: fixtureServer.origin,
+        browserSessionService
+      });
+
+      try {
+        await seedAuthenticatedSession(browserSessionService);
+
+        const result = await provider.search({
+          track: canonicalizeTrack({
+            artistName: "DJ Sealer",
+            source: "spotify",
+            title: "Warehouse Tool (Extended Mix)"
+          })
+        });
+
+        expect(result).toEqual({
+          outcome: "miss",
+          miss: expect.objectContaining({
+            providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+            providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+            reason: "no-authorized-candidate",
+            trackMissReason: "no-authorized-source-match"
+          })
+        });
+        if (result.outcome !== "miss") {
+          throw new Error("Expected SoundCloud search to return a provider miss.");
+        }
+        expect(result.miss.detail).toMatch(detailPattern);
+      } finally {
+        await browserSessionService.shutdown();
+        await fixtureServer.close();
+        await rm(workspaceRoot, { force: true, recursive: true });
+      }
+    },
+    15_000
+  );
+
+  it("maps missing and expired browser sessions to structured rejections", async () => {
+    const missingWorkspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-soundcloud-provider-auth-")
+    );
+    const expiredWorkspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-soundcloud-provider-expired-")
+    );
+    const fixtureServer = await startSoundCloudFixtureServer({
+      searchResults: [],
+      tracks: []
+    });
+    const missingBrowserSessionService = new BrowserSessionService({
+      workspaceRoot: missingWorkspaceRoot
+    });
+    const expiredBrowserSessionService = new BrowserSessionService({
+      workspaceRoot: expiredWorkspaceRoot
+    });
+
+    try {
+      const expiredSession = await expiredBrowserSessionService.openSession({
+        sessionName: SOUNDCLOUD_DIRECT_DOWNLOADS_SESSION_NAME,
+        authState: {
+          expiredAt: "2026-03-31T05:00:00.000Z",
+          providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+          reason: "fixture session expired",
+          status: "expired"
+        }
+      });
+      await expiredSession.close();
+
+      const track = canonicalizeTrack({
+        artistName: "DJ Sealer",
+        source: "spotify",
+        title: "Warehouse Tool (Extended Mix)"
+      });
+
+      await expect(
+        createSoundCloudDirectDownloadsProvider({
+          baseUrl: fixtureServer.origin,
+          browserSessionService: missingBrowserSessionService
+        }).search({ track })
+      ).resolves.toEqual({
+        outcome: "rejected",
+        rejection: {
+          detail:
+            "An authenticated SoundCloud browser session is required before automatic downloads can run.",
+          providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+          providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+          reason: "auth-required",
+          retryable: true,
+          trackDecisionReason: undefined
+        }
+      });
+
+      await expect(
+        createSoundCloudDirectDownloadsProvider({
+          baseUrl: fixtureServer.origin,
+          browserSessionService: expiredBrowserSessionService
+        }).search({ track })
+      ).resolves.toEqual({
+        outcome: "rejected",
+        rejection: {
+          detail:
+            "The SoundCloud browser session expired and must be refreshed before automatic downloads can run.",
+          providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+          providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+          reason: "provider-session-expired",
+          retryable: true,
+          trackDecisionReason: undefined
+        }
+      });
+    } finally {
+      await missingBrowserSessionService.shutdown();
+      await expiredBrowserSessionService.shutdown();
+      await fixtureServer.close();
+      await rm(missingWorkspaceRoot, { force: true, recursive: true });
+      await rm(expiredWorkspaceRoot, { force: true, recursive: true });
+    }
+  });
+
+  it(
+    "acquires the original uploaded file and normalizes artifact metadata",
+    async () => {
+      const workspaceRoot = await mkdtemp(
+        path.join(os.tmpdir(), "music-downloader-soundcloud-provider-acquire-")
+      );
+      const fixtureServer = await startSoundCloudFixtureServer({
+        searchResults: ["/dj-sealer/warehouse-tool-extended-mix"],
+        tracks: [
+          {
+            artistName: "DJ Sealer",
+            download: {
+              body: "lossless fixture payload\n",
+              contentType: "audio/flac",
+              fileName: "warehouse-tool.flac"
+            },
+            durationSeconds: 392,
+            path: "/dj-sealer/warehouse-tool-extended-mix",
+            title: "Warehouse Tool (Extended Mix)",
+            trackId: "111"
+          }
+        ]
+      });
+      const browserSessionService = new BrowserSessionService({ workspaceRoot });
+      const provider = createSoundCloudDirectDownloadsProvider({
+        baseUrl: fixtureServer.origin,
+        browserSessionService
+      });
+
+      try {
+        await seedAuthenticatedSession(browserSessionService);
+
+        const searchResult = await provider.search({
+          track: canonicalizeTrack({
+            artistName: "DJ Sealer",
+            source: "spotify",
+            title: "Warehouse Tool (Extended Mix)"
+          })
+        });
+
+        expect(searchResult.outcome).toBe("candidates");
+        if (searchResult.outcome !== "candidates") {
+          throw new Error("Expected SoundCloud search to produce a candidate.");
+        }
+
+        const candidate = searchResult.candidates[0];
+        const acquisition = await provider.acquire({
+          candidate,
+          track: canonicalizeTrack({
+            artistName: "DJ Sealer",
+            source: "spotify",
+            title: "Warehouse Tool (Extended Mix)"
+          })
+        });
+
+        expect(acquisition).toEqual({
+          outcome: "acquired",
+          candidate,
+          artifact: {
+            contentType: "audio/flac",
+            fileExtension: "flac",
+            fileName: "warehouse-tool.flac",
+            format: "flac",
+            sha256:
+              "93d31421dcf5b0f8fc767062a4ed9241b3fe0b3774ea70589e95128a7b56b703",
+            sizeBytes: 25
+          }
+        });
+      } finally {
+        await browserSessionService.shutdown();
+        await fixtureServer.close();
+        await rm(workspaceRoot, { force: true, recursive: true });
+      }
+    },
+    15_000
+  );
+});
+
+type AuthorizedDownloadFixture = {
+  body: string;
+  contentType: string;
+  fileName: string;
+};
+
+type TrackFixture = {
+  artistName: string;
+  download: AuthorizedDownloadFixture | { kind: "disabled" } | { kind: "external"; externalUrl: string };
+  durationSeconds: number;
+  path: string;
+  title: string;
+  trackId: string;
+};
+
+async function seedAuthenticatedSession(browserSessionService: BrowserSessionService) {
+  const session = await browserSessionService.openSession({
+    sessionName: SOUNDCLOUD_DIRECT_DOWNLOADS_SESSION_NAME,
+    authState: {
+      authenticatedAt: "2026-03-31T05:00:00.000Z",
+      providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+      status: "authenticated"
+    }
+  });
+
+  await session.close();
+}
+
+function createUnusedBrowserSessionService() {
+  return {
+    async openSession() {
+      throw new Error("Browser sessions should not be opened in registration tests.");
+    },
+    async requireAuthenticatedSession() {
+      throw new Error(
+        "Authenticated browser sessions should not be required in registration tests."
+      );
+    }
+  };
+}
+
+async function startSoundCloudFixtureServer(input: {
+  searchResults: string[];
+  tracks: TrackFixture[];
+}) {
+  const trackFixtures = new Map(input.tracks.map((track) => [track.path, track]));
+  const server = createServer((request, response) =>
+    handleFixtureRequest(request, response, input.searchResults, trackFixtures)
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+
+  if (address === null || typeof address === "string") {
+    throw new Error("Fixture server did not expose a TCP address.");
+  }
+
+  const origin = `http://127.0.0.1:${address.port}`;
+
+  return {
+    close: () => closeFixtureServer(server),
+    origin
+  };
+}
+
+function handleFixtureRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  searchResults: string[],
+  trackFixtures: Map<string, TrackFixture>
+) {
+  const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+  const trackFixture = trackFixtures.get(requestUrl.pathname);
+
+  if (requestUrl.pathname === "/search/sounds") {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(`<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      ${searchResults
+        .map(
+          (resultPath) =>
+            `<article><a data-testid="soundcloud-track-link" href="${resultPath}">${resultPath}</a></article>`
+        )
+        .join("\n")}
+    </main>
+  </body>
+</html>`);
+
+    return;
+  }
+
+  if (trackFixture) {
+    const host = request.headers.host ?? "127.0.0.1";
+    const trackUrl = `http://${host}${trackFixture.path}`;
+    const downloadMarkup =
+      "fileName" in trackFixture.download
+        ? `<a href="/downloads/${trackFixture.trackId}/${trackFixture.download.fileName}" download>Download file</a>`
+        : trackFixture.download.kind === "external"
+          ? `<a href="${trackFixture.download.externalUrl}" data-testid="external-download-link">External download</a>`
+          : `<p>Downloads are not enabled on this track.</p>`;
+
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta property="og:title" content="${escapeHtml(trackFixture.title)}" />
+    <meta property="og:url" content="${escapeHtml(trackUrl)}" />
+    <meta name="soundcloud:track_id" content="${escapeHtml(trackFixture.trackId)}" />
+    <meta name="soundcloud:artist_name" content="${escapeHtml(trackFixture.artistName)}" />
+    <meta name="soundcloud:duration_seconds" content="${trackFixture.durationSeconds}" />
+    <script type="application/ld+json">${JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "MusicRecording",
+      byArtist: {
+        "@type": "MusicGroup",
+        name: trackFixture.artistName
+      },
+      duration: toIsoDuration(trackFixture.durationSeconds),
+      identifier: trackFixture.trackId,
+      name: trackFixture.title,
+      url: trackUrl
+    })}</script>
+  </head>
+  <body>
+    <main>
+      <h1>${escapeHtml(trackFixture.title)}</h1>
+      ${downloadMarkup}
+    </main>
+  </body>
+</html>`);
+
+    return;
+  }
+
+  const downloadMatch = requestUrl.pathname.match(/^\/downloads\/([^/]+)\/(.+)$/);
+
+  if (downloadMatch) {
+    const [, trackId, fileName] = downloadMatch;
+    const matchingFixture = [...trackFixtures.values()].find(
+      (fixture) =>
+        fixture.trackId === trackId &&
+        "fileName" in fixture.download &&
+        fixture.download.fileName === fileName
+    );
+
+    if (matchingFixture && "fileName" in matchingFixture.download) {
+      response.writeHead(200, {
+        "content-disposition": `attachment; filename="${matchingFixture.download.fileName}"`,
+        "content-type": matchingFixture.download.contentType
+      });
+      response.end(matchingFixture.download.body);
+
+      return;
+    }
+  }
+
+  response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+  response.end("Not found");
+}
+
+async function closeFixtureServer(server: Server) {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function toIsoDuration(durationSeconds: number) {
+  const minutes = Math.floor(durationSeconds / 60);
+  const seconds = durationSeconds % 60;
+
+  return `PT${minutes}M${seconds}S`;
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}

--- a/src/features/providers/soundcloud-direct-downloads.ts
+++ b/src/features/providers/soundcloud-direct-downloads.ts
@@ -63,6 +63,7 @@ interface ParsedTrackSnapshot {
   download:
     | {
         contentType: string | null;
+        fileName: string | null;
         kind: "authorized";
       }
     | {
@@ -147,6 +148,7 @@ async function searchSoundCloudDirectDownloads(input: {
       }
 
       const candidates: ProviderCandidate[] = [];
+      let formatUnavailableDetail: string | null = null;
       let unauthorizedDetail: string | null = null;
 
       for (const trackUrl of trackUrls) {
@@ -158,7 +160,14 @@ async function searchSoundCloudDirectDownloads(input: {
         }
 
         if (snapshot.download.kind === "authorized") {
-          candidates.push(buildCandidate(snapshot, searchQuery));
+          const availableFormats = resolveCandidateAvailableFormats(snapshot.download);
+
+          if (availableFormats.length > 0) {
+            candidates.push(buildCandidate(snapshot, searchQuery, availableFormats));
+            continue;
+          }
+
+          formatUnavailableDetail = buildUnavailableFormatDetail();
           continue;
         }
 
@@ -170,6 +179,16 @@ async function searchSoundCloudDirectDownloads(input: {
           outcome: "candidates" as const,
           candidates
         };
+      }
+
+      if (formatUnavailableDetail) {
+        return buildProviderMissResult({
+          detail: formatUnavailableDetail,
+          providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+          providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+          reason: "no-authorized-candidate",
+          trackMissReason: "no-authorized-source-match"
+        });
       }
 
       if (unauthorizedDetail) {
@@ -389,6 +408,7 @@ async function parseTrackSnapshot(page: Page): Promise<ParsedTrackSnapshot> {
           artistName,
           download: {
             contentType: authorizedDownload.getAttribute("type"),
+            fileName: readAuthorizedDownloadFileName(authorizedDownload),
             kind: "authorized" as const
           },
           durationSeconds,
@@ -486,6 +506,22 @@ async function parseTrackSnapshot(page: Page): Promise<ParsedTrackSnapshot> {
         }
 
         return null;
+      }
+
+      function readAuthorizedDownloadFileName(anchor: HTMLAnchorElement) {
+        const explicitFileName = anchor.getAttribute("download")?.trim();
+
+        if (explicitFileName) {
+          return explicitFileName;
+        }
+
+        try {
+          const href = new URL(anchor.href, window.location.href);
+          const fileName = href.pathname.split("/").pop()?.trim();
+          return fileName || null;
+        } catch {
+          return null;
+        }
       }
 
       function readMetaValue(name: string) {
@@ -626,7 +662,11 @@ function isTrackMatch(track: CanonicalTrack, snapshot: ParsedTrackSnapshot) {
   return true;
 }
 
-function buildCandidate(snapshot: ParsedTrackSnapshot, searchQuery: string): ProviderCandidate {
+function buildCandidate(
+  snapshot: ParsedTrackSnapshot,
+  searchQuery: string,
+  availableFormats: readonly ProviderArtifactFormat[]
+): ProviderCandidate {
   const candidateTrack = canonicalizeTrack({
     artistName: snapshot.artistName ?? "",
     duration: snapshot.durationSeconds,
@@ -639,7 +679,7 @@ function buildCandidate(snapshot: ParsedTrackSnapshot, searchQuery: string): Pro
   return {
     artistName: candidateTrack.primaryArtist ?? snapshot.artistName ?? "Unknown Artist",
     authorizationBasis: "uploader-enabled-download",
-    availableFormats: ["original-upload-format"],
+    availableFormats,
     candidateId: snapshot.providerTrackId ?? snapshot.providerUrl,
     durationSeconds: snapshot.durationSeconds,
     mixConfidence: candidateTrack.mix.confidence,
@@ -656,6 +696,28 @@ function buildCandidate(snapshot: ParsedTrackSnapshot, searchQuery: string): Pro
     },
     title: candidateTrack.title
   };
+}
+
+function resolveCandidateAvailableFormats(
+  download: Extract<ParsedTrackSnapshot["download"], { kind: "authorized" }>
+) {
+  const inferredFormat = inferArtifactFormat(
+    normalizeFileExtension(download.fileName ?? ""),
+    download.contentType
+  );
+
+  if (inferredFormat === "mp3" || inferredFormat === "wav") {
+    return [inferredFormat];
+  }
+
+  return [];
+}
+
+function buildUnavailableFormatDetail() {
+  return (
+    "Matched SoundCloud track exposed an uploader-enabled download, but the file format " +
+    "could not be confirmed as an approved MP3 or WAV asset."
+  );
 }
 
 function buildUnauthorizedDownloadDetail(
@@ -718,6 +780,37 @@ function inferArtifactFormat(
       return "ogg-vorbis";
     case "m4a":
       return normalizedContentTypeIs(contentType, "audio/alac") ? "alac" : "original-upload-format";
+    default:
+      return inferArtifactFormatFromContentType(contentType);
+  }
+}
+
+function inferArtifactFormatFromContentType(
+  contentType: string | null
+): ProviderArtifactFormat {
+  switch (normalizeContentType(contentType)) {
+    case "audio/mpeg":
+    case "audio/mp3":
+      return "mp3";
+    case "audio/wav":
+    case "audio/wave":
+    case "audio/x-wav":
+      return "wav";
+    case "audio/aiff":
+    case "audio/x-aiff":
+      return "aiff";
+    case "audio/flac":
+    case "audio/x-flac":
+      return "flac";
+    case "audio/aac":
+    case "audio/x-aac":
+      return "aac";
+    case "audio/ogg":
+    case "audio/vorbis":
+    case "application/ogg":
+      return "ogg-vorbis";
+    case "audio/alac":
+      return "alac";
     default:
       return "original-upload-format";
   }

--- a/src/features/providers/soundcloud-direct-downloads.ts
+++ b/src/features/providers/soundcloud-direct-downloads.ts
@@ -1,0 +1,771 @@
+import { createHash } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+import type { Page } from "playwright";
+
+import {
+  BrowserSessionService,
+  ExpiredBrowserSessionAuthStateError,
+  MissingBrowserSessionAuthStateError,
+  MissingBrowserSessionStateError
+} from "@/features/browser/browser-session-service";
+import { canonicalizeTrack, type CanonicalTrack } from "@/features/tracks/canonical-track";
+
+import {
+  buildProviderMissResult,
+  buildProviderRejectedResult,
+  defineAutomaticProvider,
+  type ProviderAcquireInput,
+  type ProviderArtifactFormat,
+  type ProviderCandidate,
+  type ProviderSearchInput
+} from "./provider-registry";
+
+export const SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID = "soundcloud-direct-downloads";
+export const SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME =
+  "SoundCloud Direct Downloads";
+export const SOUNDCLOUD_DIRECT_DOWNLOADS_SESSION_NAME =
+  SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID;
+
+const DEFAULT_SOUNDCLOUD_BASE_URL = "https://soundcloud.com";
+const AUTHORIZED_DOWNLOAD_SELECTOR = [
+  '[data-testid="authorized-download-link"]',
+  'a[download]',
+  'a[aria-label*="download" i][href]',
+  'a[title*="download" i][href]'
+].join(", ");
+const EXTERNAL_DOWNLOAD_SELECTOR = [
+  '[data-testid="external-download-link"]',
+  'a[aria-label*="download" i][href]:not([download])',
+  'a[title*="download" i][href]:not([download])',
+  'a[aria-label*="buy" i][href]:not([download])',
+  'a[title*="buy" i][href]:not([download])'
+].join(", ");
+const SEARCH_RESULT_LINK_SELECTOR = [
+  '[data-testid="soundcloud-track-link"]',
+  "a.soundTitle__title",
+  "a[itemprop='url']"
+].join(", ");
+
+interface SoundCloudDirectDownloadsProviderDependencies {
+  baseUrl?: string;
+  browserSessionService: Pick<
+    BrowserSessionService,
+    "openSession" | "requireAuthenticatedSession"
+  >;
+  maxSearchResults?: number;
+  sessionName?: string;
+}
+
+interface ParsedTrackSnapshot {
+  artistName: string | null;
+  download:
+    | {
+        contentType: string | null;
+        kind: "authorized";
+      }
+    | {
+        externalUrl: string | null;
+        kind: "external";
+      }
+    | {
+        kind: "disabled";
+      };
+  durationSeconds: number | null;
+  providerTrackId: string | null;
+  providerUrl: string;
+  title: string | null;
+}
+
+export function createSoundCloudDirectDownloadsProvider(
+  dependencies: SoundCloudDirectDownloadsProviderDependencies
+) {
+  const baseUrl = dependencies.baseUrl ?? DEFAULT_SOUNDCLOUD_BASE_URL;
+  const maxSearchResults = dependencies.maxSearchResults ?? 5;
+  const sessionName =
+    dependencies.sessionName ?? SOUNDCLOUD_DIRECT_DOWNLOADS_SESSION_NAME;
+
+  return defineAutomaticProvider({
+    id: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+    displayName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+    authorizationBasis: "uploader-enabled-download",
+    priceTier: "free",
+    priorityRank: 10,
+    supportedFormats: ["original-upload-format"],
+    search: async (input) =>
+      searchSoundCloudDirectDownloads({
+        baseUrl,
+        browserSessionService: dependencies.browserSessionService,
+        input,
+        maxSearchResults,
+        sessionName
+      }),
+    acquire: async (input) =>
+      acquireSoundCloudDirectDownload({
+        baseUrl,
+        browserSessionService: dependencies.browserSessionService,
+        input,
+        sessionName
+      })
+  });
+}
+
+async function searchSoundCloudDirectDownloads(input: {
+  baseUrl: string;
+  browserSessionService: SoundCloudDirectDownloadsProviderDependencies["browserSessionService"];
+  input: ProviderSearchInput;
+  maxSearchResults: number;
+  sessionName: string;
+}) {
+  const sessionResult = await openAuthenticatedSession(
+    input.browserSessionService,
+    input.sessionName
+  );
+
+  if ("outcome" in sessionResult) {
+    return sessionResult;
+  }
+
+  const searchQuery = buildSearchQuery(input.input.track);
+
+  try {
+    return await sessionResult.withPage(async (page) => {
+      await page.goto(buildSearchUrl(input.baseUrl, searchQuery), { waitUntil: "load" });
+
+      const trackUrls = (await readSearchResultUrls(page)).slice(0, input.maxSearchResults);
+
+      if (trackUrls.length === 0) {
+        return buildProviderMissResult({
+          detail:
+            "No SoundCloud tracks matched the requested artist/title search query.",
+          providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+          providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+          reason: "no-search-results",
+          trackMissReason: "no-authorized-source-match"
+        });
+      }
+
+      const candidates: ProviderCandidate[] = [];
+      let unauthorizedDetail: string | null = null;
+
+      for (const trackUrl of trackUrls) {
+        await page.goto(trackUrl, { waitUntil: "load" });
+        const snapshot = await parseTrackSnapshot(page);
+
+        if (!isTrackMatch(input.input.track, snapshot)) {
+          continue;
+        }
+
+        if (snapshot.download.kind === "authorized") {
+          candidates.push(buildCandidate(snapshot, searchQuery));
+          continue;
+        }
+
+        unauthorizedDetail = buildUnauthorizedDownloadDetail(snapshot.download);
+      }
+
+      if (candidates.length > 0) {
+        return {
+          outcome: "candidates" as const,
+          candidates
+        };
+      }
+
+      if (unauthorizedDetail) {
+        return buildProviderMissResult({
+          detail: unauthorizedDetail,
+          providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+          providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+          reason: "no-authorized-candidate",
+          trackMissReason: "no-authorized-source-match"
+        });
+      }
+
+      return buildProviderMissResult({
+        detail:
+          "SoundCloud search results did not contain an exact artist/title match for the requested track.",
+        providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+        providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+        reason: "no-search-results",
+        trackMissReason: "no-authorized-source-match"
+      });
+    });
+  } catch (error) {
+    return buildProviderRejectedResult({
+      detail: buildProviderErrorDetail(
+        "SoundCloud search failed while checking uploader-enabled downloads.",
+        error
+      ),
+      providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+      providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+      reason: "provider-error"
+    });
+  } finally {
+    await sessionResult.close();
+  }
+}
+
+async function acquireSoundCloudDirectDownload(input: {
+  baseUrl: string;
+  browserSessionService: SoundCloudDirectDownloadsProviderDependencies["browserSessionService"];
+  input: ProviderAcquireInput;
+  sessionName: string;
+}) {
+  const sessionResult = await openAuthenticatedSession(
+    input.browserSessionService,
+    input.sessionName
+  );
+
+  if ("outcome" in sessionResult) {
+    return sessionResult;
+  }
+
+  const trackUrl =
+    input.input.candidate.provenance.providerUrl ??
+    input.input.candidate.provenance.sourcePageUrl;
+
+  if (!trackUrl) {
+    return buildProviderRejectedResult({
+      candidate: input.input.candidate,
+      detail: "SoundCloud candidate was missing the track page URL required for download.",
+      providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+      providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+      reason: "download-artifact-missing"
+    });
+  }
+
+  try {
+    await sessionResult.withPage(async (page) => {
+      await page.goto(trackUrl, { waitUntil: "load" });
+    });
+
+    const snapshot = await sessionResult.withPage(parseTrackSnapshot);
+
+    if (snapshot.download.kind !== "authorized") {
+      return buildProviderRejectedResult({
+        candidate: input.input.candidate,
+        detail: buildUnauthorizedDownloadDetail(snapshot.download),
+        providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+        providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+        reason: "no-download-entitlement"
+      });
+    }
+
+    const download = await sessionResult.captureDownload({
+      trigger: async (page) => {
+        await page.locator(AUTHORIZED_DOWNLOAD_SELECTOR).first().click();
+      }
+    });
+    const artifact = await buildArtifactMetadata(
+      download.path,
+      download.suggestedFilename,
+      snapshot.download.contentType
+    );
+
+    return {
+      outcome: "acquired" as const,
+      artifact,
+      candidate: input.input.candidate
+    };
+  } catch (error) {
+    return buildProviderRejectedResult({
+      candidate: input.input.candidate,
+      detail: buildProviderErrorDetail(
+        "SoundCloud acquisition failed while downloading the original uploaded file.",
+        error
+      ),
+      providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+      providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+      reason: "provider-error"
+    });
+  } finally {
+    await sessionResult.close();
+  }
+}
+
+async function openAuthenticatedSession(
+  browserSessionService: SoundCloudDirectDownloadsProviderDependencies["browserSessionService"],
+  sessionName: string
+) {
+  try {
+    await browserSessionService.requireAuthenticatedSession(sessionName);
+  } catch (error) {
+    if (
+      error instanceof MissingBrowserSessionStateError ||
+      error instanceof MissingBrowserSessionAuthStateError
+    ) {
+      return buildProviderRejectedResult({
+        detail:
+          "An authenticated SoundCloud browser session is required before automatic downloads can run.",
+        providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+        providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+        reason: "auth-required"
+      });
+    }
+
+    if (error instanceof ExpiredBrowserSessionAuthStateError) {
+      return buildProviderRejectedResult({
+        detail:
+          "The SoundCloud browser session expired and must be refreshed before automatic downloads can run.",
+        providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+        providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+        reason: "provider-session-expired"
+      });
+    }
+
+    throw error;
+  }
+
+  return browserSessionService.openSession({ sessionName });
+}
+
+function buildSearchQuery(track: CanonicalTrack) {
+  return [
+    track.primaryArtist,
+    track.title,
+    track.mix.displayLabel
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ");
+}
+
+function buildSearchUrl(baseUrl: string, query: string) {
+  const url = new URL("/search/sounds", baseUrl);
+  url.searchParams.set("q", query);
+  return url.toString();
+}
+
+async function readSearchResultUrls(page: Page) {
+  return page.evaluate((selector) => {
+    const urls = new Set<string>();
+
+    for (const element of document.querySelectorAll(selector)) {
+      if (!(element instanceof HTMLAnchorElement)) {
+        continue;
+      }
+
+      const href = element.getAttribute("href");
+
+      if (!href) {
+        continue;
+      }
+
+      urls.add(new URL(href, window.location.href).toString());
+    }
+
+    return [...urls];
+  }, SEARCH_RESULT_LINK_SELECTOR);
+}
+
+async function parseTrackSnapshot(page: Page): Promise<ParsedTrackSnapshot> {
+  return page.evaluate(
+    ({ authorizedDownloadSelector, externalDownloadSelector }) => {
+      const recording = readMusicRecordingStructuredData();
+      const artistName =
+        readMetaValue("soundcloud:artist_name") ??
+        readMusicRecordingArtistName(recording) ??
+        null;
+      const title =
+        readMusicRecordingTextField(recording, "name") ??
+        readMetaValue("og:title") ??
+        readHeadingText() ??
+        null;
+      const providerTrackId =
+        readMusicRecordingTextField(recording, "identifier") ??
+        readMetaValue("soundcloud:track_id") ??
+        null;
+      const providerUrl =
+        readMusicRecordingTextField(recording, "url") ??
+        readMetaValue("og:url") ??
+        window.location.href;
+      const durationSeconds =
+        parseNumber(readMetaValue("soundcloud:duration_seconds")) ??
+        parseIsoDurationSeconds(readMusicRecordingTextField(recording, "duration"));
+      const authorizedDownload = document.querySelector(authorizedDownloadSelector);
+
+      if (authorizedDownload instanceof HTMLAnchorElement) {
+        return {
+          artistName,
+          download: {
+            contentType: authorizedDownload.getAttribute("type"),
+            kind: "authorized" as const
+          },
+          durationSeconds,
+          providerTrackId,
+          providerUrl,
+          title
+        };
+      }
+
+      const externalDownload = document.querySelector(externalDownloadSelector);
+
+      if (externalDownload instanceof HTMLAnchorElement) {
+        return {
+          artistName,
+          download: {
+            externalUrl: externalDownload.href,
+            kind: "external" as const
+          },
+          durationSeconds,
+          providerTrackId,
+          providerUrl,
+          title
+        };
+      }
+
+      return {
+        artistName,
+        download: {
+          kind: "disabled" as const
+        },
+        durationSeconds,
+        providerTrackId,
+        providerUrl,
+        title
+      };
+
+      function readMusicRecordingStructuredData() {
+        for (const script of document.querySelectorAll('script[type="application/ld+json"]')) {
+          const payload = parseJson(script.textContent);
+
+          for (const candidate of flattenStructuredData(payload)) {
+            if (
+              candidate &&
+              typeof candidate === "object" &&
+              normalizeStructuredDataType((candidate as { "@type"?: unknown })["@type"]) ===
+                "musicrecording"
+            ) {
+              return candidate as Record<string, unknown>;
+            }
+          }
+        }
+
+        return null;
+      }
+
+      function readMusicRecordingArtistName(recording: Record<string, unknown> | null) {
+        if (!recording) {
+          return null;
+        }
+
+        const byArtist = recording.byArtist;
+
+        if (typeof byArtist === "string") {
+          return byArtist.trim() || null;
+        }
+
+        if (byArtist && typeof byArtist === "object") {
+          const name = (byArtist as { name?: unknown }).name;
+
+          if (typeof name === "string") {
+            return name.trim() || null;
+          }
+        }
+
+        return null;
+      }
+
+      function readMusicRecordingTextField(
+        recording: Record<string, unknown> | null,
+        field: string
+      ) {
+        if (!recording) {
+          return null;
+        }
+
+        const value = recording[field];
+
+        if (typeof value === "string") {
+          const trimmedValue = value.trim();
+          return trimmedValue || null;
+        }
+
+        if (typeof value === "number") {
+          return String(value);
+        }
+
+        return null;
+      }
+
+      function readMetaValue(name: string) {
+        const meta =
+          document.querySelector(`meta[name="${name}"]`) ??
+          document.querySelector(`meta[property="${name}"]`);
+
+        if (!(meta instanceof HTMLMetaElement)) {
+          return null;
+        }
+
+        const content = meta.content.trim();
+        return content || null;
+      }
+
+      function readHeadingText() {
+        const heading = document.querySelector("h1");
+
+        if (!heading) {
+          return null;
+        }
+
+        const text = heading.textContent?.trim();
+        return text || null;
+      }
+
+      function flattenStructuredData(payload: unknown): unknown[] {
+        if (!payload) {
+          return [];
+        }
+
+        if (Array.isArray(payload)) {
+          return payload.flatMap((entry) => flattenStructuredData(entry));
+        }
+
+        if (typeof payload === "object") {
+          const graph = (payload as { "@graph"?: unknown })["@graph"];
+
+          if (Array.isArray(graph)) {
+            return [payload, ...graph.flatMap((entry) => flattenStructuredData(entry))];
+          }
+
+          return [payload];
+        }
+
+        return [];
+      }
+
+      function normalizeStructuredDataType(value: unknown) {
+        if (Array.isArray(value)) {
+          return value.join(" ").toLowerCase();
+        }
+
+        if (typeof value === "string") {
+          return value.toLowerCase();
+        }
+
+        return "";
+      }
+
+      function parseJson(value: string | null) {
+        if (!value) {
+          return null;
+        }
+
+        try {
+          return JSON.parse(value);
+        } catch {
+          return null;
+        }
+      }
+
+      function parseNumber(value: string | null) {
+        if (!value) {
+          return null;
+        }
+
+        const nextValue = Number(value);
+        return Number.isFinite(nextValue) ? Math.round(nextValue) : null;
+      }
+
+      function parseIsoDurationSeconds(value: string | null) {
+        if (!value) {
+          return null;
+        }
+
+        const match = value.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/i);
+
+        if (!match) {
+          return null;
+        }
+
+        const hours = Number(match[1] ?? 0);
+        const minutes = Number(match[2] ?? 0);
+        const seconds = Number(match[3] ?? 0);
+
+        return hours * 3600 + minutes * 60 + seconds;
+      }
+    },
+    {
+      authorizedDownloadSelector: AUTHORIZED_DOWNLOAD_SELECTOR,
+      externalDownloadSelector: EXTERNAL_DOWNLOAD_SELECTOR
+    }
+  );
+}
+
+function isTrackMatch(track: CanonicalTrack, snapshot: ParsedTrackSnapshot) {
+  if (!snapshot.artistName || !snapshot.title) {
+    return false;
+  }
+
+  const candidateTrack = canonicalizeTrack({
+    artistName: snapshot.artistName,
+    duration: snapshot.durationSeconds,
+    source: "soundcloud",
+    sourceTrackId: snapshot.providerTrackId ?? undefined,
+    sourceUrl: snapshot.providerUrl,
+    title: snapshot.title
+  });
+
+  if (candidateTrack.normalizedTitle !== track.normalizedTitle) {
+    return false;
+  }
+
+  if (
+    track.primaryArtist &&
+    candidateTrack.primaryArtist &&
+    normalizeSearchText(candidateTrack.primaryArtist) !==
+      normalizeSearchText(track.primaryArtist)
+  ) {
+    return false;
+  }
+
+  if (track.mix.normalizedLabel) {
+    return candidateTrack.mix.normalizedLabel === track.mix.normalizedLabel;
+  }
+
+  return true;
+}
+
+function buildCandidate(snapshot: ParsedTrackSnapshot, searchQuery: string): ProviderCandidate {
+  const candidateTrack = canonicalizeTrack({
+    artistName: snapshot.artistName ?? "",
+    duration: snapshot.durationSeconds,
+    source: "soundcloud",
+    sourceTrackId: snapshot.providerTrackId ?? undefined,
+    sourceUrl: snapshot.providerUrl,
+    title: snapshot.title ?? ""
+  });
+
+  return {
+    artistName: candidateTrack.primaryArtist ?? snapshot.artistName ?? "Unknown Artist",
+    authorizationBasis: "uploader-enabled-download",
+    availableFormats: ["original-upload-format"],
+    candidateId: snapshot.providerTrackId ?? snapshot.providerUrl,
+    durationSeconds: snapshot.durationSeconds,
+    mixConfidence: candidateTrack.mix.confidence,
+    mixLabel: candidateTrack.mix.displayLabel,
+    priceTier: "free",
+    providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+    providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+    provenance: {
+      discoveredVia: "search",
+      providerTrackId: snapshot.providerTrackId ?? undefined,
+      providerUrl: snapshot.providerUrl,
+      searchQuery,
+      sourcePageUrl: snapshot.providerUrl
+    },
+    title: candidateTrack.title
+  };
+}
+
+function buildUnauthorizedDownloadDetail(
+  download: ParsedTrackSnapshot["download"]
+) {
+  if (download.kind === "external") {
+    return (
+      "Matched SoundCloud track exposed an external download link instead of an uploader-enabled direct download." +
+      (download.externalUrl ? ` (${download.externalUrl})` : "")
+    );
+  }
+
+  return "Matched SoundCloud track did not have uploader-enabled downloads enabled.";
+}
+
+async function buildArtifactMetadata(
+  downloadPath: string,
+  suggestedFilename: string,
+  contentType: string | null
+) {
+  const normalizedContentType =
+    normalizeContentType(contentType) ?? inferContentType(suggestedFilename);
+  const fileBuffer = await readFile(downloadPath);
+  const fileStats = await stat(downloadPath);
+  const fileExtension = normalizeFileExtension(suggestedFilename);
+
+  return {
+    contentType: normalizedContentType,
+    fileExtension,
+    fileName: suggestedFilename,
+    format: inferArtifactFormat(fileExtension, normalizedContentType),
+    sha256: createHash("sha256").update(fileBuffer).digest("hex"),
+    sizeBytes: fileStats.size
+  };
+}
+
+function normalizeFileExtension(fileName: string) {
+  const extension = path.extname(fileName).replace(/^\./, "").trim().toLowerCase();
+  return extension || null;
+}
+
+function inferArtifactFormat(
+  fileExtension: string | null,
+  contentType: string | null
+): ProviderArtifactFormat {
+  switch (fileExtension) {
+    case "mp3":
+      return "mp3";
+    case "wav":
+      return "wav";
+    case "aif":
+    case "aiff":
+      return "aiff";
+    case "flac":
+      return "flac";
+    case "aac":
+      return "aac";
+    case "ogg":
+    case "oga":
+      return "ogg-vorbis";
+    case "m4a":
+      return normalizedContentTypeIs(contentType, "audio/alac") ? "alac" : "original-upload-format";
+    default:
+      return "original-upload-format";
+  }
+}
+
+function normalizeContentType(contentType: string | null) {
+  const normalizedContentType = contentType?.trim().toLowerCase();
+  return normalizedContentType || null;
+}
+
+function inferContentType(fileName: string) {
+  switch (normalizeFileExtension(fileName)) {
+    case "mp3":
+      return "audio/mpeg";
+    case "wav":
+      return "audio/wav";
+    case "aif":
+    case "aiff":
+      return "audio/aiff";
+    case "flac":
+      return "audio/flac";
+    case "aac":
+      return "audio/aac";
+    case "ogg":
+    case "oga":
+      return "audio/ogg";
+    default:
+      return null;
+  }
+}
+
+function normalizedContentTypeIs(contentType: string | null, expected: string) {
+  return normalizeContentType(contentType) === expected;
+}
+
+function buildProviderErrorDetail(message: string, error: unknown) {
+  if (error instanceof Error && error.message) {
+    return `${message} ${error.message}`;
+  }
+
+  return message;
+}
+
+function normalizeSearchText(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}


### PR DESCRIPTION
**@worker-02**

## Summary
- add the `soundcloud-direct-downloads` automatic provider using the shared provider contract metadata from the research registry
- search SoundCloud through the managed browser/session layer and only return candidates when uploader-enabled downloads are present
- normalize downloaded artifact metadata and cover registration, negative download states, session rejections, and acquisition with focused provider tests

## Verification
- `npm test`
- `npx tsc --noEmit`
- `npx eslint src/features/providers/soundcloud-direct-downloads.ts src/features/providers/soundcloud-direct-downloads.test.ts`

## Notes
- `npm run lint` currently fails on pre-existing generated `.branch-sandbox/.next` files in this worktree, so lint verification for this issue was scoped to the touched provider files.
- Refs #46
