### PR TITLE
feat: add Bandcamp free-or-owned provider

### DIFF
--- a/src/features/providers/bandcamp.test.ts
+++ b/src/features/providers/bandcamp.test.ts
@@ -244,6 +244,98 @@ describe("createBandcampProvider", () => {
     15_000
   );
 
+  it(
+    "acquires the preferred entitled download when Bandcamp omits fixture-only download selectors",
+    async () => {
+      const workspaceRoot = await mkdtemp(
+        path.join(os.tmpdir(), "music-downloader-bandcamp-provider-production-selectors-")
+      );
+      const fixtureServer = await startBandcampFixtureServer({
+        releases: [
+          {
+            artistName: "DJ Sealer",
+            downloadOptions: [
+              {
+                body: "mp3 v0 fixture payload\n",
+                contentType: "audio/mpeg",
+                fileName: "warehouse-tool--v0.mp3",
+                formatKey: "mp3-v0",
+                label: "MP3 V0"
+              },
+              {
+                body: "mp3 320 fixture payload\n",
+                contentType: "audio/mpeg",
+                fileName: "warehouse-tool--320.mp3",
+                formatKey: "mp3-320",
+                label: "MP3 320"
+              },
+              {
+                body: "wav fixture payload\n",
+                contentType: "audio/wav",
+                fileName: "warehouse-tool.wav",
+                formatKey: "wav",
+                label: "WAV"
+              }
+            ],
+            durationSeconds: 392,
+            entitlement: "owned",
+            includeDownloadTestId: false,
+            path: "/album/warehouse-tool-production-selectors",
+            title: "Warehouse Tool (Extended Mix)",
+            trackId: "bandcamp-track-112"
+          }
+        ],
+        searchResults: ["/album/warehouse-tool-production-selectors"]
+      });
+      const browserSessionService = new BrowserSessionService({ workspaceRoot });
+      const provider = createBandcampProvider({
+        baseUrl: fixtureServer.origin,
+        browserSessionService
+      });
+
+      try {
+        await seedAuthenticatedSession(browserSessionService);
+        const track = canonicalizeTrack({
+          artistName: "DJ Sealer",
+          source: "spotify",
+          title: "Warehouse Tool (Extended Mix)"
+        });
+        const searchResult = await provider.search({ track });
+
+        expect(searchResult.outcome).toBe("candidates");
+
+        if (searchResult.outcome !== "candidates") {
+          throw new Error("Expected Bandcamp search to produce a candidate.");
+        }
+
+        await expect(
+          provider.acquire({
+            candidate: searchResult.candidates[0],
+            track
+          })
+        ).resolves.toEqual({
+          outcome: "acquired",
+          candidate: searchResult.candidates[0],
+          artifact: {
+            contentType: "audio/mpeg",
+            fileExtension: "mp3",
+            fileName: "warehouse-tool--320.mp3",
+            format: "mp3",
+            sha256: createHash("sha256")
+              .update("mp3 320 fixture payload\n")
+              .digest("hex"),
+            sizeBytes: Buffer.byteLength("mp3 320 fixture payload\n")
+          }
+        });
+      } finally {
+        await browserSessionService.shutdown();
+        await fixtureServer.close();
+        await rm(workspaceRoot, { force: true, recursive: true });
+      }
+    },
+    15_000
+  );
+
   it("returns a structured miss when the matching release still requires payment", async () => {
     const workspaceRoot = await mkdtemp(
       path.join(os.tmpdir(), "music-downloader-bandcamp-provider-paid-")
@@ -474,6 +566,7 @@ type ReleaseFixture = {
   downloadOptions: DownloadOptionFixture[];
   durationSeconds: number;
   entitlement: ReleaseEntitlement;
+  includeDownloadTestId?: boolean;
   path: string;
   title: string;
   trackId: string;
@@ -572,7 +665,11 @@ function handleFixtureRequest(
         ? releaseFixture.downloadOptions
             .map(
               (downloadOption) =>
-                `<a data-testid="bandcamp-download-link" data-entitlement="${releaseFixture.entitlement}" data-format-key="${escapeHtml(downloadOption.formatKey)}" href="/downloads/${releaseFixture.trackId}/${escapeHtml(downloadOption.fileName)}" download="${escapeHtml(downloadOption.fileName)}" type="${escapeHtml(downloadOption.contentType)}">${escapeHtml(downloadOption.label)}</a>`
+                `<a${
+                  releaseFixture.includeDownloadTestId === false
+                    ? ""
+                    : ' data-testid="bandcamp-download-link"'
+                } data-entitlement="${releaseFixture.entitlement}" data-format-key="${escapeHtml(downloadOption.formatKey)}" href="/downloads/${releaseFixture.trackId}/${escapeHtml(downloadOption.fileName)}" download="${escapeHtml(downloadOption.fileName)}" type="${escapeHtml(downloadOption.contentType)}">${escapeHtml(downloadOption.label)}</a>`
             )
             .join("\n")
         : `<p data-testid="bandcamp-paid-message">Paid checkout required for this release.</p>`;

--- a/src/features/providers/bandcamp.test.ts
+++ b/src/features/providers/bandcamp.test.ts
@@ -245,7 +245,7 @@ describe("createBandcampProvider", () => {
   );
 
   it(
-    "acquires the preferred entitled download when Bandcamp omits fixture-only download selectors",
+    "finds and acquires the preferred entitled download through a Bandcamp download page without fixture-only selectors",
     async () => {
       const workspaceRoot = await mkdtemp(
         path.join(os.tmpdir(), "music-downloader-bandcamp-provider-production-selectors-")
@@ -278,8 +278,10 @@ describe("createBandcampProvider", () => {
               }
             ],
             durationSeconds: 392,
+            downloadPagePath: "/download/warehouse-tool-production-selectors",
             entitlement: "owned",
             includeDownloadTestId: false,
+            includeReleaseEntitlementTestHooks: false,
             path: "/album/warehouse-tool-production-selectors",
             title: "Warehouse Tool (Extended Mix)",
             trackId: "bandcamp-track-112"
@@ -563,10 +565,12 @@ type DownloadOptionFixture = {
 
 type ReleaseFixture = {
   artistName: string;
+  downloadPagePath?: string;
   downloadOptions: DownloadOptionFixture[];
   durationSeconds: number;
   entitlement: ReleaseEntitlement;
   includeDownloadTestId?: boolean;
+  includeReleaseEntitlementTestHooks?: boolean;
   path: string;
   title: string;
   trackId: string;
@@ -661,18 +665,24 @@ function handleFixtureRequest(
     const host = request.headers.host ?? "127.0.0.1";
     const releaseUrl = `http://${host}${releaseFixture.path}`;
     const downloadMarkup =
-      releaseFixture.downloadOptions.length > 0
-        ? releaseFixture.downloadOptions
-            .map(
-              (downloadOption) =>
-                `<a${
-                  releaseFixture.includeDownloadTestId === false
-                    ? ""
-                    : ' data-testid="bandcamp-download-link"'
-                } data-entitlement="${releaseFixture.entitlement}" data-format-key="${escapeHtml(downloadOption.formatKey)}" href="/downloads/${releaseFixture.trackId}/${escapeHtml(downloadOption.fileName)}" download="${escapeHtml(downloadOption.fileName)}" type="${escapeHtml(downloadOption.contentType)}">${escapeHtml(downloadOption.label)}</a>`
-            )
-            .join("\n")
+      releaseFixture.downloadOptions.length > 0 && !releaseFixture.downloadPagePath
+        ? renderDownloadLinks(releaseFixture)
         : `<p data-testid="bandcamp-paid-message">Paid checkout required for this release.</p>`;
+    const releaseDownloadMarkup =
+      releaseFixture.downloadOptions.length > 0 && releaseFixture.downloadPagePath
+        ? `<a data-entitlement="${escapeHtml(releaseFixture.entitlement)}" href="${escapeHtml(releaseFixture.downloadPagePath)}">Download</a>`
+        : downloadMarkup;
+    const releaseRootAttributes =
+      releaseFixture.includeReleaseEntitlementTestHooks === false
+        ? ""
+        : `
+      data-testid="bandcamp-release"
+      data-bandcamp-entitlement="${escapeHtml(releaseFixture.entitlement)}"`;
+    const releaseEntitlementMarkup =
+      releaseFixture.includeReleaseEntitlementTestHooks === false
+        ? ""
+        : `
+      <p data-testid="bandcamp-entitlement">${escapeHtml(releaseFixture.entitlement)}</p>`;
 
     response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
     response.end(`<!doctype html>
@@ -697,15 +707,32 @@ function handleFixtureRequest(
     })}</script>
   </head>
   <body>
-    <main
-      data-testid="bandcamp-release"
-      data-bandcamp-entitlement="${escapeHtml(releaseFixture.entitlement)}"
-    >
+    <main${releaseRootAttributes}>
       <h1>${escapeHtml(releaseFixture.title)}</h1>
       <p data-testid="bandcamp-artist-name">${escapeHtml(releaseFixture.artistName)}</p>
-      <p data-testid="bandcamp-entitlement">${escapeHtml(releaseFixture.entitlement)}</p>
+      ${releaseEntitlementMarkup}
       <section data-testid="bandcamp-downloads">
-        ${downloadMarkup}
+        ${releaseDownloadMarkup}
+      </section>
+    </main>
+  </body>
+</html>`);
+
+    return;
+  }
+
+  const downloadPageFixture = [...releaseFixtures.values()].find(
+    (fixture) => fixture.downloadPagePath === requestUrl.pathname
+  );
+
+  if (downloadPageFixture) {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(`<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      <section data-testid="bandcamp-downloads">
+        ${renderDownloadLinks(downloadPageFixture)}
       </section>
     </main>
   </body>
@@ -771,4 +798,17 @@ function escapeHtml(value: string) {
     .replaceAll("\"", "&quot;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;");
+}
+
+function renderDownloadLinks(releaseFixture: ReleaseFixture) {
+  return releaseFixture.downloadOptions
+    .map(
+      (downloadOption) =>
+        `<a${
+          releaseFixture.includeDownloadTestId === false
+            ? ""
+            : ' data-testid="bandcamp-download-link"'
+        } data-entitlement="${releaseFixture.entitlement}" data-format-key="${escapeHtml(downloadOption.formatKey)}" href="/downloads/${releaseFixture.trackId}/${escapeHtml(downloadOption.fileName)}" download="${escapeHtml(downloadOption.fileName)}" type="${escapeHtml(downloadOption.contentType)}">${escapeHtml(downloadOption.label)}</a>`
+    )
+    .join("\n");
 }

--- a/src/features/providers/bandcamp.test.ts
+++ b/src/features/providers/bandcamp.test.ts
@@ -1,0 +1,677 @@
+/* @vitest-environment node */
+
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { BrowserSessionService } from "@/features/browser/browser-session-service";
+import { matchTrackCandidates } from "@/features/matching/track-matcher";
+import { canonicalizeTrack } from "@/features/tracks/canonical-track";
+
+import {
+  ProviderRegistry,
+  buildProviderMissResult,
+  buildProviderRejectedResult,
+  defineAutomaticProvider,
+  defineReviewQueueProvider,
+  type ProviderCandidate
+} from "./provider-registry";
+import {
+  BANDCAMP_PROVIDER_ID,
+  BANDCAMP_PROVIDER_NAME,
+  BANDCAMP_SESSION_NAME,
+  createBandcampProvider
+} from "./bandcamp";
+
+describe("createBandcampProvider", () => {
+  it("registers with the research-mandated metadata and deterministic provider order", () => {
+    const registry = new ProviderRegistry([
+      defineReviewQueueProvider({
+        id: "beatport",
+        displayName: "Beatport",
+        authorizationBasis: "purchase-entitlement",
+        priorityRank: 90,
+        supportedFormats: ["mp3", "wav", "aiff"],
+        search: async () =>
+          buildProviderMissResult({
+            detail: "No Beatport candidate queued yet.",
+            providerId: "beatport",
+            providerName: "Beatport",
+            reason: "no-search-results",
+            trackMissReason: "no-authorized-source-match"
+          }),
+        queueForReview: async ({ candidate }) => ({
+          outcome: "queued-for-review",
+          candidate,
+          review: {
+            queueName: "beatport-review",
+            summary: "Queued for later operator approval."
+          }
+        })
+      }),
+      defineAutomaticProvider({
+        id: "soundcloud-direct-downloads",
+        displayName: "SoundCloud Direct Downloads",
+        authorizationBasis: "uploader-enabled-download",
+        priceTier: "free",
+        priorityRank: 10,
+        supportedFormats: ["original-upload-format"],
+        search: async () =>
+          buildProviderMissResult({
+            detail: "No SoundCloud direct download is available for the requested track.",
+            providerId: "soundcloud-direct-downloads",
+            providerName: "SoundCloud Direct Downloads",
+            reason: "no-authorized-candidate",
+            trackMissReason: "no-authorized-source-match"
+          }),
+        acquire: async ({ candidate }) =>
+          buildProviderRejectedResult({
+            candidate,
+            detail: "Fixture provider does not acquire assets in this test.",
+            providerId: "soundcloud-direct-downloads",
+            providerName: "SoundCloud Direct Downloads",
+            reason: "provider-error"
+          })
+      }),
+      createBandcampProvider({
+        browserSessionService: createUnusedBrowserSessionService()
+      })
+    ]);
+
+    expect(registry.list().map((provider) => provider.id)).toEqual([
+      "soundcloud-direct-downloads",
+      BANDCAMP_PROVIDER_ID,
+      "beatport"
+    ]);
+
+    const provider = registry.get(BANDCAMP_PROVIDER_ID);
+
+    expect(provider).toEqual(
+      expect.objectContaining({
+        authorizationBasis: "rights-holder-storefront",
+        displayName: BANDCAMP_PROVIDER_NAME,
+        id: BANDCAMP_PROVIDER_ID,
+        implementationBucket: "free-auto",
+        mode: "automatic",
+        priceTier: "free-or-owned",
+        priorityRank: 20,
+        supportedFormats: ["mp3", "wav", "aiff", "flac", "aac", "ogg-vorbis", "alac"]
+      })
+    );
+  });
+
+  it(
+    "returns an entitled candidate and acquires the preferred Bandcamp download with normalized metadata",
+    async () => {
+      const workspaceRoot = await mkdtemp(
+        path.join(os.tmpdir(), "music-downloader-bandcamp-provider-")
+      );
+      const fixtureServer = await startBandcampFixtureServer({
+        releases: [
+          {
+            artistName: "DJ Sealer",
+            downloadOptions: [
+              {
+                body: "mp3 v0 fixture payload\n",
+                contentType: "audio/mpeg",
+                fileName: "warehouse-tool--v0.mp3",
+                formatKey: "mp3-v0",
+                label: "MP3 V0"
+              },
+              {
+                body: "mp3 320 fixture payload\n",
+                contentType: "audio/mpeg",
+                fileName: "warehouse-tool--320.mp3",
+                formatKey: "mp3-320",
+                label: "MP3 320"
+              },
+              {
+                body: "wav fixture payload\n",
+                contentType: "audio/wav",
+                fileName: "warehouse-tool.wav",
+                formatKey: "wav",
+                label: "WAV"
+              },
+              {
+                body: "flac fixture payload\n",
+                contentType: "audio/flac",
+                fileName: "warehouse-tool.flac",
+                formatKey: "flac",
+                label: "FLAC"
+              }
+            ],
+            durationSeconds: 392,
+            entitlement: "owned",
+            path: "/album/warehouse-tool-extended-mix",
+            title: "Warehouse Tool (Extended Mix)",
+            trackId: "bandcamp-track-111"
+          }
+        ],
+        searchResults: ["/album/warehouse-tool-extended-mix"]
+      });
+      const browserSessionService = new BrowserSessionService({ workspaceRoot });
+      const provider = createBandcampProvider({
+        baseUrl: fixtureServer.origin,
+        browserSessionService
+      });
+
+      try {
+        await seedAuthenticatedSession(browserSessionService);
+        const track = canonicalizeTrack({
+          artistName: "DJ Sealer",
+          source: "spotify",
+          title: "Warehouse Tool (Extended Mix)"
+        });
+
+        const searchResult = await provider.search({ track });
+
+        expect(searchResult).toEqual({
+          outcome: "candidates",
+          candidates: [
+            {
+              artistName: "DJ Sealer",
+              authorizationBasis: "rights-holder-storefront",
+              availableFormats: ["mp3", "wav", "flac"],
+              candidateId: "bandcamp-track-111",
+              durationSeconds: 392,
+              mixConfidence: "high",
+              mixLabel: "Extended Mix",
+              priceTier: "free-or-owned",
+              providerId: BANDCAMP_PROVIDER_ID,
+              providerName: BANDCAMP_PROVIDER_NAME,
+              provenance: {
+                discoveredVia: "search",
+                providerTrackId: "bandcamp-track-111",
+                providerUrl: `${fixtureServer.origin}/album/warehouse-tool-extended-mix`,
+                searchQuery: "DJ Sealer Warehouse Tool Extended Mix",
+                sourcePageUrl: `${fixtureServer.origin}/album/warehouse-tool-extended-mix`
+              },
+              title: "Warehouse Tool"
+            }
+          ]
+        });
+
+        if (searchResult.outcome !== "candidates") {
+          throw new Error("Expected Bandcamp search to produce a candidate.");
+        }
+
+        expect(
+          matchTrackCandidates({
+            candidates: searchResult.candidates,
+            track
+          })
+        ).toMatchObject({
+          outcome: "selected",
+          rejected: [],
+          selected: {
+            candidate: {
+              candidateId: "bandcamp-track-111"
+            },
+            reason: "accepted-extended-mix",
+            selectedFormat: "mp3"
+          }
+        });
+
+        const acquisition = await provider.acquire({
+          candidate: searchResult.candidates[0],
+          track
+        });
+
+        expect(acquisition).toEqual({
+          outcome: "acquired",
+          candidate: searchResult.candidates[0],
+          artifact: {
+            contentType: "audio/mpeg",
+            fileExtension: "mp3",
+            fileName: "warehouse-tool--320.mp3",
+            format: "mp3",
+            sha256: createHash("sha256")
+              .update("mp3 320 fixture payload\n")
+              .digest("hex"),
+            sizeBytes: Buffer.byteLength("mp3 320 fixture payload\n")
+          }
+        });
+      } finally {
+        await browserSessionService.shutdown();
+        await fixtureServer.close();
+        await rm(workspaceRoot, { force: true, recursive: true });
+      }
+    },
+    15_000
+  );
+
+  it("returns a structured miss when the matching release still requires payment", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-bandcamp-provider-paid-")
+    );
+    const fixtureServer = await startBandcampFixtureServer({
+      releases: [
+        {
+          artistName: "DJ Sealer",
+          downloadOptions: [],
+          durationSeconds: 392,
+          entitlement: "paid-only",
+          path: "/album/warehouse-tool-extended-mix",
+          title: "Warehouse Tool (Extended Mix)",
+          trackId: "bandcamp-track-111"
+        }
+      ],
+      searchResults: ["/album/warehouse-tool-extended-mix"]
+    });
+    const browserSessionService = new BrowserSessionService({ workspaceRoot });
+    const provider = createBandcampProvider({
+      baseUrl: fixtureServer.origin,
+      browserSessionService
+    });
+
+    try {
+      await seedAuthenticatedSession(browserSessionService);
+
+      const searchResult = await provider.search({
+        track: canonicalizeTrack({
+          artistName: "DJ Sealer",
+          source: "spotify",
+          title: "Warehouse Tool (Extended Mix)"
+        })
+      });
+
+      expect(searchResult).toEqual({
+        outcome: "miss",
+        miss: expect.objectContaining({
+          providerId: BANDCAMP_PROVIDER_ID,
+          providerName: BANDCAMP_PROVIDER_NAME,
+          reason: "no-authorized-candidate",
+          trackMissReason: "no-authorized-source-match"
+        })
+      });
+
+      if (searchResult.outcome !== "miss") {
+        throw new Error("Expected a Bandcamp provider miss for a paid-only release.");
+      }
+
+      expect(searchResult.miss.detail).toMatch(/paid checkout|free-or-owned/i);
+    } finally {
+      await browserSessionService.shutdown();
+      await fixtureServer.close();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects acquisition when a candidate is no longer entitled for download", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-bandcamp-provider-entitlement-")
+    );
+    const fixtureServer = await startBandcampFixtureServer({
+      releases: [
+        {
+          artistName: "DJ Sealer",
+          downloadOptions: [],
+          durationSeconds: 392,
+          entitlement: "paid-only",
+          path: "/album/warehouse-tool-extended-mix",
+          title: "Warehouse Tool (Extended Mix)",
+          trackId: "bandcamp-track-111"
+        }
+      ],
+      searchResults: ["/album/warehouse-tool-extended-mix"]
+    });
+    const browserSessionService = new BrowserSessionService({ workspaceRoot });
+    const provider = createBandcampProvider({
+      baseUrl: fixtureServer.origin,
+      browserSessionService
+    });
+    const track = canonicalizeTrack({
+      artistName: "DJ Sealer",
+      source: "spotify",
+      title: "Warehouse Tool (Extended Mix)"
+    });
+    const candidate: ProviderCandidate = {
+      artistName: "DJ Sealer",
+      authorizationBasis: "rights-holder-storefront",
+      availableFormats: ["mp3", "wav"],
+      candidateId: "bandcamp-track-111",
+      durationSeconds: 392,
+      mixConfidence: "high",
+      mixLabel: "Extended Mix",
+      priceTier: "free-or-owned",
+      providerId: BANDCAMP_PROVIDER_ID,
+      providerName: BANDCAMP_PROVIDER_NAME,
+      provenance: {
+        discoveredVia: "search",
+        providerTrackId: "bandcamp-track-111",
+        providerUrl: `${fixtureServer.origin}/album/warehouse-tool-extended-mix`,
+        searchQuery: "DJ Sealer Warehouse Tool Extended Mix",
+        sourcePageUrl: `${fixtureServer.origin}/album/warehouse-tool-extended-mix`
+      },
+      title: "Warehouse Tool"
+    };
+
+    try {
+      await seedAuthenticatedSession(browserSessionService);
+
+      await expect(provider.acquire({ candidate, track })).resolves.toEqual({
+        outcome: "rejected",
+        candidate,
+        rejection: {
+          detail:
+            "Bandcamp candidate is no longer entitled for automatic free-or-owned download acquisition.",
+          providerId: BANDCAMP_PROVIDER_ID,
+          providerName: BANDCAMP_PROVIDER_NAME,
+          reason: "no-download-entitlement",
+          retryable: false,
+          trackDecisionReason: undefined
+        }
+      });
+    } finally {
+      await browserSessionService.shutdown();
+      await fixtureServer.close();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("maps missing and expired browser sessions to structured rejections", async () => {
+    const missingWorkspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-bandcamp-provider-auth-")
+    );
+    const expiredWorkspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-bandcamp-provider-expired-")
+    );
+    const fixtureServer = await startBandcampFixtureServer({
+      releases: [],
+      searchResults: []
+    });
+    const missingBrowserSessionService = new BrowserSessionService({
+      workspaceRoot: missingWorkspaceRoot
+    });
+    const expiredBrowserSessionService = new BrowserSessionService({
+      workspaceRoot: expiredWorkspaceRoot
+    });
+
+    try {
+      const expiredSession = await expiredBrowserSessionService.openSession({
+        sessionName: BANDCAMP_SESSION_NAME,
+        authState: {
+          expiredAt: "2026-03-31T05:00:00.000Z",
+          providerId: BANDCAMP_PROVIDER_ID,
+          reason: "fixture session expired",
+          status: "expired"
+        }
+      });
+      await expiredSession.close();
+
+      const track = canonicalizeTrack({
+        artistName: "DJ Sealer",
+        source: "spotify",
+        title: "Warehouse Tool (Extended Mix)"
+      });
+
+      await expect(
+        createBandcampProvider({
+          baseUrl: fixtureServer.origin,
+          browserSessionService: missingBrowserSessionService
+        }).search({ track })
+      ).resolves.toEqual({
+        outcome: "rejected",
+        rejection: {
+          detail:
+            "An authenticated Bandcamp browser session is required before automatic downloads can run.",
+          providerId: BANDCAMP_PROVIDER_ID,
+          providerName: BANDCAMP_PROVIDER_NAME,
+          reason: "auth-required",
+          retryable: true,
+          trackDecisionReason: undefined
+        }
+      });
+
+      await expect(
+        createBandcampProvider({
+          baseUrl: fixtureServer.origin,
+          browserSessionService: expiredBrowserSessionService
+        }).search({ track })
+      ).resolves.toEqual({
+        outcome: "rejected",
+        rejection: {
+          detail:
+            "The Bandcamp browser session expired and must be refreshed before automatic downloads can run.",
+          providerId: BANDCAMP_PROVIDER_ID,
+          providerName: BANDCAMP_PROVIDER_NAME,
+          reason: "provider-session-expired",
+          retryable: true,
+          trackDecisionReason: undefined
+        }
+      });
+    } finally {
+      await missingBrowserSessionService.shutdown();
+      await expiredBrowserSessionService.shutdown();
+      await fixtureServer.close();
+      await rm(missingWorkspaceRoot, { force: true, recursive: true });
+      await rm(expiredWorkspaceRoot, { force: true, recursive: true });
+    }
+  });
+});
+
+type ReleaseEntitlement =
+  | "free"
+  | "no-minimum"
+  | "redeemable"
+  | "owned"
+  | "paid-only";
+
+type DownloadOptionFixture = {
+  body: string;
+  contentType: string;
+  fileName: string;
+  formatKey: string;
+  label: string;
+};
+
+type ReleaseFixture = {
+  artistName: string;
+  downloadOptions: DownloadOptionFixture[];
+  durationSeconds: number;
+  entitlement: ReleaseEntitlement;
+  path: string;
+  title: string;
+  trackId: string;
+};
+
+async function seedAuthenticatedSession(browserSessionService: BrowserSessionService) {
+  const session = await browserSessionService.openSession({
+    sessionName: BANDCAMP_SESSION_NAME,
+    authState: {
+      authenticatedAt: "2026-03-31T05:00:00.000Z",
+      providerId: BANDCAMP_PROVIDER_ID,
+      status: "authenticated"
+    }
+  });
+
+  await session.close();
+}
+
+function createUnusedBrowserSessionService() {
+  return {
+    async openSession() {
+      throw new Error("Browser sessions should not be opened in registration tests.");
+    },
+    async requireAuthenticatedSession() {
+      throw new Error(
+        "Authenticated browser sessions should not be required in registration tests."
+      );
+    }
+  };
+}
+
+async function startBandcampFixtureServer(input: {
+  releases: ReleaseFixture[];
+  searchResults: string[];
+}) {
+  const releaseFixtures = new Map(input.releases.map((release) => [release.path, release]));
+  const server = createServer((request, response) =>
+    handleFixtureRequest(request, response, input.searchResults, releaseFixtures)
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+
+  if (address === null || typeof address === "string") {
+    throw new Error("Fixture server did not expose a TCP address.");
+  }
+
+  const origin = `http://127.0.0.1:${address.port}`;
+
+  return {
+    close: () => closeFixtureServer(server),
+    origin
+  };
+}
+
+function handleFixtureRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  searchResults: string[],
+  releaseFixtures: Map<string, ReleaseFixture>
+) {
+  const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+  const releaseFixture = releaseFixtures.get(requestUrl.pathname);
+
+  if (requestUrl.pathname === "/search") {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(`<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      ${searchResults
+        .map(
+          (resultPath) =>
+            `<article><a data-testid="bandcamp-search-result" href="${resultPath}">${resultPath}</a></article>`
+        )
+        .join("\n")}
+    </main>
+  </body>
+</html>`);
+
+    return;
+  }
+
+  if (releaseFixture) {
+    const host = request.headers.host ?? "127.0.0.1";
+    const releaseUrl = `http://${host}${releaseFixture.path}`;
+    const downloadMarkup =
+      releaseFixture.downloadOptions.length > 0
+        ? releaseFixture.downloadOptions
+            .map(
+              (downloadOption) =>
+                `<a data-testid="bandcamp-download-link" data-entitlement="${releaseFixture.entitlement}" data-format-key="${escapeHtml(downloadOption.formatKey)}" href="/downloads/${releaseFixture.trackId}/${escapeHtml(downloadOption.fileName)}" download="${escapeHtml(downloadOption.fileName)}" type="${escapeHtml(downloadOption.contentType)}">${escapeHtml(downloadOption.label)}</a>`
+            )
+            .join("\n")
+        : `<p data-testid="bandcamp-paid-message">Paid checkout required for this release.</p>`;
+
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta property="og:title" content="${escapeHtml(releaseFixture.title)}" />
+    <meta property="og:url" content="${escapeHtml(releaseUrl)}" />
+    <meta name="bandcamp:artist_name" content="${escapeHtml(releaseFixture.artistName)}" />
+    <meta name="bandcamp:track_id" content="${escapeHtml(releaseFixture.trackId)}" />
+    <meta name="bandcamp:duration_seconds" content="${releaseFixture.durationSeconds}" />
+    <script type="application/ld+json">${JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "MusicRecording",
+      byArtist: {
+        "@type": "MusicGroup",
+        name: releaseFixture.artistName
+      },
+      duration: toIsoDuration(releaseFixture.durationSeconds),
+      identifier: releaseFixture.trackId,
+      name: releaseFixture.title,
+      url: releaseUrl
+    })}</script>
+  </head>
+  <body>
+    <main
+      data-testid="bandcamp-release"
+      data-bandcamp-entitlement="${escapeHtml(releaseFixture.entitlement)}"
+    >
+      <h1>${escapeHtml(releaseFixture.title)}</h1>
+      <p data-testid="bandcamp-artist-name">${escapeHtml(releaseFixture.artistName)}</p>
+      <p data-testid="bandcamp-entitlement">${escapeHtml(releaseFixture.entitlement)}</p>
+      <section data-testid="bandcamp-downloads">
+        ${downloadMarkup}
+      </section>
+    </main>
+  </body>
+</html>`);
+
+    return;
+  }
+
+  const downloadMatch = requestUrl.pathname.match(/^\/downloads\/([^/]+)\/(.+)$/);
+
+  if (downloadMatch) {
+    const [, trackId, fileName] = downloadMatch;
+    const matchingFixture = [...releaseFixtures.values()].find(
+      (fixture) =>
+        fixture.trackId === trackId &&
+        fixture.downloadOptions.some((downloadOption) => downloadOption.fileName === fileName)
+    );
+
+    if (matchingFixture) {
+      const downloadOption = matchingFixture.downloadOptions.find(
+        (option) => option.fileName === fileName
+      );
+
+      if (downloadOption) {
+        response.writeHead(200, {
+          "content-disposition": `attachment; filename="${downloadOption.fileName}"`,
+          "content-type": downloadOption.contentType
+        });
+        response.end(downloadOption.body);
+
+        return;
+      }
+    }
+  }
+
+  response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+  response.end("Not found");
+}
+
+async function closeFixtureServer(server: Server) {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function toIsoDuration(durationSeconds: number) {
+  const minutes = Math.floor(durationSeconds / 60);
+  const seconds = durationSeconds % 60;
+
+  return `PT${minutes}M${seconds}S`;
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}

--- a/src/features/providers/bandcamp.ts
+++ b/src/features/providers/bandcamp.ts
@@ -61,6 +61,7 @@ interface ParsedDownloadOption {
   fileName: string | null;
   formatKey: string | null;
   label: string | null;
+  reacquireSelector: string | null;
 }
 
 interface ParsedReleaseSnapshot {
@@ -284,13 +285,9 @@ async function acquireBandcampDownload(input: {
     const download = await sessionResult.captureDownload({
       trigger: async (page) => {
         const locator =
-          preferredDownload.option.formatKey === null
+          preferredDownload.option.reacquireSelector === null
             ? page.locator(DOWNLOAD_LINK_SELECTOR).first()
-            : page
-                .locator(
-                  `[data-testid="bandcamp-download-link"][data-format-key="${preferredDownload.option.formatKey}"]`
-                )
-                .first();
+            : page.locator(preferredDownload.option.reacquireSelector).first();
 
         await locator.click();
       }
@@ -429,7 +426,8 @@ async function parseReleaseSnapshot(page: Page): Promise<ParsedReleaseSnapshot> 
           contentType: element.getAttribute("type"),
           fileName: readAuthorizedDownloadFileName(element),
           formatKey: element.getAttribute("data-format-key")?.trim() || null,
-          label: element.textContent?.trim() || null
+          label: element.textContent?.trim() || null,
+          reacquireSelector: buildAuthorizedDownloadSelector(element)
         };
       })
       .filter((option): option is NonNullable<typeof option> => option !== null);
@@ -533,6 +531,30 @@ async function parseReleaseSnapshot(page: Page): Promise<ParsedReleaseSnapshot> 
       } catch {
         return null;
       }
+    }
+
+    function buildAuthorizedDownloadSelector(anchor: HTMLAnchorElement) {
+      const selectorParts = ["a"];
+      const explicitFileName = anchor.getAttribute("download");
+      const formatKey = anchor.getAttribute("data-format-key")?.trim();
+      const href = anchor.getAttribute("href")?.trim();
+
+      if (explicitFileName !== null) {
+        const trimmedFileName = explicitFileName.trim();
+        selectorParts.push(
+          trimmedFileName ? `[download="${CSS.escape(trimmedFileName)}"]` : "[download]"
+        );
+      }
+
+      if (formatKey) {
+        selectorParts.push(`[data-format-key="${CSS.escape(formatKey)}"]`);
+      }
+
+      if (href) {
+        selectorParts.push(`[href="${CSS.escape(href)}"]`);
+      }
+
+      return selectorParts.length > 1 ? selectorParts.join("") : null;
     }
 
     function readMetaValue(name: string) {

--- a/src/features/providers/bandcamp.ts
+++ b/src/features/providers/bandcamp.ts
@@ -37,6 +37,10 @@ const DOWNLOAD_LINK_SELECTOR = [
   'a[download][data-format-key]',
   'a[download][href*="/download"]'
 ].join(", ");
+const DOWNLOAD_PAGE_LINK_SELECTOR = [
+  'a[data-entitlement][href*="/download"]:not([download])',
+  'a[href*="/download"]:not([download])'
+].join(", ");
 
 type BandcampEntitlement =
   | "free"
@@ -72,6 +76,10 @@ interface ParsedReleaseSnapshot {
   providerTrackId: string | null;
   providerUrl: string;
   title: string | null;
+}
+
+interface ParsedBandcampPageSnapshot extends ParsedReleaseSnapshot {
+  downloadPageUrl: string | null;
 }
 
 type RankedDownloadFormat = Exclude<ProviderArtifactFormat, "unknown">;
@@ -390,305 +398,395 @@ async function readSearchResultUrls(page: Page) {
 }
 
 async function parseReleaseSnapshot(page: Page): Promise<ParsedReleaseSnapshot> {
-  return page.evaluate((downloadLinkSelector) => {
-    const recording = readMusicRecordingStructuredData();
-    const artistName =
-      readMetaValue("bandcamp:artist_name") ??
-      readTextContent('[data-testid="bandcamp-artist-name"]') ??
-      readMusicRecordingArtistName(recording) ??
-      null;
-    const title =
-      readMusicRecordingTextField(recording, "name") ??
-      readMetaValue("og:title") ??
-      readHeadingText() ??
-      null;
-    const providerTrackId =
-      readMusicRecordingTextField(recording, "identifier") ??
-      readMetaValue("bandcamp:track_id") ??
-      null;
-    const providerUrl =
-      readMusicRecordingTextField(recording, "url") ??
-      readMetaValue("og:url") ??
-      window.location.href;
-    const durationSeconds =
-      parseNumber(readMetaValue("bandcamp:duration_seconds")) ??
-      parseIsoDurationSeconds(readMusicRecordingTextField(recording, "duration"));
-    const entitlement = normalizeEntitlement(
-      readBandcampEntitlement() ?? readPaidOnlyMessage() ?? null
-    );
-    const downloadOptions = [...document.querySelectorAll(downloadLinkSelector)]
-      .map((element) => {
-        if (!(element instanceof HTMLAnchorElement)) {
+  const releasePageSnapshot = await readBandcampPageSnapshot(page);
+
+  if (
+    releasePageSnapshot.downloadOptions.length > 0 ||
+    releasePageSnapshot.downloadPageUrl === null
+  ) {
+    return toReleaseSnapshot(releasePageSnapshot);
+  }
+
+  await page.goto(releasePageSnapshot.downloadPageUrl, { waitUntil: "load" });
+  const downloadPageSnapshot = await readBandcampPageSnapshot(page);
+
+  return {
+    ...toReleaseSnapshot(releasePageSnapshot),
+    downloadOptions: downloadPageSnapshot.downloadOptions,
+    entitlement: mergeEntitlement(
+      releasePageSnapshot.entitlement,
+      downloadPageSnapshot.entitlement
+    )
+  };
+}
+
+async function readBandcampPageSnapshot(page: Page): Promise<ParsedBandcampPageSnapshot> {
+  return page.evaluate(
+    ({ downloadLinkSelector, downloadPageLinkSelector }) => {
+      const recording = readMusicRecordingStructuredData();
+      const artistName =
+        readMetaValue("bandcamp:artist_name") ??
+        readTextContent('[data-testid="bandcamp-artist-name"]') ??
+        readMusicRecordingArtistName(recording) ??
+        null;
+      const title =
+        readMusicRecordingTextField(recording, "name") ??
+        readMetaValue("og:title") ??
+        readHeadingText() ??
+        null;
+      const providerTrackId =
+        readMusicRecordingTextField(recording, "identifier") ??
+        readMetaValue("bandcamp:track_id") ??
+        null;
+      const providerUrl =
+        readMusicRecordingTextField(recording, "url") ??
+        readMetaValue("og:url") ??
+        window.location.href;
+      const durationSeconds =
+        parseNumber(readMetaValue("bandcamp:duration_seconds")) ??
+        parseIsoDurationSeconds(readMusicRecordingTextField(recording, "duration"));
+      const entitlement = normalizeEntitlement(
+        readBandcampEntitlement() ?? readPaidOnlyMessage() ?? null
+      );
+      const downloadOptions = [...document.querySelectorAll(downloadLinkSelector)]
+        .map((element) => {
+          if (!(element instanceof HTMLAnchorElement)) {
+            return null;
+          }
+
+          return {
+            contentType: element.getAttribute("type"),
+            fileName: readAuthorizedDownloadFileName(element),
+            formatKey: element.getAttribute("data-format-key")?.trim() || null,
+            label: element.textContent?.trim() || null,
+            reacquireSelector: buildAuthorizedDownloadSelector(element)
+          };
+        })
+        .filter((option): option is NonNullable<typeof option> => option !== null);
+      const downloadPageUrl = readDownloadPageUrl();
+
+      return {
+        artistName,
+        downloadOptions,
+        downloadPageUrl,
+        durationSeconds,
+        entitlement,
+        providerTrackId,
+        providerUrl,
+        title
+      };
+
+      function readBandcampEntitlement() {
+        const releaseRoot = document.querySelector('[data-testid="bandcamp-release"]');
+        const datasetValue =
+          releaseRoot?.getAttribute("data-bandcamp-entitlement")?.trim() ?? null;
+
+        if (datasetValue) {
+          return datasetValue;
+        }
+
+        const explicitEntitlement = readTextContent('[data-testid="bandcamp-entitlement"]');
+
+        if (explicitEntitlement) {
+          return explicitEntitlement;
+        }
+
+        for (const element of document.querySelectorAll("[data-entitlement]")) {
+          const value = element.getAttribute("data-entitlement")?.trim();
+
+          if (value) {
+            return value;
+          }
+        }
+
+        return null;
+      }
+
+      function readPaidOnlyMessage() {
+        return readTextContent('[data-testid="bandcamp-paid-message"]');
+      }
+
+      function readDownloadPageUrl() {
+        const link = document.querySelector(downloadPageLinkSelector);
+
+        if (!(link instanceof HTMLAnchorElement)) {
           return null;
         }
 
-        return {
-          contentType: element.getAttribute("type"),
-          fileName: readAuthorizedDownloadFileName(element),
-          formatKey: element.getAttribute("data-format-key")?.trim() || null,
-          label: element.textContent?.trim() || null,
-          reacquireSelector: buildAuthorizedDownloadSelector(element)
-        };
-      })
-      .filter((option): option is NonNullable<typeof option> => option !== null);
+        const href = link.getAttribute("href");
 
-    return {
-      artistName,
-      downloadOptions,
-      durationSeconds,
-      entitlement,
-      providerTrackId,
-      providerUrl,
-      title
-    };
+        if (!href) {
+          return null;
+        }
 
-    function readBandcampEntitlement() {
-      const releaseRoot = document.querySelector('[data-testid="bandcamp-release"]');
-      const datasetValue =
-        releaseRoot?.getAttribute("data-bandcamp-entitlement")?.trim() ?? null;
+        try {
+          return new URL(href, window.location.href).toString();
+        } catch {
+          return null;
+        }
+      }
 
-      return datasetValue ?? readTextContent('[data-testid="bandcamp-entitlement"]');
-    }
+      function readMusicRecordingStructuredData() {
+        for (const script of document.querySelectorAll('script[type="application/ld+json"]')) {
+          const payload = parseJson(script.textContent);
 
-    function readPaidOnlyMessage() {
-      return readTextContent('[data-testid="bandcamp-paid-message"]');
-    }
-
-    function readMusicRecordingStructuredData() {
-      for (const script of document.querySelectorAll('script[type="application/ld+json"]')) {
-        const payload = parseJson(script.textContent);
-
-        for (const candidate of flattenStructuredData(payload)) {
-          if (
-            candidate &&
-            typeof candidate === "object" &&
-            normalizeStructuredDataType((candidate as { "@type"?: unknown })["@type"]) ===
-              "musicrecording"
-          ) {
-            return candidate as Record<string, unknown>;
+          for (const candidate of flattenStructuredData(payload)) {
+            if (
+              candidate &&
+              typeof candidate === "object" &&
+              normalizeStructuredDataType((candidate as { "@type"?: unknown })["@type"]) ===
+                "musicrecording"
+            ) {
+              return candidate as Record<string, unknown>;
+            }
           }
         }
-      }
 
-      return null;
-    }
-
-    function readMusicRecordingArtistName(recording: Record<string, unknown> | null) {
-      if (!recording) {
         return null;
       }
 
-      const byArtist = recording.byArtist;
+      function readMusicRecordingArtistName(recording: Record<string, unknown> | null) {
+        if (!recording) {
+          return null;
+        }
 
-      if (typeof byArtist === "string") {
-        return byArtist.trim() || null;
+        const byArtist = recording.byArtist;
+
+        if (typeof byArtist === "string") {
+          return byArtist.trim() || null;
+        }
+
+        if (byArtist && typeof byArtist === "object") {
+          const name = (byArtist as { name?: unknown }).name;
+
+          if (typeof name === "string") {
+            return name.trim() || null;
+          }
+        }
+
+        return null;
       }
 
-      if (byArtist && typeof byArtist === "object") {
-        const name = (byArtist as { name?: unknown }).name;
+      function readMusicRecordingTextField(
+        recording: Record<string, unknown> | null,
+        field: string
+      ) {
+        if (!recording) {
+          return null;
+        }
 
-        if (typeof name === "string") {
-          return name.trim() || null;
+        const value = recording[field];
+
+        if (typeof value === "string") {
+          const trimmedValue = value.trim();
+          return trimmedValue || null;
+        }
+
+        if (typeof value === "number") {
+          return String(value);
+        }
+
+        return null;
+      }
+
+      function readAuthorizedDownloadFileName(anchor: HTMLAnchorElement) {
+        const explicitFileName = anchor.getAttribute("download")?.trim();
+
+        if (explicitFileName) {
+          return explicitFileName;
+        }
+
+        try {
+          const href = new URL(anchor.href, window.location.href);
+          const fileName = href.pathname.split("/").pop()?.trim();
+          return fileName || null;
+        } catch {
+          return null;
         }
       }
 
-      return null;
-    }
+      function buildAuthorizedDownloadSelector(anchor: HTMLAnchorElement) {
+        const selectorParts = ["a"];
+        const explicitFileName = anchor.getAttribute("download");
+        const formatKey = anchor.getAttribute("data-format-key")?.trim();
+        const href = anchor.getAttribute("href")?.trim();
 
-    function readMusicRecordingTextField(
-      recording: Record<string, unknown> | null,
-      field: string
-    ) {
-      if (!recording) {
-        return null;
+        if (explicitFileName !== null) {
+          const trimmedFileName = explicitFileName.trim();
+          selectorParts.push(
+            trimmedFileName ? `[download="${CSS.escape(trimmedFileName)}"]` : "[download]"
+          );
+        }
+
+        if (formatKey) {
+          selectorParts.push(`[data-format-key="${CSS.escape(formatKey)}"]`);
+        }
+
+        if (href) {
+          selectorParts.push(`[href="${CSS.escape(href)}"]`);
+        }
+
+        return selectorParts.length > 1 ? selectorParts.join("") : null;
       }
 
-      const value = recording[field];
+      function readMetaValue(name: string) {
+        const meta =
+          document.querySelector(`meta[name="${name}"]`) ??
+          document.querySelector(`meta[property="${name}"]`);
 
-      if (typeof value === "string") {
-        const trimmedValue = value.trim();
-        return trimmedValue || null;
+        if (!(meta instanceof HTMLMetaElement)) {
+          return null;
+        }
+
+        const content = meta.content.trim();
+        return content || null;
       }
 
-      if (typeof value === "number") {
-        return String(value);
+      function readTextContent(selector: string) {
+        const element = document.querySelector(selector);
+        const text = element?.textContent?.trim() ?? null;
+        return text || null;
       }
 
-      return null;
-    }
-
-    function readAuthorizedDownloadFileName(anchor: HTMLAnchorElement) {
-      const explicitFileName = anchor.getAttribute("download")?.trim();
-
-      if (explicitFileName) {
-        return explicitFileName;
+      function readHeadingText() {
+        const heading = document.querySelector("h1");
+        const text = heading?.textContent?.trim() ?? null;
+        return text || null;
       }
 
-      try {
-        const href = new URL(anchor.href, window.location.href);
-        const fileName = href.pathname.split("/").pop()?.trim();
-        return fileName || null;
-      } catch {
-        return null;
-      }
-    }
+      function flattenStructuredData(payload: unknown): unknown[] {
+        if (!payload) {
+          return [];
+        }
 
-    function buildAuthorizedDownloadSelector(anchor: HTMLAnchorElement) {
-      const selectorParts = ["a"];
-      const explicitFileName = anchor.getAttribute("download");
-      const formatKey = anchor.getAttribute("data-format-key")?.trim();
-      const href = anchor.getAttribute("href")?.trim();
+        if (Array.isArray(payload)) {
+          return payload.flatMap((entry) => flattenStructuredData(entry));
+        }
 
-      if (explicitFileName !== null) {
-        const trimmedFileName = explicitFileName.trim();
-        selectorParts.push(
-          trimmedFileName ? `[download="${CSS.escape(trimmedFileName)}"]` : "[download]"
-        );
-      }
+        if (typeof payload === "object") {
+          const graph = (payload as { "@graph"?: unknown })["@graph"];
 
-      if (formatKey) {
-        selectorParts.push(`[data-format-key="${CSS.escape(formatKey)}"]`);
-      }
+          if (Array.isArray(graph)) {
+            return [payload, ...graph.flatMap((entry) => flattenStructuredData(entry))];
+          }
 
-      if (href) {
-        selectorParts.push(`[href="${CSS.escape(href)}"]`);
-      }
+          return [payload];
+        }
 
-      return selectorParts.length > 1 ? selectorParts.join("") : null;
-    }
-
-    function readMetaValue(name: string) {
-      const meta =
-        document.querySelector(`meta[name="${name}"]`) ??
-        document.querySelector(`meta[property="${name}"]`);
-
-      if (!(meta instanceof HTMLMetaElement)) {
-        return null;
-      }
-
-      const content = meta.content.trim();
-      return content || null;
-    }
-
-    function readTextContent(selector: string) {
-      const element = document.querySelector(selector);
-      const text = element?.textContent?.trim() ?? null;
-      return text || null;
-    }
-
-    function readHeadingText() {
-      const heading = document.querySelector("h1");
-      const text = heading?.textContent?.trim() ?? null;
-      return text || null;
-    }
-
-    function flattenStructuredData(payload: unknown): unknown[] {
-      if (!payload) {
         return [];
       }
 
-      if (Array.isArray(payload)) {
-        return payload.flatMap((entry) => flattenStructuredData(entry));
-      }
-
-      if (typeof payload === "object") {
-        const graph = (payload as { "@graph"?: unknown })["@graph"];
-
-        if (Array.isArray(graph)) {
-          return [payload, ...graph.flatMap((entry) => flattenStructuredData(entry))];
+      function normalizeStructuredDataType(value: unknown) {
+        if (Array.isArray(value)) {
+          return value.join(" ").toLowerCase();
         }
 
-        return [payload];
+        if (typeof value === "string") {
+          return value.toLowerCase();
+        }
+
+        return "";
       }
 
-      return [];
-    }
+      function parseJson(value: string | null) {
+        if (!value) {
+          return null;
+        }
 
-    function normalizeStructuredDataType(value: unknown) {
-      if (Array.isArray(value)) {
-        return value.join(" ").toLowerCase();
+        try {
+          return JSON.parse(value);
+        } catch {
+          return null;
+        }
       }
 
-      if (typeof value === "string") {
-        return value.toLowerCase();
+      function parseNumber(value: string | null) {
+        if (!value) {
+          return null;
+        }
+
+        const nextValue = Number(value);
+        return Number.isFinite(nextValue) ? Math.round(nextValue) : null;
       }
 
-      return "";
-    }
+      function parseIsoDurationSeconds(value: string | null) {
+        if (!value) {
+          return null;
+        }
 
-    function parseJson(value: string | null) {
-      if (!value) {
-        return null;
+        const match = value.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/i);
+
+        if (!match) {
+          return null;
+        }
+
+        const hours = Number(match[1] ?? 0);
+        const minutes = Number(match[2] ?? 0);
+        const seconds = Number(match[3] ?? 0);
+
+        return hours * 3600 + minutes * 60 + seconds;
       }
 
-      try {
-        return JSON.parse(value);
-      } catch {
-        return null;
-      }
-    }
+      function normalizeEntitlement(value: string | null): BandcampEntitlement {
+        if (!value) {
+          return "unknown";
+        }
 
-    function parseNumber(value: string | null) {
-      if (!value) {
-        return null;
-      }
+        const normalizedValue = value.trim().toLowerCase();
 
-      const nextValue = Number(value);
-      return Number.isFinite(nextValue) ? Math.round(nextValue) : null;
-    }
+        if (normalizedValue.includes("no-minimum")) {
+          return "no-minimum";
+        }
 
-    function parseIsoDurationSeconds(value: string | null) {
-      if (!value) {
-        return null;
-      }
+        if (normalizedValue.includes("redeem")) {
+          return "redeemable";
+        }
 
-      const match = value.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/i);
+        if (normalizedValue.includes("owned")) {
+          return "owned";
+        }
 
-      if (!match) {
-        return null;
-      }
+        if (
+          normalizedValue.includes("paid-only") ||
+          normalizedValue.includes("paid checkout") ||
+          normalizedValue.includes("purchase")
+        ) {
+          return "paid-only";
+        }
 
-      const hours = Number(match[1] ?? 0);
-      const minutes = Number(match[2] ?? 0);
-      const seconds = Number(match[3] ?? 0);
+        if (normalizedValue.includes("free")) {
+          return "free";
+        }
 
-      return hours * 3600 + minutes * 60 + seconds;
-    }
-
-    function normalizeEntitlement(value: string | null): BandcampEntitlement {
-      if (!value) {
         return "unknown";
       }
-
-      const normalizedValue = value.trim().toLowerCase();
-
-      if (normalizedValue.includes("no-minimum")) {
-        return "no-minimum";
-      }
-
-      if (normalizedValue.includes("redeem")) {
-        return "redeemable";
-      }
-
-      if (normalizedValue.includes("owned")) {
-        return "owned";
-      }
-
-      if (
-        normalizedValue.includes("paid-only") ||
-        normalizedValue.includes("paid checkout") ||
-        normalizedValue.includes("purchase")
-      ) {
-        return "paid-only";
-      }
-
-      if (normalizedValue.includes("free")) {
-        return "free";
-      }
-
-      return "unknown";
+    },
+    {
+      downloadLinkSelector: DOWNLOAD_LINK_SELECTOR,
+      downloadPageLinkSelector: DOWNLOAD_PAGE_LINK_SELECTOR
     }
-  }, DOWNLOAD_LINK_SELECTOR);
+  );
+}
+
+function toReleaseSnapshot(snapshot: ParsedBandcampPageSnapshot): ParsedReleaseSnapshot {
+  return {
+    artistName: snapshot.artistName,
+    downloadOptions: snapshot.downloadOptions,
+    durationSeconds: snapshot.durationSeconds,
+    entitlement: snapshot.entitlement,
+    providerTrackId: snapshot.providerTrackId,
+    providerUrl: snapshot.providerUrl,
+    title: snapshot.title
+  };
+}
+
+function mergeEntitlement(
+  releasePageEntitlement: BandcampEntitlement,
+  downloadPageEntitlement: BandcampEntitlement
+): BandcampEntitlement {
+  return releasePageEntitlement === "unknown"
+    ? downloadPageEntitlement
+    : releasePageEntitlement;
 }
 
 function isTrackMatch(track: CanonicalTrack, snapshot: ParsedReleaseSnapshot) {

--- a/src/features/providers/bandcamp.ts
+++ b/src/features/providers/bandcamp.ts
@@ -1,0 +1,1024 @@
+import { createHash } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+import type { Page } from "playwright";
+
+import {
+  BrowserSessionService,
+  ExpiredBrowserSessionAuthStateError,
+  MissingBrowserSessionAuthStateError,
+  MissingBrowserSessionStateError
+} from "@/features/browser/browser-session-service";
+import { canonicalizeTrack, type CanonicalTrack } from "@/features/tracks/canonical-track";
+
+import {
+  buildProviderMissResult,
+  buildProviderRejectedResult,
+  defineAutomaticProvider,
+  type ProviderAcquireInput,
+  type ProviderArtifactFormat,
+  type ProviderCandidate,
+  type ProviderSearchInput
+} from "./provider-registry";
+
+export const BANDCAMP_PROVIDER_ID = "bandcamp";
+export const BANDCAMP_PROVIDER_NAME = "Bandcamp";
+export const BANDCAMP_SESSION_NAME = BANDCAMP_PROVIDER_ID;
+
+const DEFAULT_BANDCAMP_BASE_URL = "https://bandcamp.com";
+const SEARCH_RESULT_LINK_SELECTOR = [
+  '[data-testid="bandcamp-search-result"]',
+  'a[href*="/album/"]',
+  'a[href*="/track/"]'
+].join(", ");
+const DOWNLOAD_LINK_SELECTOR = [
+  '[data-testid="bandcamp-download-link"]',
+  'a[download][data-format-key]',
+  'a[download][href*="/download"]'
+].join(", ");
+
+type BandcampEntitlement =
+  | "free"
+  | "no-minimum"
+  | "redeemable"
+  | "owned"
+  | "paid-only"
+  | "unknown";
+
+interface BandcampProviderDependencies {
+  baseUrl?: string;
+  browserSessionService: Pick<
+    BrowserSessionService,
+    "openSession" | "requireAuthenticatedSession"
+  >;
+  maxSearchResults?: number;
+  sessionName?: string;
+}
+
+interface ParsedDownloadOption {
+  contentType: string | null;
+  fileName: string | null;
+  formatKey: string | null;
+  label: string | null;
+}
+
+interface ParsedReleaseSnapshot {
+  artistName: string | null;
+  downloadOptions: ParsedDownloadOption[];
+  durationSeconds: number | null;
+  entitlement: BandcampEntitlement;
+  providerTrackId: string | null;
+  providerUrl: string;
+  title: string | null;
+}
+
+type RankedDownloadFormat = Exclude<ProviderArtifactFormat, "unknown">;
+
+interface RankedDownloadOption {
+  format: RankedDownloadFormat;
+  option: ParsedDownloadOption;
+}
+
+export function createBandcampProvider(
+  dependencies: BandcampProviderDependencies
+) {
+  const baseUrl = dependencies.baseUrl ?? DEFAULT_BANDCAMP_BASE_URL;
+  const maxSearchResults = dependencies.maxSearchResults ?? 5;
+  const sessionName = dependencies.sessionName ?? BANDCAMP_SESSION_NAME;
+
+  return defineAutomaticProvider({
+    id: BANDCAMP_PROVIDER_ID,
+    displayName: BANDCAMP_PROVIDER_NAME,
+    authorizationBasis: "rights-holder-storefront",
+    priceTier: "free-or-owned",
+    priorityRank: 20,
+    supportedFormats: ["mp3", "wav", "aiff", "flac", "aac", "ogg-vorbis", "alac"],
+    search: async (input) =>
+      searchBandcamp({
+        baseUrl,
+        browserSessionService: dependencies.browserSessionService,
+        input,
+        maxSearchResults,
+        sessionName
+      }),
+    acquire: async (input) =>
+      acquireBandcampDownload({
+        browserSessionService: dependencies.browserSessionService,
+        input,
+        sessionName
+      })
+  });
+}
+
+async function searchBandcamp(input: {
+  baseUrl: string;
+  browserSessionService: BandcampProviderDependencies["browserSessionService"];
+  input: ProviderSearchInput;
+  maxSearchResults: number;
+  sessionName: string;
+}) {
+  const sessionResult = await openAuthenticatedSession(
+    input.browserSessionService,
+    input.sessionName
+  );
+
+  if ("outcome" in sessionResult) {
+    return sessionResult;
+  }
+
+  const searchQuery = buildSearchQuery(input.input.track);
+
+  try {
+    return await sessionResult.withPage(async (page) => {
+      await page.goto(buildSearchUrl(input.baseUrl, searchQuery), { waitUntil: "load" });
+
+      const releaseUrls = (await readSearchResultUrls(page)).slice(0, input.maxSearchResults);
+
+      if (releaseUrls.length === 0) {
+        return buildProviderMissResult({
+          detail: "No Bandcamp releases matched the requested artist/title search query.",
+          providerId: BANDCAMP_PROVIDER_ID,
+          providerName: BANDCAMP_PROVIDER_NAME,
+          reason: "no-search-results",
+          trackMissReason: "no-authorized-source-match"
+        });
+      }
+
+      const candidates: ProviderCandidate[] = [];
+      let unavailableFormatDetail: string | null = null;
+      let unauthorizedDetail: string | null = null;
+
+      for (const releaseUrl of releaseUrls) {
+        await page.goto(releaseUrl, { waitUntil: "load" });
+        const snapshot = await parseReleaseSnapshot(page);
+
+        if (!isTrackMatch(input.input.track, snapshot)) {
+          continue;
+        }
+
+        if (!isAutoAcquirableEntitlement(snapshot.entitlement)) {
+          unauthorizedDetail = buildUnauthorizedDetail(snapshot.entitlement);
+          continue;
+        }
+
+        const availableFormats = resolveCandidateAvailableFormats(snapshot.downloadOptions);
+
+        if (availableFormats.length === 0) {
+          unavailableFormatDetail = buildUnavailableFormatDetail();
+          continue;
+        }
+
+        candidates.push(buildCandidate(snapshot, searchQuery, availableFormats));
+      }
+
+      if (candidates.length > 0) {
+        return {
+          outcome: "candidates" as const,
+          candidates
+        };
+      }
+
+      if (unauthorizedDetail) {
+        return buildProviderMissResult({
+          detail: unauthorizedDetail,
+          providerId: BANDCAMP_PROVIDER_ID,
+          providerName: BANDCAMP_PROVIDER_NAME,
+          reason: "no-authorized-candidate",
+          trackMissReason: "no-authorized-source-match"
+        });
+      }
+
+      if (unavailableFormatDetail) {
+        return buildProviderMissResult({
+          detail: unavailableFormatDetail,
+          providerId: BANDCAMP_PROVIDER_ID,
+          providerName: BANDCAMP_PROVIDER_NAME,
+          reason: "no-authorized-candidate",
+          trackMissReason: "no-authorized-source-match"
+        });
+      }
+
+      return buildProviderMissResult({
+        detail:
+          "Bandcamp search results did not contain an exact artist/title match for the requested track.",
+        providerId: BANDCAMP_PROVIDER_ID,
+        providerName: BANDCAMP_PROVIDER_NAME,
+        reason: "no-search-results",
+        trackMissReason: "no-authorized-source-match"
+      });
+    });
+  } catch (error) {
+    return buildProviderRejectedResult({
+      detail: buildProviderErrorDetail(
+        "Bandcamp search failed while checking free-or-owned download entitlements.",
+        error
+      ),
+      providerId: BANDCAMP_PROVIDER_ID,
+      providerName: BANDCAMP_PROVIDER_NAME,
+      reason: "provider-error"
+    });
+  } finally {
+    await sessionResult.close();
+  }
+}
+
+async function acquireBandcampDownload(input: {
+  browserSessionService: BandcampProviderDependencies["browserSessionService"];
+  input: ProviderAcquireInput;
+  sessionName: string;
+}) {
+  const sessionResult = await openAuthenticatedSession(
+    input.browserSessionService,
+    input.sessionName
+  );
+
+  if ("outcome" in sessionResult) {
+    return sessionResult;
+  }
+
+  const releaseUrl =
+    input.input.candidate.provenance.providerUrl ??
+    input.input.candidate.provenance.sourcePageUrl;
+
+  if (!releaseUrl) {
+    return buildProviderRejectedResult({
+      candidate: input.input.candidate,
+      detail: "Bandcamp candidate was missing the release URL required for download.",
+      providerId: BANDCAMP_PROVIDER_ID,
+      providerName: BANDCAMP_PROVIDER_NAME,
+      reason: "download-artifact-missing"
+    });
+  }
+
+  try {
+    const snapshot = await sessionResult.withPage(async (page) => {
+      await page.goto(releaseUrl, { waitUntil: "load" });
+      return parseReleaseSnapshot(page);
+    });
+
+    if (!isAutoAcquirableEntitlement(snapshot.entitlement)) {
+      return buildProviderRejectedResult({
+        candidate: input.input.candidate,
+        detail:
+          "Bandcamp candidate is no longer entitled for automatic free-or-owned download acquisition.",
+        providerId: BANDCAMP_PROVIDER_ID,
+        providerName: BANDCAMP_PROVIDER_NAME,
+        reason: "no-download-entitlement"
+      });
+    }
+
+    const preferredDownload = selectPreferredDownloadOption(snapshot.downloadOptions);
+
+    if (!preferredDownload) {
+      return buildProviderRejectedResult({
+        candidate: input.input.candidate,
+        detail:
+          "Bandcamp release exposed an entitled download, but none of the download formats mapped to the shared provider contract.",
+        providerId: BANDCAMP_PROVIDER_ID,
+        providerName: BANDCAMP_PROVIDER_NAME,
+        reason: "candidate-format-unavailable"
+      });
+    }
+
+    const download = await sessionResult.captureDownload({
+      trigger: async (page) => {
+        const locator =
+          preferredDownload.option.formatKey === null
+            ? page.locator(DOWNLOAD_LINK_SELECTOR).first()
+            : page
+                .locator(
+                  `[data-testid="bandcamp-download-link"][data-format-key="${preferredDownload.option.formatKey}"]`
+                )
+                .first();
+
+        await locator.click();
+      }
+    });
+    const artifact = await buildArtifactMetadata(
+      download.path,
+      download.suggestedFilename,
+      preferredDownload.option.contentType
+    );
+
+    return {
+      outcome: "acquired" as const,
+      artifact,
+      candidate: input.input.candidate
+    };
+  } catch (error) {
+    return buildProviderRejectedResult({
+      candidate: input.input.candidate,
+      detail: buildProviderErrorDetail(
+        "Bandcamp acquisition failed while downloading an entitled release.",
+        error
+      ),
+      providerId: BANDCAMP_PROVIDER_ID,
+      providerName: BANDCAMP_PROVIDER_NAME,
+      reason: "provider-error"
+    });
+  } finally {
+    await sessionResult.close();
+  }
+}
+
+async function openAuthenticatedSession(
+  browserSessionService: BandcampProviderDependencies["browserSessionService"],
+  sessionName: string
+) {
+  try {
+    await browserSessionService.requireAuthenticatedSession(sessionName);
+  } catch (error) {
+    if (
+      error instanceof MissingBrowserSessionStateError ||
+      error instanceof MissingBrowserSessionAuthStateError
+    ) {
+      return buildProviderRejectedResult({
+        detail:
+          "An authenticated Bandcamp browser session is required before automatic downloads can run.",
+        providerId: BANDCAMP_PROVIDER_ID,
+        providerName: BANDCAMP_PROVIDER_NAME,
+        reason: "auth-required"
+      });
+    }
+
+    if (error instanceof ExpiredBrowserSessionAuthStateError) {
+      return buildProviderRejectedResult({
+        detail:
+          "The Bandcamp browser session expired and must be refreshed before automatic downloads can run.",
+        providerId: BANDCAMP_PROVIDER_ID,
+        providerName: BANDCAMP_PROVIDER_NAME,
+        reason: "provider-session-expired"
+      });
+    }
+
+    throw error;
+  }
+
+  return browserSessionService.openSession({ sessionName });
+}
+
+function buildSearchQuery(track: CanonicalTrack) {
+  return [track.primaryArtist, track.title, track.mix.displayLabel]
+    .filter((value): value is string => Boolean(value))
+    .join(" ");
+}
+
+function buildSearchUrl(baseUrl: string, query: string) {
+  const url = new URL("/search", baseUrl);
+  url.searchParams.set("q", query);
+  return url.toString();
+}
+
+async function readSearchResultUrls(page: Page) {
+  return page.evaluate((selector) => {
+    const urls = new Set<string>();
+
+    for (const element of document.querySelectorAll(selector)) {
+      if (!(element instanceof HTMLAnchorElement)) {
+        continue;
+      }
+
+      const href = element.getAttribute("href");
+
+      if (!href) {
+        continue;
+      }
+
+      urls.add(new URL(href, window.location.href).toString());
+    }
+
+    return [...urls];
+  }, SEARCH_RESULT_LINK_SELECTOR);
+}
+
+async function parseReleaseSnapshot(page: Page): Promise<ParsedReleaseSnapshot> {
+  return page.evaluate((downloadLinkSelector) => {
+    const recording = readMusicRecordingStructuredData();
+    const artistName =
+      readMetaValue("bandcamp:artist_name") ??
+      readTextContent('[data-testid="bandcamp-artist-name"]') ??
+      readMusicRecordingArtistName(recording) ??
+      null;
+    const title =
+      readMusicRecordingTextField(recording, "name") ??
+      readMetaValue("og:title") ??
+      readHeadingText() ??
+      null;
+    const providerTrackId =
+      readMusicRecordingTextField(recording, "identifier") ??
+      readMetaValue("bandcamp:track_id") ??
+      null;
+    const providerUrl =
+      readMusicRecordingTextField(recording, "url") ??
+      readMetaValue("og:url") ??
+      window.location.href;
+    const durationSeconds =
+      parseNumber(readMetaValue("bandcamp:duration_seconds")) ??
+      parseIsoDurationSeconds(readMusicRecordingTextField(recording, "duration"));
+    const entitlement = normalizeEntitlement(
+      readBandcampEntitlement() ?? readPaidOnlyMessage() ?? null
+    );
+    const downloadOptions = [...document.querySelectorAll(downloadLinkSelector)]
+      .map((element) => {
+        if (!(element instanceof HTMLAnchorElement)) {
+          return null;
+        }
+
+        return {
+          contentType: element.getAttribute("type"),
+          fileName: readAuthorizedDownloadFileName(element),
+          formatKey: element.getAttribute("data-format-key")?.trim() || null,
+          label: element.textContent?.trim() || null
+        };
+      })
+      .filter((option): option is NonNullable<typeof option> => option !== null);
+
+    return {
+      artistName,
+      downloadOptions,
+      durationSeconds,
+      entitlement,
+      providerTrackId,
+      providerUrl,
+      title
+    };
+
+    function readBandcampEntitlement() {
+      const releaseRoot = document.querySelector('[data-testid="bandcamp-release"]');
+      const datasetValue =
+        releaseRoot?.getAttribute("data-bandcamp-entitlement")?.trim() ?? null;
+
+      return datasetValue ?? readTextContent('[data-testid="bandcamp-entitlement"]');
+    }
+
+    function readPaidOnlyMessage() {
+      return readTextContent('[data-testid="bandcamp-paid-message"]');
+    }
+
+    function readMusicRecordingStructuredData() {
+      for (const script of document.querySelectorAll('script[type="application/ld+json"]')) {
+        const payload = parseJson(script.textContent);
+
+        for (const candidate of flattenStructuredData(payload)) {
+          if (
+            candidate &&
+            typeof candidate === "object" &&
+            normalizeStructuredDataType((candidate as { "@type"?: unknown })["@type"]) ===
+              "musicrecording"
+          ) {
+            return candidate as Record<string, unknown>;
+          }
+        }
+      }
+
+      return null;
+    }
+
+    function readMusicRecordingArtistName(recording: Record<string, unknown> | null) {
+      if (!recording) {
+        return null;
+      }
+
+      const byArtist = recording.byArtist;
+
+      if (typeof byArtist === "string") {
+        return byArtist.trim() || null;
+      }
+
+      if (byArtist && typeof byArtist === "object") {
+        const name = (byArtist as { name?: unknown }).name;
+
+        if (typeof name === "string") {
+          return name.trim() || null;
+        }
+      }
+
+      return null;
+    }
+
+    function readMusicRecordingTextField(
+      recording: Record<string, unknown> | null,
+      field: string
+    ) {
+      if (!recording) {
+        return null;
+      }
+
+      const value = recording[field];
+
+      if (typeof value === "string") {
+        const trimmedValue = value.trim();
+        return trimmedValue || null;
+      }
+
+      if (typeof value === "number") {
+        return String(value);
+      }
+
+      return null;
+    }
+
+    function readAuthorizedDownloadFileName(anchor: HTMLAnchorElement) {
+      const explicitFileName = anchor.getAttribute("download")?.trim();
+
+      if (explicitFileName) {
+        return explicitFileName;
+      }
+
+      try {
+        const href = new URL(anchor.href, window.location.href);
+        const fileName = href.pathname.split("/").pop()?.trim();
+        return fileName || null;
+      } catch {
+        return null;
+      }
+    }
+
+    function readMetaValue(name: string) {
+      const meta =
+        document.querySelector(`meta[name="${name}"]`) ??
+        document.querySelector(`meta[property="${name}"]`);
+
+      if (!(meta instanceof HTMLMetaElement)) {
+        return null;
+      }
+
+      const content = meta.content.trim();
+      return content || null;
+    }
+
+    function readTextContent(selector: string) {
+      const element = document.querySelector(selector);
+      const text = element?.textContent?.trim() ?? null;
+      return text || null;
+    }
+
+    function readHeadingText() {
+      const heading = document.querySelector("h1");
+      const text = heading?.textContent?.trim() ?? null;
+      return text || null;
+    }
+
+    function flattenStructuredData(payload: unknown): unknown[] {
+      if (!payload) {
+        return [];
+      }
+
+      if (Array.isArray(payload)) {
+        return payload.flatMap((entry) => flattenStructuredData(entry));
+      }
+
+      if (typeof payload === "object") {
+        const graph = (payload as { "@graph"?: unknown })["@graph"];
+
+        if (Array.isArray(graph)) {
+          return [payload, ...graph.flatMap((entry) => flattenStructuredData(entry))];
+        }
+
+        return [payload];
+      }
+
+      return [];
+    }
+
+    function normalizeStructuredDataType(value: unknown) {
+      if (Array.isArray(value)) {
+        return value.join(" ").toLowerCase();
+      }
+
+      if (typeof value === "string") {
+        return value.toLowerCase();
+      }
+
+      return "";
+    }
+
+    function parseJson(value: string | null) {
+      if (!value) {
+        return null;
+      }
+
+      try {
+        return JSON.parse(value);
+      } catch {
+        return null;
+      }
+    }
+
+    function parseNumber(value: string | null) {
+      if (!value) {
+        return null;
+      }
+
+      const nextValue = Number(value);
+      return Number.isFinite(nextValue) ? Math.round(nextValue) : null;
+    }
+
+    function parseIsoDurationSeconds(value: string | null) {
+      if (!value) {
+        return null;
+      }
+
+      const match = value.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/i);
+
+      if (!match) {
+        return null;
+      }
+
+      const hours = Number(match[1] ?? 0);
+      const minutes = Number(match[2] ?? 0);
+      const seconds = Number(match[3] ?? 0);
+
+      return hours * 3600 + minutes * 60 + seconds;
+    }
+
+    function normalizeEntitlement(value: string | null): BandcampEntitlement {
+      if (!value) {
+        return "unknown";
+      }
+
+      const normalizedValue = value.trim().toLowerCase();
+
+      if (normalizedValue.includes("no-minimum")) {
+        return "no-minimum";
+      }
+
+      if (normalizedValue.includes("redeem")) {
+        return "redeemable";
+      }
+
+      if (normalizedValue.includes("owned")) {
+        return "owned";
+      }
+
+      if (
+        normalizedValue.includes("paid-only") ||
+        normalizedValue.includes("paid checkout") ||
+        normalizedValue.includes("purchase")
+      ) {
+        return "paid-only";
+      }
+
+      if (normalizedValue.includes("free")) {
+        return "free";
+      }
+
+      return "unknown";
+    }
+  }, DOWNLOAD_LINK_SELECTOR);
+}
+
+function isTrackMatch(track: CanonicalTrack, snapshot: ParsedReleaseSnapshot) {
+  if (!snapshot.artistName || !snapshot.title) {
+    return false;
+  }
+
+  const candidateTrack = canonicalizeTrack({
+    artistName: snapshot.artistName,
+    duration: snapshot.durationSeconds,
+    source: BANDCAMP_PROVIDER_ID,
+    sourceTrackId: snapshot.providerTrackId ?? undefined,
+    sourceUrl: snapshot.providerUrl,
+    title: snapshot.title
+  });
+
+  if (candidateTrack.normalizedTitle !== track.normalizedTitle) {
+    return false;
+  }
+
+  if (
+    track.primaryArtist &&
+    candidateTrack.primaryArtist &&
+    normalizeSearchText(candidateTrack.primaryArtist) !==
+      normalizeSearchText(track.primaryArtist)
+  ) {
+    return false;
+  }
+
+  if (track.mix.normalizedLabel) {
+    return candidateTrack.mix.normalizedLabel === track.mix.normalizedLabel;
+  }
+
+  return true;
+}
+
+function isAutoAcquirableEntitlement(entitlement: BandcampEntitlement) {
+  return (
+    entitlement === "free" ||
+    entitlement === "no-minimum" ||
+    entitlement === "redeemable" ||
+    entitlement === "owned"
+  );
+}
+
+function buildCandidate(
+  snapshot: ParsedReleaseSnapshot,
+  searchQuery: string,
+  availableFormats: readonly ProviderArtifactFormat[]
+): ProviderCandidate {
+  const candidateTrack = canonicalizeTrack({
+    artistName: snapshot.artistName ?? "",
+    duration: snapshot.durationSeconds,
+    source: BANDCAMP_PROVIDER_ID,
+    sourceTrackId: snapshot.providerTrackId ?? undefined,
+    sourceUrl: snapshot.providerUrl,
+    title: snapshot.title ?? ""
+  });
+
+  return {
+    artistName: candidateTrack.primaryArtist ?? snapshot.artistName ?? "Unknown Artist",
+    authorizationBasis: "rights-holder-storefront",
+    availableFormats,
+    candidateId: snapshot.providerTrackId ?? snapshot.providerUrl,
+    durationSeconds: snapshot.durationSeconds,
+    mixConfidence: candidateTrack.mix.confidence,
+    mixLabel: candidateTrack.mix.displayLabel,
+    priceTier: "free-or-owned",
+    providerId: BANDCAMP_PROVIDER_ID,
+    providerName: BANDCAMP_PROVIDER_NAME,
+    provenance: {
+      discoveredVia: "search",
+      providerTrackId: snapshot.providerTrackId ?? undefined,
+      providerUrl: snapshot.providerUrl,
+      searchQuery,
+      sourcePageUrl: snapshot.providerUrl
+    },
+    title: candidateTrack.title
+  };
+}
+
+function resolveCandidateAvailableFormats(downloadOptions: readonly ParsedDownloadOption[]) {
+  const availableFormats = new Set<ProviderArtifactFormat>();
+
+  for (const option of downloadOptions) {
+    const format = inferBandcampFormat(option);
+
+    if (format !== "unknown") {
+      availableFormats.add(format);
+    }
+  }
+
+  return BANDCAMP_FORMAT_ORDER.filter((format) => availableFormats.has(format));
+}
+
+function selectPreferredDownloadOption(
+  downloadOptions: readonly ParsedDownloadOption[]
+): RankedDownloadOption | null {
+  const rankedOptions = downloadOptions
+    .map((option) => {
+      const format = inferBandcampFormat(option);
+
+      if (format === "unknown") {
+        return null;
+      }
+
+      return {
+        format,
+        option
+      };
+    })
+    .filter((option): option is RankedDownloadOption => option !== null)
+    .sort(compareDownloadOptions);
+
+  return rankedOptions[0] ?? null;
+}
+
+function compareDownloadOptions(left: RankedDownloadOption, right: RankedDownloadOption) {
+  const formatDifference =
+    DOWNLOAD_PREFERENCE_ORDER[left.format] - DOWNLOAD_PREFERENCE_ORDER[right.format];
+
+  if (formatDifference !== 0) {
+    return formatDifference;
+  }
+
+  const variantDifference =
+    resolveMp3VariantRank(left.option.formatKey) - resolveMp3VariantRank(right.option.formatKey);
+
+  if (variantDifference !== 0) {
+    return variantDifference;
+  }
+
+  return (left.option.fileName ?? "").localeCompare(right.option.fileName ?? "");
+}
+
+function resolveMp3VariantRank(formatKey: string | null) {
+  switch (normalizeSearchText(formatKey ?? "")) {
+    case "mp3 320":
+      return 0;
+    case "mp3 v0":
+      return 1;
+    case "mp3":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+function inferBandcampFormat(option: ParsedDownloadOption): ProviderArtifactFormat {
+  const normalizedKey = normalizeSearchText(option.formatKey ?? option.label ?? "");
+
+  switch (normalizedKey) {
+    case "mp3 v0":
+    case "mp3 320":
+    case "mp3":
+      return "mp3";
+    case "wav":
+      return "wav";
+    case "aif":
+    case "aiff":
+      return "aiff";
+    case "flac":
+      return "flac";
+    case "aac":
+      return "aac";
+    case "ogg":
+    case "oga":
+    case "ogg vorbis":
+    case "vorbis":
+      return "ogg-vorbis";
+    case "alac":
+      return "alac";
+    default:
+      return inferArtifactFormat(
+        normalizeFileExtension(option.fileName ?? ""),
+        option.contentType
+      );
+  }
+}
+
+function buildUnauthorizedDetail(entitlement: BandcampEntitlement) {
+  if (entitlement === "paid-only") {
+    return (
+      "Matched Bandcamp release still requires a paid checkout and is outside the current " +
+      "free-or-owned acquisition scope."
+    );
+  }
+
+  return (
+    "Matched Bandcamp release did not expose a free, no-minimum, redeemable, or already-owned " +
+    "download entitlement for automatic acquisition."
+  );
+}
+
+function buildUnavailableFormatDetail() {
+  return (
+    "Matched Bandcamp release exposed an entitled download, but none of the advertised formats " +
+    "mapped to the shared provider contract."
+  );
+}
+
+async function buildArtifactMetadata(
+  downloadPath: string,
+  suggestedFilename: string,
+  contentType: string | null
+) {
+  const normalizedContentType =
+    normalizeContentType(contentType) ?? inferContentType(suggestedFilename);
+  const fileBuffer = await readFile(downloadPath);
+  const fileStats = await stat(downloadPath);
+  const fileExtension = normalizeFileExtension(suggestedFilename);
+
+  return {
+    contentType: normalizedContentType,
+    fileExtension,
+    fileName: suggestedFilename,
+    format: inferArtifactFormat(fileExtension, normalizedContentType),
+    sha256: createHash("sha256").update(fileBuffer).digest("hex"),
+    sizeBytes: fileStats.size
+  };
+}
+
+function normalizeFileExtension(fileName: string) {
+  const extension = path.extname(fileName).replace(/^\./, "").trim().toLowerCase();
+  return extension || null;
+}
+
+function inferArtifactFormat(
+  fileExtension: string | null,
+  contentType: string | null
+): ProviderArtifactFormat {
+  switch (fileExtension) {
+    case "mp3":
+      return "mp3";
+    case "wav":
+      return "wav";
+    case "aif":
+    case "aiff":
+      return "aiff";
+    case "flac":
+      return "flac";
+    case "aac":
+      return "aac";
+    case "ogg":
+    case "oga":
+      return "ogg-vorbis";
+    case "m4a":
+      return normalizedContentTypeIs(contentType, "audio/alac") ? "alac" : "aac";
+    default:
+      return inferArtifactFormatFromContentType(contentType);
+  }
+}
+
+function inferArtifactFormatFromContentType(
+  contentType: string | null
+): ProviderArtifactFormat {
+  switch (normalizeContentType(contentType)) {
+    case "audio/mpeg":
+    case "audio/mp3":
+      return "mp3";
+    case "audio/wav":
+    case "audio/wave":
+    case "audio/x-wav":
+      return "wav";
+    case "audio/aiff":
+    case "audio/x-aiff":
+      return "aiff";
+    case "audio/flac":
+    case "audio/x-flac":
+      return "flac";
+    case "audio/aac":
+    case "audio/x-aac":
+    case "audio/mp4":
+      return "aac";
+    case "audio/ogg":
+    case "audio/vorbis":
+    case "application/ogg":
+      return "ogg-vorbis";
+    case "audio/alac":
+      return "alac";
+    default:
+      return "unknown";
+  }
+}
+
+function normalizeContentType(contentType: string | null) {
+  const normalizedContentType = contentType?.trim().toLowerCase();
+  return normalizedContentType || null;
+}
+
+function inferContentType(fileName: string) {
+  switch (normalizeFileExtension(fileName)) {
+    case "mp3":
+      return "audio/mpeg";
+    case "wav":
+      return "audio/wav";
+    case "aif":
+    case "aiff":
+      return "audio/aiff";
+    case "flac":
+      return "audio/flac";
+    case "aac":
+      return "audio/aac";
+    case "m4a":
+      return "audio/mp4";
+    case "ogg":
+    case "oga":
+      return "audio/ogg";
+    default:
+      return null;
+  }
+}
+
+function normalizedContentTypeIs(contentType: string | null, expected: string) {
+  return normalizeContentType(contentType) === expected;
+}
+
+function buildProviderErrorDetail(message: string, error: unknown) {
+  if (error instanceof Error && error.message) {
+    return `${message} ${error.message}`;
+  }
+
+  return message;
+}
+
+function normalizeSearchText(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+const BANDCAMP_FORMAT_ORDER: readonly ProviderArtifactFormat[] = [
+  "mp3",
+  "wav",
+  "aiff",
+  "flac",
+  "aac",
+  "ogg-vorbis",
+  "alac"
+];
+
+const DOWNLOAD_PREFERENCE_ORDER: Record<ProviderArtifactFormat, number> = {
+  mp3: 0,
+  wav: 1,
+  aiff: 2,
+  flac: 3,
+  aac: 4,
+  "ogg-vorbis": 5,
+  alac: 6,
+  "original-upload-format": 7,
+  unknown: 8
+};


### PR DESCRIPTION
**@worker-02**

## Summary
- add a Bandcamp automatic provider for free, no-minimum, redeemable, and already-owned storefront downloads
- keep paid-only releases out of automatic acquisition with structured misses/rejections instead of adding a second paid queue
- normalize Bandcamp download formats into the shared provider contract, including MP3 variant collapse to `mp3` with exact artifact filenames preserved
- add focused provider tests for registration order, entitled acquisition, paid-only misses, entitlement loss, and missing/expired session handling

## Verification
- `npm test`
- `npm run lint`
- `npm run build`

## Issue
- Refs #47
