### PR TITLE
feat: ingest Spotify playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Local web app for authorized-source playlist acquisition, optimized for DJ and e
 - Local-only operator workflow
 - Authorized-source acquisition only
 - No stream-ripping, bypass, or unauthorized-source behavior
-- Current state: bootstrap app shell with placeholder intake and recent-run surfaces
+- Current state: app shell with persisted Spotify and SoundCloud playlist intake
 
 ## Requirements
 
@@ -18,6 +18,22 @@ Local web app for authorized-source playlist acquisition, optimized for DJ and e
 
 ```bash
 npm install
+```
+
+To enable authorized Spotify playlist ingestion through the Spotify Web API
+client-credentials flow,
+set these Spotify env vars before running the app:
+
+```bash
+export SPOTIFY_CLIENT_ID=your-spotify-client-id
+export SPOTIFY_CLIENT_SECRET=your-spotify-client-secret
+```
+
+Spotify playlist item requests default to the `US` market. Override that for
+your local operator setup if needed:
+
+```bash
+export SPOTIFY_MARKET=US
 ```
 
 To enable authorized SoundCloud playlist ingestion through the official API,
@@ -47,5 +63,5 @@ npm run test:e2e
 
 ## Notes
 
-- The landing page currently establishes the shared shell, form controls, and placeholder recent-runs area for later tasks.
+- The landing page currently provides the shared shell, form controls, and persisted recent-runs area for later tasks.
 - Background jobs, provider matching, manifests, misses, and artifact packaging land in later issues.

--- a/src/app/api/runs/route.test.ts
+++ b/src/app/api/runs/route.test.ts
@@ -24,9 +24,78 @@ async function withTempDatabase(
 }
 
 describe("/api/runs", () => {
-  it("creates a queued run and exposes its pollable status", async () => {
+  it("ingests a Spotify playlist into persisted run data and exposes its pollable status", async () => {
     await withTempDatabase(async (databasePath) => {
       vi.resetModules();
+
+      const originalClientId = process.env.SPOTIFY_CLIENT_ID;
+      const originalClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+      const originalMarket = process.env.SPOTIFY_MARKET;
+
+      process.env.SPOTIFY_CLIENT_ID = "spotify-client-id";
+      process.env.SPOTIFY_CLIENT_SECRET = "spotify-client-secret";
+      process.env.SPOTIFY_MARKET = "US";
+
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ access_token: "spotify-access-token" }), {
+            headers: {
+              "content-type": "application/json"
+            },
+            status: 200
+          })
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              external_urls: {
+                spotify:
+                  "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9"
+              },
+              name: "Warehouse Starters"
+            }),
+            {
+              headers: {
+                "content-type": "application/json"
+              },
+              status: 200
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              items: [
+                {
+                  track: {
+                    artists: [{ name: "Anyma" }, { name: "Chris Avantgarde" }],
+                    duration_ms: 391578,
+                    id: "0abc123",
+                    name: "Consciousness (Extended Mix)",
+                    type: "track"
+                  }
+                },
+                {
+                  track: {
+                    artists: [{ name: "Kx5" }],
+                    duration_ms: 265000,
+                    id: "0def456",
+                    name: "Escape",
+                    type: "track"
+                  }
+                }
+              ],
+              next: null
+            }),
+            {
+              headers: {
+                "content-type": "application/json"
+              },
+              status: 200
+            }
+          )
+        );
 
       const [{ POST }, { GET }, runStoreModule] = await Promise.all([
         import("./route"),
@@ -34,11 +103,119 @@ describe("/api/runs", () => {
         import("@/features/runs/run-store")
       ]);
 
-      const createResponse = await POST(
+      try {
+        const createResponse = await POST(
+          new Request("http://localhost/api/runs", {
+            body: JSON.stringify({
+              playlistUrl:
+                "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9"
+            }),
+            headers: {
+              "content-type": "application/json"
+            },
+            method: "POST"
+          })
+        );
+
+        expect(createResponse.status).toBe(201);
+        expect(existsSync(databasePath)).toBe(true);
+        expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+        const createdRun = (await createResponse.json()) as {
+          id: string;
+          playlistTitle: string | null;
+          sourceType: string;
+          status: string;
+          trackCount: number;
+          tracks: Array<{
+            artist: string;
+            title: string;
+            version: string | null;
+          }>;
+        };
+        const pollResponse = await GET(
+          new Request(`http://localhost/api/runs/${createdRun.id}`),
+          {
+            params: Promise.resolve({ runId: createdRun.id })
+          }
+        );
+        const polledRun = (await pollResponse.json()) as {
+          id: string;
+          playlistTitle: string | null;
+          sourceType: string;
+          status: string;
+          trackCount: number;
+          tracks: Array<{
+            artist: string;
+            title: string;
+            version: string | null;
+          }>;
+        };
+
+        expect(createdRun).toEqual(
+          expect.objectContaining({
+            playlistTitle: "Warehouse Starters",
+            sourceType: "spotify",
+            status: "queued",
+            trackCount: 2
+          })
+        );
+        expect(createdRun.tracks).toEqual([
+          expect.objectContaining({
+            artist: "Anyma",
+            title: "Consciousness",
+            version: "Extended Mix"
+          }),
+          expect.objectContaining({
+            artist: "Kx5",
+            title: "Escape",
+            version: null
+          })
+        ]);
+        expect(polledRun).toEqual(
+          expect.objectContaining({
+            id: createdRun.id,
+            playlistTitle: "Warehouse Starters",
+            sourceType: "spotify",
+            status: "queued",
+            trackCount: 2
+          })
+        );
+        expect(runStoreModule.getRunStore().listRuns()).toHaveLength(1);
+      } finally {
+        fetchSpy.mockRestore();
+
+        if (originalClientId === undefined) {
+          delete process.env.SPOTIFY_CLIENT_ID;
+        } else {
+          process.env.SPOTIFY_CLIENT_ID = originalClientId;
+        }
+
+        if (originalClientSecret === undefined) {
+          delete process.env.SPOTIFY_CLIENT_SECRET;
+        } else {
+          process.env.SPOTIFY_CLIENT_SECRET = originalClientSecret;
+        }
+
+        if (originalMarket === undefined) {
+          delete process.env.SPOTIFY_MARKET;
+        } else {
+          process.env.SPOTIFY_MARKET = originalMarket;
+        }
+      }
+    });
+  });
+
+  it("returns explicit validation errors for unsupported Spotify URLs", async () => {
+    await withTempDatabase(async () => {
+      vi.resetModules();
+
+      const { POST } = await import("./route");
+
+      const response = await POST(
         new Request("http://localhost/api/runs", {
           body: JSON.stringify({
-            playlistUrl:
-              "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9"
+            playlistUrl: "https://open.spotify.com/album/37i9dQZF1DWVRSukIED0e9"
           }),
           headers: {
             "content-type": "application/json"
@@ -47,30 +224,65 @@ describe("/api/runs", () => {
         })
       );
 
-      expect(createResponse.status).toBe(201);
-      expect(existsSync(databasePath)).toBe(true);
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error:
+          "Spotify URL must point to a playlist (for example /playlist/<playlist-id>)."
+      });
+    });
+  });
 
-      const createdRun = (await createResponse.json()) as { id: string };
-      const pollResponse = await GET(
-        new Request(`http://localhost/api/runs/${createdRun.id}`),
-        {
-          params: Promise.resolve({ runId: createdRun.id })
+  it("returns explicit setup errors when Spotify credentials are missing", async () => {
+    await withTempDatabase(async () => {
+      vi.resetModules();
+
+      const originalClientId = process.env.SPOTIFY_CLIENT_ID;
+      const originalClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+      const originalMarket = process.env.SPOTIFY_MARKET;
+
+      delete process.env.SPOTIFY_CLIENT_ID;
+      delete process.env.SPOTIFY_CLIENT_SECRET;
+      delete process.env.SPOTIFY_MARKET;
+
+      try {
+        const { POST } = await import("./route");
+
+        const response = await POST(
+          new Request("http://localhost/api/runs", {
+            body: JSON.stringify({
+              playlistUrl:
+                "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9"
+            }),
+            headers: {
+              "content-type": "application/json"
+            },
+            method: "POST"
+          })
+        );
+
+        expect(response.status).toBe(500);
+        await expect(response.json()).resolves.toEqual({
+          error: "Spotify ingestion requires SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET."
+        });
+      } finally {
+        if (originalClientId === undefined) {
+          delete process.env.SPOTIFY_CLIENT_ID;
+        } else {
+          process.env.SPOTIFY_CLIENT_ID = originalClientId;
         }
-      );
-      const polledRun = (await pollResponse.json()) as {
-        id: string;
-        sourceType: string;
-        status: string;
-      };
 
-      expect(polledRun).toEqual(
-        expect.objectContaining({
-          id: createdRun.id,
-          sourceType: "spotify",
-          status: "queued"
-        })
-      );
-      expect(runStoreModule.getRunStore().listRuns()).toHaveLength(1);
+        if (originalClientSecret === undefined) {
+          delete process.env.SPOTIFY_CLIENT_SECRET;
+        } else {
+          process.env.SPOTIFY_CLIENT_SECRET = originalClientSecret;
+        }
+
+        if (originalMarket === undefined) {
+          delete process.env.SPOTIFY_MARKET;
+        } else {
+          process.env.SPOTIFY_MARKET = originalMarket;
+        }
+      }
     });
   });
 

--- a/src/features/ingestion/playlist-intake.ts
+++ b/src/features/ingestion/playlist-intake.ts
@@ -2,9 +2,11 @@ import { getRunStore, type RunDetail, type RunStore } from "@/features/runs/run-
 
 import { PlaylistIntakeError } from "./playlist-intake-error";
 import { fetchSoundCloudPlaylistSnapshot } from "./soundcloud-playlist";
+import { fetchSpotifyPlaylistSnapshot } from "./spotify-playlist";
 
 type PlaylistIntakeDependencies = {
   fetchSoundCloudPlaylistSnapshot?: typeof fetchSoundCloudPlaylistSnapshot;
+  fetchSpotifyPlaylistSnapshot?: typeof fetchSpotifyPlaylistSnapshot;
   runStore?: Pick<RunStore, "createRun" | "getRun" | "replaceRunTracks">;
 };
 
@@ -40,19 +42,20 @@ export async function createRunFromPlaylistUrl(
   }
 
   const runStore = dependencies.runStore ?? getRunStore();
-
-  if (sourceType === "spotify") {
-    return runStore.createRun({ playlistUrl, sourceType });
-  }
-
-  const snapshot = await (
-    dependencies.fetchSoundCloudPlaylistSnapshot ??
-    fetchSoundCloudPlaylistSnapshot
-  )(playlistUrl);
+  const snapshot =
+    sourceType === "spotify"
+      ? await (
+          dependencies.fetchSpotifyPlaylistSnapshot ??
+          fetchSpotifyPlaylistSnapshot
+        )(playlistUrl)
+      : await (
+          dependencies.fetchSoundCloudPlaylistSnapshot ??
+          fetchSoundCloudPlaylistSnapshot
+        )(playlistUrl);
   const run = runStore.createRun({
     playlistTitle: snapshot.playlistTitle,
     playlistUrl: snapshot.playlistUrl,
-    sourceType: "soundcloud"
+    sourceType
   });
 
   runStore.replaceRunTracks(run.id, snapshot.tracks);
@@ -60,7 +63,7 @@ export async function createRunFromPlaylistUrl(
   const hydratedRun = runStore.getRun(run.id);
 
   if (!hydratedRun) {
-    throw new Error(`Run not found after SoundCloud ingestion: ${run.id}`);
+    throw new Error(`Run not found after ${sourceType} ingestion: ${run.id}`);
   }
 
   return hydratedRun;

--- a/src/features/ingestion/spotify-playlist.test.ts
+++ b/src/features/ingestion/spotify-playlist.test.ts
@@ -1,0 +1,259 @@
+/* @vitest-environment node */
+
+import {
+  fetchSpotifyPlaylistSnapshot,
+  mapSpotifyPlaylistSnapshot,
+  parseSpotifyPlaylistUrl
+} from "./spotify-playlist";
+
+describe("parseSpotifyPlaylistUrl", () => {
+  it("normalizes supported Spotify playlist URLs", () => {
+    const playlistUrl = parseSpotifyPlaylistUrl(
+      "https://open.spotify.com/playlist/37i9dQZF1DX4dyzvuaRJ0n?si=abc123#queue"
+    );
+
+    expect(playlistUrl.toString()).toBe(
+      "https://open.spotify.com/playlist/37i9dQZF1DX4dyzvuaRJ0n"
+    );
+  });
+
+  it("rejects non-playlist Spotify URLs with an explicit error", () => {
+    expect(() =>
+      parseSpotifyPlaylistUrl("https://open.spotify.com/album/37i9dQZF1DX4dyzvuaRJ0n")
+    ).toThrowError(
+      "Spotify URL must point to a playlist (for example /playlist/<playlist-id>)."
+    );
+  });
+});
+
+describe("mapSpotifyPlaylistSnapshot", () => {
+  it("maps Spotify playlist metadata and track items into run-track inputs", () => {
+    const snapshot = mapSpotifyPlaylistSnapshot(
+      {
+        external_urls: {
+          spotify: "https://open.spotify.com/playlist/37i9dQZF1DX4dyzvuaRJ0n"
+        },
+        name: "Peak-Time Cuts"
+      },
+      [
+        {
+          items: [
+            {
+              track: {
+                artists: [{ name: "Anyma" }, { name: "Chris Avantgarde" }],
+                duration_ms: 391578,
+                external_urls: {
+                  spotify: "https://open.spotify.com/track/0abc123"
+                },
+                id: "0abc123",
+                name: "Consciousness (Extended Mix)",
+                type: "track"
+              }
+            },
+            {
+              track: {
+                artists: [{ name: "Kx5" }],
+                duration_ms: 265000,
+                id: "0def456",
+                name: "Escape",
+                type: "track"
+              }
+            }
+          ],
+          next: null
+        }
+      ],
+      "https://open.spotify.com/playlist/37i9dQZF1DX4dyzvuaRJ0n"
+    );
+
+    expect(snapshot).toEqual({
+      playlistTitle: "Peak-Time Cuts",
+      playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DX4dyzvuaRJ0n",
+      tracks: [
+        {
+          artist: "Anyma",
+          sourcePosition: 1,
+          sourceTrackId: "0abc123",
+          title: "Consciousness",
+          version: "Extended Mix"
+        },
+        {
+          artist: "Kx5",
+          sourcePosition: 2,
+          sourceTrackId: "0def456",
+          title: "Escape",
+          version: null
+        }
+      ]
+    });
+  });
+
+  it("rejects playlist items that do not resolve to Spotify tracks", () => {
+    expect(() =>
+      mapSpotifyPlaylistSnapshot(
+        {
+          name: "Broken Playlist"
+        },
+        [
+          {
+            items: [
+              {
+                track: {
+                  id: "episode-1",
+                  name: "DJ interview",
+                  type: "episode"
+                }
+              }
+            ],
+            next: null
+          }
+        ],
+        "https://open.spotify.com/playlist/37i9dQZF1DX4dyzvuaRJ0n"
+      )
+    ).toThrowError("Spotify playlist item 1 is not a playable track.");
+  });
+});
+
+describe("fetchSpotifyPlaylistSnapshot", () => {
+  it("uses the documented Spotify client-credentials contract and paginates playlist items", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: "spotify-access-token" }), {
+          headers: {
+            "content-type": "application/json"
+          },
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            external_urls: {
+              spotify: "https://open.spotify.com/playlist/37i9dQZF1DX4dyzvuaRJ0n"
+            },
+            name: "Peak-Time Cuts"
+          }),
+          {
+            headers: {
+              "content-type": "application/json"
+            },
+            status: 200
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            items: [
+              {
+                track: {
+                  artists: [{ name: "Anyma" }],
+                  duration_ms: 391578,
+                  id: "0abc123",
+                  name: "Consciousness (Extended Mix)",
+                  type: "track"
+                }
+              }
+            ],
+            next: "https://api.spotify.com/v1/playlists/37i9dQZF1DX4dyzvuaRJ0n/items?offset=1&limit=50&market=US"
+          }),
+          {
+            headers: {
+              "content-type": "application/json"
+            },
+            status: 200
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            items: [
+              {
+                track: {
+                  artists: [{ name: "Cassian" }],
+                  duration_ms: 303000,
+                  id: "0def456",
+                  name: "Aran",
+                  type: "track"
+                }
+              }
+            ],
+            next: null
+          }),
+          {
+            headers: {
+              "content-type": "application/json"
+            },
+            status: 200
+          }
+        )
+      );
+
+    const snapshot = await fetchSpotifyPlaylistSnapshot(
+      "https://open.spotify.com/playlist/37i9dQZF1DX4dyzvuaRJ0n",
+      {
+        clientId: "spotify-client-id",
+        clientSecret: "spotify-client-secret",
+        fetchImpl,
+        market: "US"
+      }
+    );
+
+    expect(snapshot).toEqual({
+      playlistTitle: "Peak-Time Cuts",
+      playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DX4dyzvuaRJ0n",
+      tracks: [
+        {
+          artist: "Anyma",
+          sourcePosition: 1,
+          sourceTrackId: "0abc123",
+          title: "Consciousness",
+          version: "Extended Mix"
+        },
+        {
+          artist: "Cassian",
+          sourcePosition: 2,
+          sourceTrackId: "0def456",
+          title: "Aran",
+          version: null
+        }
+      ]
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+
+    const [tokenUrl, tokenRequest] = fetchImpl.mock.calls[0] ?? [];
+    const tokenHeaders = new Headers(tokenRequest?.headers);
+    const tokenBody = new URLSearchParams(String(tokenRequest?.body ?? ""));
+
+    expect(String(tokenUrl)).toBe("https://accounts.spotify.com/api/token");
+    expect(tokenRequest?.method).toBe("POST");
+    expect(tokenHeaders.get("accept")).toBe("application/json; charset=utf-8");
+    expect(tokenHeaders.get("content-type")).toBe(
+      "application/x-www-form-urlencoded"
+    );
+    expect(tokenHeaders.get("authorization")).toBe(
+      `Basic ${Buffer.from("spotify-client-id:spotify-client-secret").toString("base64")}`
+    );
+    expect(tokenBody.get("grant_type")).toBe("client_credentials");
+
+    const [metadataUrl, metadataRequest] = fetchImpl.mock.calls[1] ?? [];
+    const [itemsUrl, itemsRequest] = fetchImpl.mock.calls[2] ?? [];
+
+    expect(String(metadataUrl)).toBe(
+      "https://api.spotify.com/v1/playlists/37i9dQZF1DX4dyzvuaRJ0n"
+    );
+    expect(new Headers(metadataRequest?.headers).get("authorization")).toBe(
+      "Bearer spotify-access-token"
+    );
+    expect(String(itemsUrl)).toContain(
+      "/v1/playlists/37i9dQZF1DX4dyzvuaRJ0n/items"
+    );
+    expect(String(itemsUrl)).toContain("limit=50");
+    expect(String(itemsUrl)).toContain("market=US");
+    expect(new Headers(itemsRequest?.headers).get("authorization")).toBe(
+      "Bearer spotify-access-token"
+    );
+  });
+});

--- a/src/features/ingestion/spotify-playlist.ts
+++ b/src/features/ingestion/spotify-playlist.ts
@@ -1,0 +1,361 @@
+import type { ReplaceRunTrackInput } from "@/features/runs/run-store";
+import { canonicalizeTrack } from "@/features/tracks/canonical-track";
+
+import { PlaylistIntakeError } from "./playlist-intake-error";
+
+type FetchLike = typeof fetch;
+
+type SpotifyExternalUrlsPayload = {
+  spotify?: string | null;
+};
+
+type SpotifyArtistPayload = {
+  name?: string | null;
+};
+
+type SpotifyTrackPayload = {
+  artists?: SpotifyArtistPayload[] | null;
+  duration_ms?: number | null;
+  external_urls?: SpotifyExternalUrlsPayload | null;
+  id?: string | null;
+  is_local?: boolean | null;
+  name?: string | null;
+  type?: string | null;
+};
+
+type SpotifyPlaylistPayload = {
+  external_urls?: SpotifyExternalUrlsPayload | null;
+  name?: string | null;
+  type?: string | null;
+};
+
+type SpotifyPlaylistItemPayload = {
+  track?: SpotifyTrackPayload | null;
+};
+
+type SpotifyPlaylistItemsPagePayload = {
+  items?: SpotifyPlaylistItemPayload[] | null;
+  next?: string | null;
+};
+
+type SpotifyTokenPayload = {
+  access_token?: string;
+  error?: string | { message?: string };
+  error_description?: string;
+};
+
+type SpotifyPlaylistSnapshot = {
+  playlistTitle: string | null;
+  playlistUrl: string;
+  tracks: ReplaceRunTrackInput[];
+};
+
+type SpotifyPlaylistDependencies = {
+  apiBaseUrl?: string;
+  clientId?: string;
+  clientSecret?: string;
+  fetchImpl?: FetchLike;
+  market?: string;
+  tokenUrl?: string;
+};
+
+const spotifyHosts = new Set(["open.spotify.com", "play.spotify.com"]);
+const spotifyPlaylistIdPattern = /^[A-Za-z0-9]{22}$/;
+
+export function parseSpotifyPlaylistUrl(playlistUrl: string) {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(playlistUrl);
+  } catch {
+    throw new PlaylistIntakeError("Spotify URL is invalid.", 400);
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+  const pathSegments = parsedUrl.pathname.split("/").filter(Boolean);
+  const playlistSegmentIndex = pathSegments.lastIndexOf("playlist");
+  const playlistId = pathSegments.at(-1);
+
+  if (!spotifyHosts.has(hostname)) {
+    throw new PlaylistIntakeError(
+      "Spotify URL must use open.spotify.com playlist links.",
+      400
+    );
+  }
+
+  if (
+    playlistSegmentIndex < 0 ||
+    playlistSegmentIndex !== pathSegments.length - 2 ||
+    !playlistId ||
+    !spotifyPlaylistIdPattern.test(playlistId)
+  ) {
+    throw new PlaylistIntakeError(
+      "Spotify URL must point to a playlist (for example /playlist/<playlist-id>).",
+      400
+    );
+  }
+
+  return new URL(`https://open.spotify.com/playlist/${playlistId}`);
+}
+
+export function mapSpotifyPlaylistSnapshot(
+  playlist: SpotifyPlaylistPayload,
+  itemPages: SpotifyPlaylistItemsPagePayload[],
+  playlistUrl: string
+): SpotifyPlaylistSnapshot {
+  if (cleanValue(playlist.type) && cleanValue(playlist.type) !== "playlist") {
+    throw new PlaylistIntakeError(
+      "Spotify URL did not resolve to a playlist.",
+      502
+    );
+  }
+
+  const tracks: ReplaceRunTrackInput[] = [];
+
+  for (const page of itemPages) {
+    if (!Array.isArray(page.items)) {
+      throw new PlaylistIntakeError(
+        "Spotify playlist response did not include track data.",
+        502
+      );
+    }
+
+    for (const item of page.items) {
+      tracks.push(mapSpotifyPlaylistItem(item, tracks.length));
+    }
+  }
+
+  return {
+    playlistTitle: cleanValue(playlist.name),
+    playlistUrl: cleanValue(playlist.external_urls?.spotify) ?? playlistUrl,
+    tracks
+  };
+}
+
+export async function fetchSpotifyPlaylistSnapshot(
+  playlistUrl: string,
+  dependencies: SpotifyPlaylistDependencies = {}
+) {
+  const normalizedPlaylistUrl = parseSpotifyPlaylistUrl(playlistUrl).toString();
+  const clientId = dependencies.clientId ?? process.env.SPOTIFY_CLIENT_ID;
+  const clientSecret =
+    dependencies.clientSecret ?? process.env.SPOTIFY_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    throw new PlaylistIntakeError(
+      "Spotify ingestion requires SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET.",
+      500
+    );
+  }
+
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const playlistId = normalizedPlaylistUrl.split("/").at(-1);
+
+  if (!playlistId) {
+    throw new PlaylistIntakeError("Spotify URL is invalid.", 400);
+  }
+
+  const accessToken = await fetchSpotifyAccessToken({
+    clientId,
+    clientSecret,
+    fetchImpl,
+    tokenUrl:
+      dependencies.tokenUrl ?? "https://accounts.spotify.com/api/token"
+  });
+  const authorizationHeaders = {
+    Accept: "application/json; charset=utf-8",
+    Authorization: `Bearer ${accessToken}`
+  };
+  const apiBaseUrl = ensureTrailingSlash(
+    dependencies.apiBaseUrl ?? "https://api.spotify.com/v1"
+  );
+  const market = resolveMarket(dependencies.market);
+
+  const playlistResponse = await fetchImpl(
+    new URL(`playlists/${playlistId}`, apiBaseUrl),
+    { headers: authorizationHeaders }
+  );
+
+  if (!playlistResponse.ok) {
+    throw new PlaylistIntakeError(
+      (await readErrorMessage(playlistResponse)) ?? "Spotify playlist lookup failed.",
+      502
+    );
+  }
+
+  const itemPages: SpotifyPlaylistItemsPagePayload[] = [];
+  const firstItemsUrl = new URL(`playlists/${playlistId}/items`, apiBaseUrl);
+
+  firstItemsUrl.searchParams.set("limit", "50");
+  firstItemsUrl.searchParams.set("market", market);
+
+  let nextItemsUrl: string | null = firstItemsUrl.toString();
+
+  while (nextItemsUrl) {
+    const itemsResponse = await fetchImpl(nextItemsUrl, {
+      headers: authorizationHeaders
+    });
+
+    if (!itemsResponse.ok) {
+      throw new PlaylistIntakeError(
+        (await readErrorMessage(itemsResponse)) ??
+          "Spotify playlist tracks lookup failed.",
+        502
+      );
+    }
+
+    const itemPage = (await itemsResponse.json()) as SpotifyPlaylistItemsPagePayload;
+
+    itemPages.push(itemPage);
+    nextItemsUrl = cleanValue(itemPage.next);
+  }
+
+  return mapSpotifyPlaylistSnapshot(
+    (await playlistResponse.json()) as SpotifyPlaylistPayload,
+    itemPages,
+    normalizedPlaylistUrl
+  );
+}
+
+function mapSpotifyPlaylistItem(
+  item: SpotifyPlaylistItemPayload,
+  index: number
+): ReplaceRunTrackInput {
+  const track = item.track;
+  const trackType = cleanValue(track?.type) ?? "track";
+
+  if (!track || track.is_local || trackType !== "track") {
+    throw new PlaylistIntakeError(
+      `Spotify playlist item ${index + 1} is not a playable track.`,
+      502
+    );
+  }
+
+  const rawTitle = cleanValue(track.name);
+
+  if (!rawTitle) {
+    throw new PlaylistIntakeError(
+      `Spotify playlist track ${index + 1} is missing a title.`,
+      502
+    );
+  }
+
+  const artistNames =
+    track.artists?.flatMap((artist) => {
+      const name = cleanValue(artist.name);
+
+      return name ? [name] : [];
+    }) ?? [];
+
+  if (!artistNames.length) {
+    throw new PlaylistIntakeError(
+      `Spotify playlist track ${index + 1} is missing artist metadata.`,
+      502
+    );
+  }
+
+  const sourceTrackId = cleanValue(track.id);
+  const canonicalTrack = canonicalizeTrack({
+    artistNames,
+    duration: track.duration_ms ?? null,
+    source: "spotify",
+    sourceTrackId: sourceTrackId ?? undefined,
+    sourceUrl: cleanValue(track.external_urls?.spotify) ?? undefined,
+    title: rawTitle
+  });
+
+  return {
+    artist: canonicalTrack.primaryArtist ?? artistNames[0],
+    sourcePosition: index + 1,
+    sourceTrackId,
+    title: canonicalTrack.title,
+    version: canonicalTrack.mix.displayLabel
+  };
+}
+
+async function fetchSpotifyAccessToken(input: {
+  clientId: string;
+  clientSecret: string;
+  fetchImpl: FetchLike;
+  tokenUrl: string;
+}) {
+  const response = await input.fetchImpl(input.tokenUrl, {
+    body: new URLSearchParams({
+      grant_type: "client_credentials"
+    }).toString(),
+    headers: {
+      Accept: "application/json; charset=utf-8",
+      Authorization: `Basic ${Buffer.from(
+        `${input.clientId}:${input.clientSecret}`
+      ).toString("base64")}`,
+      "Content-Type": "application/x-www-form-urlencoded"
+    },
+    method: "POST"
+  });
+
+  if (!response.ok) {
+    throw new PlaylistIntakeError(
+      (await readErrorMessage(response)) ?? "Spotify authentication failed.",
+      502
+    );
+  }
+
+  const payload = (await response.json()) as SpotifyTokenPayload;
+
+  if (!payload.access_token) {
+    throw new PlaylistIntakeError(
+      "Spotify authentication response did not include an access token.",
+      502
+    );
+  }
+
+  return payload.access_token;
+}
+
+function cleanValue(value: string | null | undefined) {
+  const trimmedValue = value?.trim();
+
+  return trimmedValue ? trimmedValue : null;
+}
+
+function ensureTrailingSlash(value: string) {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function resolveMarket(marketOverride: string | undefined) {
+  const configuredMarket = cleanValue(marketOverride ?? process.env.SPOTIFY_MARKET);
+
+  return configuredMarket?.toUpperCase() ?? "US";
+}
+
+async function readErrorMessage(response: Response) {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    const payload = (await response.json().catch(() => null)) as
+      | {
+          error?: string | { message?: string };
+          error_description?: string;
+          message?: string;
+        }
+      | null;
+
+    if (!payload) {
+      return null;
+    }
+
+    if (payload.error_description) {
+      return payload.error_description;
+    }
+
+    if (typeof payload.error === "string") {
+      return payload.error;
+    }
+
+    return payload.error?.message ?? payload.message ?? null;
+  }
+
+  const text = await response.text().catch(() => "");
+
+  return text.trim() || null;
+}


### PR DESCRIPTION
**@worker-03**

## Summary
- add authorized Spotify playlist ingestion through the Spotify Web API client-credentials flow
- persist Spotify playlist metadata and canonicalized track rows into the existing run model
- cover URL parsing, adapter mapping, setup and failure handling, and route integration with mocked responses
- document the required Spotify env vars and optional market override

## Verification
- npm run lint
- npm test
- npm run build

Closes #5
