### PR TITLE
feat: generate run artifacts locally

### DIFF
--- a/src/app/api/runs/[runId]/artifacts/[artifactKind]/route.ts
+++ b/src/app/api/runs/[runId]/artifacts/[artifactKind]/route.ts
@@ -1,0 +1,80 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { NextResponse } from "next/server";
+
+import {
+  RunArtifactNotFoundError,
+  resolveRunArtifact
+} from "@/features/artifacts/run-artifacts";
+import { type ArtifactKind, getRunStore } from "@/features/runs/run-store";
+
+type RouteContext = {
+  params: Promise<{
+    artifactKind: string;
+    runId: string;
+  }>;
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const { artifactKind, runId } = await context.params;
+  const runStore = getRunStore();
+
+  if (!runStore.getRun(runId)) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+
+  if (!isArtifactKind(artifactKind)) {
+    return NextResponse.json({ error: "Artifact not found" }, { status: 404 });
+  }
+
+  try {
+    const artifact = resolveRunArtifact({
+      artifactKind,
+      runId,
+      runStore
+    });
+    const fileBytes = await readFile(
+      /* turbopackIgnore: true */ artifact.absolutePath
+    );
+
+    return new Response(fileBytes, {
+      headers: {
+        "content-disposition": `attachment; filename="${path.basename(
+          artifact.relativePath
+        )}"`,
+        "content-type": getArtifactContentType(artifact.kind)
+      }
+    });
+  } catch (error) {
+    if (error instanceof RunArtifactNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+
+    throw error;
+  }
+}
+
+function isArtifactKind(value: string): value is ArtifactKind {
+  return (
+    value === "downloads-zip" ||
+    value === "manifest-json" ||
+    value === "misses-txt" ||
+    value === "run-report"
+  );
+}
+
+function getArtifactContentType(kind: ArtifactKind) {
+  switch (kind) {
+    case "downloads-zip":
+      return "application/zip";
+    case "manifest-json":
+      return "application/json; charset=utf-8";
+    case "misses-txt":
+      return "text/plain; charset=utf-8";
+    case "run-report":
+      return "text/html; charset=utf-8";
+    default:
+      return "application/octet-stream";
+  }
+}

--- a/src/app/api/runs/[runId]/artifacts/route.test.ts
+++ b/src/app/api/runs/[runId]/artifacts/route.test.ts
@@ -1,0 +1,194 @@
+/* @vitest-environment node */
+
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+async function withTempWorkspace(callback: (workspaceRoot: string) => Promise<void>) {
+  const workspaceRoot = mkdtempSync(
+    path.join(tmpdir(), "music-downloader-artifact-route-")
+  );
+  const databasePath = path.join(workspaceRoot, "data", "music-downloader.sqlite");
+  const originalDatabasePath = process.env.MUSIC_DOWNLOADER_DB_PATH;
+  const originalWorkspaceRoot = process.env.MUSIC_DOWNLOADER_WORKSPACE_ROOT;
+
+  process.env.MUSIC_DOWNLOADER_DB_PATH = databasePath;
+  process.env.MUSIC_DOWNLOADER_WORKSPACE_ROOT = workspaceRoot;
+
+  try {
+    await callback(workspaceRoot);
+  } finally {
+    const runStoreModule = await import("@/features/runs/run-store");
+
+    runStoreModule.resetRunStoreForTests();
+
+    if (originalDatabasePath === undefined) {
+      delete process.env.MUSIC_DOWNLOADER_DB_PATH;
+    } else {
+      process.env.MUSIC_DOWNLOADER_DB_PATH = originalDatabasePath;
+    }
+
+    if (originalWorkspaceRoot === undefined) {
+      delete process.env.MUSIC_DOWNLOADER_WORKSPACE_ROOT;
+    } else {
+      process.env.MUSIC_DOWNLOADER_WORKSPACE_ROOT = originalWorkspaceRoot;
+    }
+
+    rmSync(workspaceRoot, { force: true, recursive: true });
+  }
+}
+
+function createSha256(buffer: Buffer) {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+describe("/api/runs/[runId]/artifacts", () => {
+  it("generates artifacts and exposes stable download URLs for the run report UI", async () => {
+    await withTempWorkspace(async (workspaceRoot) => {
+      vi.resetModules();
+
+      const [
+        { POST, GET: listArtifacts },
+        { GET: downloadArtifact },
+        runStoreModule,
+        runArtifactsModule
+      ] = await Promise.all([
+        import("./route"),
+        import("./[artifactKind]/route"),
+        import("@/features/runs/run-store"),
+        import("@/features/artifacts/run-artifacts")
+      ]);
+
+      const store = runStoreModule.getRunStore();
+      const run = store.createRun({
+        playlistTitle: "Night Drive",
+        playlistUrl: "https://soundcloud.com/sets/night-drive",
+        sourceType: "soundcloud"
+      });
+      const [track] = store.replaceRunTracks(run.id, [
+        {
+          artist: "Nora En Pure",
+          sourcePosition: 1,
+          title: "Lake Arrowhead",
+          version: "Original Mix"
+        }
+      ]);
+      const acquiredFilePath = path.join(workspaceRoot, "downloads", "lake-arrowhead.mp3");
+      const acquiredFileBody = Buffer.from("fixture download\n", "utf8");
+
+      mkdirSync(path.dirname(acquiredFilePath), { recursive: true });
+      writeFileSync(acquiredFilePath, acquiredFileBody);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+      store.transitionRunStatus(run.id, "packaging");
+      store.updateRunTrackStatus(track.id, "acquired");
+      store.recordAcquisitionAttempt({
+        note: JSON.stringify(
+          runArtifactsModule.buildAcquiredArtifactSourceNote({
+            artifact: {
+              contentType: "audio/mpeg",
+              fileExtension: "mp3",
+              fileName: "lake-arrowhead.mp3",
+              format: "mp3",
+              localFilePath: acquiredFilePath,
+              sha256: createSha256(acquiredFileBody),
+              sizeBytes: acquiredFileBody.length
+            },
+            provider: {
+              authorizationBasis: "uploader-enabled-download",
+              candidateId: "sc-track-201",
+              discoveredVia: "search",
+              priceTier: "free",
+              providerId: "soundcloud-direct-downloads",
+              providerName: "SoundCloud Direct Downloads",
+              providerUrl: "https://soundcloud.com/noraenpure/lake-arrowhead"
+            },
+            selection: {
+              details: "Original Mix matched the approved fallback preference order.",
+              reason: "accepted-original-mix",
+              selectedFormat: "mp3"
+            }
+          })
+        ),
+        outcome: "matched",
+        providerKey: "soundcloud-direct-downloads",
+        runTrackId: track.id
+      });
+
+      const generateResponse = await POST(
+        new Request(`http://localhost/api/runs/${run.id}/artifacts`, {
+          method: "POST"
+        }),
+        {
+          params: Promise.resolve({ runId: run.id })
+        }
+      );
+
+      expect(generateResponse.status).toBe(200);
+
+      const generatedPayload = (await generateResponse.json()) as {
+        artifacts: Array<{
+          downloadUrl: string;
+          kind: string;
+        }>;
+      };
+
+      expect(generatedPayload.artifacts).toEqual([
+        {
+          downloadUrl: `/api/runs/${run.id}/artifacts/downloads-zip`,
+          kind: "downloads-zip"
+        },
+        {
+          downloadUrl: `/api/runs/${run.id}/artifacts/misses-txt`,
+          kind: "misses-txt"
+        },
+        {
+          downloadUrl: `/api/runs/${run.id}/artifacts/manifest-json`,
+          kind: "manifest-json"
+        }
+      ]);
+
+      const listResponse = await listArtifacts(
+        new Request(`http://localhost/api/runs/${run.id}/artifacts`, {
+          method: "GET"
+        }),
+        {
+          params: Promise.resolve({ runId: run.id })
+        }
+      );
+
+      expect(listResponse.status).toBe(200);
+      await expect(listResponse.json()).resolves.toEqual(generatedPayload);
+
+      const manifestResponse = await downloadArtifact(
+        new Request(`http://localhost/api/runs/${run.id}/artifacts/manifest-json`, {
+          method: "GET"
+        }),
+        {
+          params: Promise.resolve({
+            artifactKind: "manifest-json",
+            runId: run.id
+          })
+        }
+      );
+
+      expect(manifestResponse.status).toBe(200);
+      expect(manifestResponse.headers.get("content-type")).toMatch(
+        /application\/json/
+      );
+      await expect(manifestResponse.json()).resolves.toMatchObject({
+        run: {
+          id: run.id,
+          playlistTitle: "Night Drive"
+        },
+        summary: {
+          acquiredCount: 1,
+          missCount: 0,
+          trackCount: 1
+        }
+      });
+    });
+  });
+});

--- a/src/app/api/runs/[runId]/artifacts/route.ts
+++ b/src/app/api/runs/[runId]/artifacts/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+
+import {
+  RunArtifactsNotReadyError,
+  generateRunArtifacts,
+  listRunArtifactDownloads
+} from "@/features/artifacts/run-artifacts";
+import { getRunStore } from "@/features/runs/run-store";
+
+type RouteContext = {
+  params: Promise<{
+    runId: string;
+  }>;
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const { runId } = await context.params;
+  const runStore = getRunStore();
+
+  if (!runStore.getRun(runId)) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    artifacts: listRunArtifactDownloads({
+      runId,
+      runStore
+    })
+  });
+}
+
+export async function POST(_request: Request, context: RouteContext) {
+  const { runId } = await context.params;
+  const runStore = getRunStore();
+
+  if (!runStore.getRun(runId)) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+
+  try {
+    await generateRunArtifacts({
+      runId,
+      runStore
+    });
+  } catch (error) {
+    if (error instanceof RunArtifactsNotReadyError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+
+    throw error;
+  }
+
+  return NextResponse.json({
+    artifacts: listRunArtifactDownloads({
+      runId,
+      runStore
+    })
+  });
+}

--- a/src/features/artifacts/run-artifacts.test.ts
+++ b/src/features/artifacts/run-artifacts.test.ts
@@ -1,0 +1,287 @@
+/* @vitest-environment node */
+
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { createRunStore } from "@/features/runs/run-store";
+
+import {
+  buildAcquiredArtifactSourceNote,
+  buildMissedArtifactSourceNote,
+  generateRunArtifacts
+} from "./run-artifacts";
+
+function createTempWorkspace() {
+  const workspaceRoot = mkdtempSync(
+    path.join(tmpdir(), "music-downloader-run-artifacts-")
+  );
+
+  return {
+    databasePath: path.join(workspaceRoot, "data", "music-downloader.sqlite"),
+    cleanup() {
+      rmSync(workspaceRoot, { force: true, recursive: true });
+    },
+    workspaceRoot
+  };
+}
+
+function createSha256(buffer: Buffer) {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+function readStoredZipEntries(zipFilePath: string) {
+  const bytes = readFileSync(zipFilePath);
+  const entries = new Map<string, Buffer>();
+  let offset = 0;
+
+  while (offset + 4 <= bytes.length) {
+    const signature = bytes.readUInt32LE(offset);
+
+    if (signature === 0x02014b50 || signature === 0x06054b50) {
+      break;
+    }
+
+    if (signature !== 0x04034b50) {
+      throw new Error(`Unexpected ZIP signature ${signature.toString(16)} at ${offset}`);
+    }
+
+    const compressionMethod = bytes.readUInt16LE(offset + 8);
+    const compressedSize = bytes.readUInt32LE(offset + 18);
+    const fileNameLength = bytes.readUInt16LE(offset + 26);
+    const extraFieldLength = bytes.readUInt16LE(offset + 28);
+    const fileName = bytes
+      .subarray(offset + 30, offset + 30 + fileNameLength)
+      .toString("utf8");
+    const fileDataStart = offset + 30 + fileNameLength + extraFieldLength;
+    const fileDataEnd = fileDataStart + compressedSize;
+
+    if (compressionMethod !== 0) {
+      throw new Error(`Expected stored ZIP entry for ${fileName}.`);
+    }
+
+    entries.set(fileName, bytes.subarray(fileDataStart, fileDataEnd));
+    offset = fileDataEnd;
+  }
+
+  return entries;
+}
+
+describe("generateRunArtifacts", () => {
+  it("packages acquired downloads, misses, and manifest metadata from persisted run data", async () => {
+    const tempWorkspace = createTempWorkspace();
+    const store = createRunStore({ databasePath: tempWorkspace.databasePath });
+
+    try {
+      const run = store.createRun({
+        playlistTitle: "Warehouse Drivers",
+        playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+        sourceType: "spotify"
+      });
+      const tracks = store.replaceRunTracks(run.id, [
+        {
+          artist: "DJ Sealer",
+          sourcePosition: 1,
+          title: "Warehouse Tool",
+          version: "Extended Mix"
+        },
+        {
+          artist: "Lane 8",
+          sourcePosition: 2,
+          title: "Little Voices"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+      store.transitionRunStatus(run.id, "packaging");
+
+      const downloadDirectory = path.join(tempWorkspace.workspaceRoot, "downloads");
+      const acquiredFilePath = path.join(downloadDirectory, "warehouse-tool-source.mp3");
+      const acquiredFileBody = Buffer.from("fixture mp3 payload\n", "utf8");
+
+      mkdirSync(downloadDirectory, { recursive: true });
+      writeFileSync(acquiredFilePath, acquiredFileBody);
+
+      store.updateRunTrackStatus(tracks[0].id, "acquired");
+      store.recordAcquisitionAttempt({
+        note: JSON.stringify(
+          buildAcquiredArtifactSourceNote({
+            artifact: {
+              contentType: "audio/mpeg",
+              fileExtension: "mp3",
+              fileName: "warehouse-tool-source.mp3",
+              format: "mp3",
+              localFilePath: acquiredFilePath,
+              sha256: createSha256(acquiredFileBody),
+              sizeBytes: acquiredFileBody.length
+            },
+            provider: {
+              authorizationBasis: "uploader-enabled-download",
+              candidateId: "sc-track-111",
+              discoveredVia: "search",
+              priceTier: "free",
+              providerId: "soundcloud-direct-downloads",
+              providerName: "SoundCloud Direct Downloads",
+              providerUrl:
+                "https://soundcloud.com/dj-sealer/warehouse-tool-extended-mix"
+            },
+            selection: {
+              details: "Extended Mix matched the highest-priority mix preference.",
+              reason: "accepted-extended-mix",
+              selectedFormat: "mp3"
+            }
+          })
+        ),
+        outcome: "matched",
+        providerKey: "soundcloud-direct-downloads",
+        runTrackId: tracks[0].id
+      });
+
+      store.updateRunTrackStatus(tracks[1].id, "missed");
+      store.recordAcquisitionAttempt({
+        note: JSON.stringify(
+          buildMissedArtifactSourceNote({
+            miss: {
+              detail: "No authorized source matched the requested track.",
+              reason: "no-authorized-source-match"
+            }
+          })
+        ),
+        outcome: "missed",
+        providerKey: "track-matcher",
+        runTrackId: tracks[1].id
+      });
+
+      const generated = await generateRunArtifacts({
+        runId: run.id,
+        runStore: store,
+        workspaceRoot: tempWorkspace.workspaceRoot
+      });
+      const regenerated = await generateRunArtifacts({
+        runId: run.id,
+        runStore: store,
+        workspaceRoot: tempWorkspace.workspaceRoot
+      });
+
+      expect(generated.artifacts.map((artifact) => artifact.kind)).toEqual([
+        "downloads-zip",
+        "misses-txt",
+        "manifest-json"
+      ]);
+      expect(generated.artifacts.map((artifact) => artifact.relativePath)).toEqual([
+        `data/runs/${run.id}/artifacts/downloads.zip`,
+        `data/runs/${run.id}/artifacts/misses.txt`,
+        `data/runs/${run.id}/artifacts/manifest.json`
+      ]);
+      expect(regenerated.artifacts.map((artifact) => artifact.relativePath)).toEqual(
+        generated.artifacts.map((artifact) => artifact.relativePath)
+      );
+      expect(store.getRun(run.id)?.artifacts).toHaveLength(3);
+
+      const downloadsZipPath = generated.artifacts.find(
+        (artifact) => artifact.kind === "downloads-zip"
+      )?.absolutePath;
+      const manifestPath = generated.artifacts.find(
+        (artifact) => artifact.kind === "manifest-json"
+      )?.absolutePath;
+      const missesPath = generated.artifacts.find(
+        (artifact) => artifact.kind === "misses-txt"
+      )?.absolutePath;
+
+      expect(downloadsZipPath).toBeDefined();
+      expect(manifestPath).toBeDefined();
+      expect(missesPath).toBeDefined();
+
+      const zipEntries = readStoredZipEntries(downloadsZipPath as string);
+      const manifest = JSON.parse(readFileSync(manifestPath as string, "utf8")) as {
+        run: {
+          id: string;
+          playlistTitle: string | null;
+          sourceType: string;
+        };
+        summary: {
+          acquiredCount: number;
+          missCount: number;
+          trackCount: number;
+        };
+        tracks: Array<{
+          artist: string;
+          miss?: {
+            detail: string;
+            reason: string;
+          } | null;
+          outcome: string;
+          selection?: {
+            artifactFormat: string;
+            providerId: string;
+            zipEntryName: string;
+          } | null;
+          sourcePosition: number;
+          title: string;
+          version: string | null;
+        }>;
+      };
+      const missesText = readFileSync(missesPath as string, "utf8");
+
+      expect([...zipEntries.keys()]).toEqual([
+        "001 - DJ Sealer - Warehouse Tool (Extended Mix).mp3"
+      ]);
+      expect(
+        zipEntries.get("001 - DJ Sealer - Warehouse Tool (Extended Mix).mp3")?.toString(
+          "utf8"
+        )
+      ).toBe(acquiredFileBody.toString("utf8"));
+      expect(missesText).toBe(
+        "002 - Lane 8 - Little Voices :: no-authorized-source-match :: No authorized source matched the requested track.\n"
+      );
+      expect(manifest).toMatchObject({
+        run: {
+          id: run.id,
+          playlistTitle: "Warehouse Drivers",
+          sourceType: "spotify"
+        },
+        summary: {
+          acquiredCount: 1,
+          missCount: 1,
+          trackCount: 2
+        },
+        tracks: [
+          {
+            artist: "DJ Sealer",
+            outcome: "acquired",
+            selection: {
+              artifactFormat: "mp3",
+              providerId: "soundcloud-direct-downloads",
+              zipEntryName: "001 - DJ Sealer - Warehouse Tool (Extended Mix).mp3"
+            },
+            sourcePosition: 1,
+            title: "Warehouse Tool",
+            version: "Extended Mix"
+          },
+          {
+            artist: "Lane 8",
+            miss: {
+              detail: "No authorized source matched the requested track.",
+              reason: "no-authorized-source-match"
+            },
+            outcome: "missed",
+            sourcePosition: 2,
+            title: "Little Voices",
+            version: null
+          }
+        ]
+      });
+    } finally {
+      store.close();
+      tempWorkspace.cleanup();
+    }
+  });
+});

--- a/src/features/artifacts/run-artifacts.ts
+++ b/src/features/artifacts/run-artifacts.ts
@@ -1,0 +1,646 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type {
+  ProviderArtifactFormat,
+  ProviderAuthorizationBasis,
+  ProviderPriceTier,
+  ProviderProvenance
+} from "@/features/providers/provider-registry";
+import {
+  getRunStore,
+  type ArtifactKind,
+  type RecordRunArtifactInput,
+  type RunArtifact,
+  type RunStore,
+  type RunTrack
+} from "@/features/runs/run-store";
+import type {
+  TrackAcceptedDecision,
+  TrackAudioFormat,
+  TrackMissReason
+} from "@/features/tracks/canonical-track";
+
+export const RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA =
+  "run-track-artifact-source.v1";
+
+const RUN_ARTIFACT_KIND_ORDER: ArtifactKind[] = [
+  "downloads-zip",
+  "misses-txt",
+  "manifest-json",
+  "run-report"
+];
+
+type ArtifactSourceNoteSchema =
+  typeof RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA;
+
+type ArtifactSourceProviderDiscovery = ProviderProvenance["discoveredVia"];
+
+export type RunTrackArtifactSourceProvider = {
+  authorizationBasis: ProviderAuthorizationBasis;
+  candidateId?: string | null;
+  discoveredVia?: ArtifactSourceProviderDiscovery;
+  priceTier: ProviderPriceTier;
+  providerId: string;
+  providerName: string;
+  providerUrl?: string | null;
+};
+
+export type RunTrackArtifactSourceSelection = {
+  details: string;
+  reason: TrackAcceptedDecision["reason"];
+  selectedFormat: TrackAudioFormat | null;
+};
+
+export type RunTrackArtifactSourceArtifact = {
+  contentType?: string | null;
+  fileExtension: string | null;
+  fileName: string;
+  format: ProviderArtifactFormat;
+  localFilePath: string;
+  sha256?: string | null;
+  sizeBytes: number | null;
+};
+
+export type RunTrackArtifactSourceMiss = {
+  detail: string;
+  providerId?: string | null;
+  providerName?: string | null;
+  reason: TrackMissReason | string;
+};
+
+export type AcquiredArtifactSourceNote = {
+  artifact: RunTrackArtifactSourceArtifact;
+  outcome: "acquired";
+  provider: RunTrackArtifactSourceProvider;
+  schema: ArtifactSourceNoteSchema;
+  selection: RunTrackArtifactSourceSelection;
+};
+
+export type MissedArtifactSourceNote = {
+  miss: RunTrackArtifactSourceMiss;
+  outcome: "missed";
+  schema: ArtifactSourceNoteSchema;
+};
+
+export type RunTrackArtifactSourceNote =
+  | AcquiredArtifactSourceNote
+  | MissedArtifactSourceNote;
+
+export type GeneratedRunArtifact = {
+  absolutePath: string;
+  kind: Exclude<ArtifactKind, "run-report">;
+  relativePath: string;
+};
+
+export type RunArtifactDownload = {
+  downloadUrl: string;
+  kind: ArtifactKind;
+};
+
+type GenerateRunArtifactsInput = {
+  runId: string;
+  runStore?: RunStore;
+  workspaceRoot?: string;
+};
+
+type ManifestTrackEntry =
+  | {
+      artist: string;
+      miss: null;
+      outcome: "acquired";
+      selection: {
+        artifactFormat: ProviderArtifactFormat;
+        artifactSha256: string | null;
+        artifactSizeBytes: number | null;
+        providerId: string;
+        providerName: string;
+        providerUrl: string | null;
+        selectedFormat: TrackAudioFormat | null;
+        selectedReason: TrackAcceptedDecision["reason"];
+        zipEntryName: string;
+      };
+      sourcePosition: number;
+      title: string;
+      version: string | null;
+    }
+  | {
+      artist: string;
+      miss: RunTrackArtifactSourceMiss;
+      outcome: "missed";
+      selection: null;
+      sourcePosition: number;
+      title: string;
+      version: string | null;
+    };
+
+type RunArtifactsManifest = {
+  generatedAt: string;
+  run: {
+    id: string;
+    playlistTitle: string | null;
+    playlistUrl: string;
+    sourceType: string;
+    status: string;
+  };
+  schemaVersion: 1;
+  summary: {
+    acquiredCount: number;
+    missCount: number;
+    trackCount: number;
+  };
+  tracks: ManifestTrackEntry[];
+};
+
+export class RunArtifactsNotReadyError extends Error {
+  readonly runId: string;
+
+  constructor(runId: string, message: string) {
+    super(message);
+    this.name = "RunArtifactsNotReadyError";
+    this.runId = runId;
+  }
+}
+
+export class RunArtifactNotFoundError extends Error {
+  readonly artifactKind: ArtifactKind;
+  readonly runId: string;
+
+  constructor(runId: string, artifactKind: ArtifactKind) {
+    super(`Run "${runId}" does not have a generated ${artifactKind} artifact.`);
+    this.name = "RunArtifactNotFoundError";
+    this.artifactKind = artifactKind;
+    this.runId = runId;
+  }
+}
+
+export function buildAcquiredArtifactSourceNote(input: {
+  artifact: RunTrackArtifactSourceArtifact;
+  provider: RunTrackArtifactSourceProvider;
+  selection: RunTrackArtifactSourceSelection;
+}): AcquiredArtifactSourceNote {
+  return {
+    artifact: input.artifact,
+    outcome: "acquired",
+    provider: input.provider,
+    schema: RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA,
+    selection: input.selection
+  };
+}
+
+export function buildMissedArtifactSourceNote(input: {
+  miss: RunTrackArtifactSourceMiss;
+}): MissedArtifactSourceNote {
+  return {
+    miss: input.miss,
+    outcome: "missed",
+    schema: RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA
+  };
+}
+
+export function buildRunArtifactDownloadUrl(runId: string, kind: ArtifactKind) {
+  return `/api/runs/${encodeURIComponent(runId)}/artifacts/${kind}`;
+}
+
+export async function generateRunArtifacts(
+  input: GenerateRunArtifactsInput
+): Promise<{
+  artifacts: GeneratedRunArtifact[];
+  manifest: RunArtifactsManifest;
+}> {
+  const runStore = input.runStore ?? getRunStore();
+  const workspaceRoot = resolveWorkspaceRoot(input.workspaceRoot);
+  const run = runStore.getRun(input.runId);
+
+  if (!run) {
+    throw new Error(`Run not found: ${input.runId}`);
+  }
+
+  const attempts = runStore.listRunTrackAttempts(input.runId);
+  const notesByTrackId = getLatestArtifactSourceNotesByTrackId(attempts);
+  const zipEntries: Array<{ data: Buffer; name: string }> = [];
+  const manifestTracks: ManifestTrackEntry[] = [];
+
+  for (const track of run.tracks) {
+    const note = notesByTrackId.get(track.id);
+
+    if (track.status === "acquired") {
+      if (note?.outcome !== "acquired") {
+        throw new RunArtifactsNotReadyError(
+          run.id,
+          `Run track "${track.id}" is acquired but does not have a persisted artifact source note.`
+        );
+      }
+
+      const fileBytes = await readFile(
+        /* turbopackIgnore: true */ note.artifact.localFilePath
+      );
+      const zipEntryName = buildZipEntryName(track, note.artifact);
+
+      zipEntries.push({
+        data: fileBytes,
+        name: zipEntryName
+      });
+      manifestTracks.push({
+        artist: track.artist,
+        miss: null,
+        outcome: "acquired",
+        selection: {
+          artifactFormat: note.artifact.format,
+          artifactSha256: note.artifact.sha256 ?? null,
+          artifactSizeBytes: note.artifact.sizeBytes,
+          providerId: note.provider.providerId,
+          providerName: note.provider.providerName,
+          providerUrl: note.provider.providerUrl ?? null,
+          selectedFormat: note.selection.selectedFormat,
+          selectedReason: note.selection.reason,
+          zipEntryName
+        },
+        sourcePosition: track.sourcePosition,
+        title: track.title,
+        version: track.version
+      });
+
+      continue;
+    }
+
+    if (track.status === "missed") {
+      if (note?.outcome !== "missed") {
+        throw new RunArtifactsNotReadyError(
+          run.id,
+          `Run track "${track.id}" is missed but does not have a persisted miss note.`
+        );
+      }
+
+      manifestTracks.push({
+        artist: track.artist,
+        miss: note.miss,
+        outcome: "missed",
+        selection: null,
+        sourcePosition: track.sourcePosition,
+        title: track.title,
+        version: track.version
+      });
+
+      continue;
+    }
+
+    throw new RunArtifactsNotReadyError(
+      run.id,
+      `Run track "${track.id}" is still "${track.status}" and cannot be packaged yet.`
+    );
+  }
+
+  const artifactDirectory = getRunArtifactDirectory(workspaceRoot, run.id);
+  const downloadsZipPath = path.join(artifactDirectory, "downloads.zip");
+  const missesPath = path.join(artifactDirectory, "misses.txt");
+  const manifestPath = path.join(artifactDirectory, "manifest.json");
+  const manifest: RunArtifactsManifest = {
+    generatedAt: new Date().toISOString(),
+    run: {
+      id: run.id,
+      playlistTitle: run.playlistTitle,
+      playlistUrl: run.playlistUrl,
+      sourceType: run.sourceType,
+      status: run.status
+    },
+    schemaVersion: 1,
+    summary: {
+      acquiredCount: manifestTracks.filter((track) => track.outcome === "acquired")
+        .length,
+      missCount: manifestTracks.filter((track) => track.outcome === "missed").length,
+      trackCount: manifestTracks.length
+    },
+    tracks: manifestTracks
+  };
+
+  await mkdir(/* turbopackIgnore: true */ artifactDirectory, { recursive: true });
+  await writeStoreZip(downloadsZipPath, zipEntries);
+  await writeFile(
+    /* turbopackIgnore: true */ missesPath,
+    renderMissesText(manifestTracks),
+    "utf8"
+  );
+  await writeFile(
+    /* turbopackIgnore: true */ manifestPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8"
+  );
+
+  const records: Array<
+    RecordRunArtifactInput & {
+      kind: GeneratedRunArtifact["kind"];
+    }
+  > = [
+    {
+      kind: "downloads-zip",
+      relativePath: toRelativeWorkspacePath(workspaceRoot, downloadsZipPath),
+      runId: run.id
+    },
+    {
+      kind: "misses-txt",
+      relativePath: toRelativeWorkspacePath(workspaceRoot, missesPath),
+      runId: run.id
+    },
+    {
+      kind: "manifest-json",
+      relativePath: toRelativeWorkspacePath(workspaceRoot, manifestPath),
+      runId: run.id
+    }
+  ];
+
+  runStore.replaceRunArtifacts(run.id, records);
+
+  return {
+    artifacts: records.map((record) => ({
+      absolutePath: path.join(workspaceRoot, record.relativePath),
+      kind: record.kind,
+      relativePath: record.relativePath
+    })),
+    manifest
+  };
+}
+
+export function listRunArtifactDownloads(input: {
+  runId: string;
+  runStore?: RunStore;
+}) {
+  const runStore = input.runStore ?? getRunStore();
+  const run = runStore.getRun(input.runId);
+
+  if (!run) {
+    throw new Error(`Run not found: ${input.runId}`);
+  }
+
+  return [...run.artifacts]
+    .sort(compareArtifactsByKind)
+    .map((artifact) => ({
+      downloadUrl: buildRunArtifactDownloadUrl(run.id, artifact.kind),
+      kind: artifact.kind
+    })) satisfies RunArtifactDownload[];
+}
+
+export function resolveRunArtifact(input: {
+  artifactKind: ArtifactKind;
+  runId: string;
+  runStore?: RunStore;
+  workspaceRoot?: string;
+}): RunArtifact & { absolutePath: string } {
+  const runStore = input.runStore ?? getRunStore();
+  const workspaceRoot = resolveWorkspaceRoot(input.workspaceRoot);
+  const run = runStore.getRun(input.runId);
+
+  if (!run) {
+    throw new Error(`Run not found: ${input.runId}`);
+  }
+
+  const artifact = [...run.artifacts]
+    .sort(compareArtifactsByKind)
+    .find((candidate) => candidate.kind === input.artifactKind);
+
+  if (!artifact) {
+    throw new RunArtifactNotFoundError(input.runId, input.artifactKind);
+  }
+
+  return {
+    ...artifact,
+    absolutePath: path.join(workspaceRoot, artifact.relativePath)
+  };
+}
+
+function getLatestArtifactSourceNotesByTrackId(
+  attempts: ReturnType<RunStore["listRunTrackAttempts"]>
+) {
+  const notesByTrackId = new Map<string, RunTrackArtifactSourceNote>();
+
+  for (const attempt of attempts) {
+    if (notesByTrackId.has(attempt.runTrackId)) {
+      continue;
+    }
+
+    const note = parseRunTrackArtifactSourceNote(attempt.note);
+
+    if (note) {
+      notesByTrackId.set(attempt.runTrackId, note);
+    }
+  }
+
+  return notesByTrackId;
+}
+
+function parseRunTrackArtifactSourceNote(note: string | null) {
+  if (!note) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(note) as Record<string, unknown>;
+
+    if (
+      parsed.schema !== RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA ||
+      (parsed.outcome !== "acquired" && parsed.outcome !== "missed")
+    ) {
+      return null;
+    }
+
+    return parsed as RunTrackArtifactSourceNote;
+  } catch {
+    return null;
+  }
+}
+
+function buildZipEntryName(
+  track: RunTrack,
+  artifact: RunTrackArtifactSourceArtifact
+) {
+  const extension = resolveArtifactExtension(artifact);
+
+  return `${buildTrackLabel(track)}.${extension}`;
+}
+
+function resolveArtifactExtension(artifact: RunTrackArtifactSourceArtifact) {
+  const fileExtension =
+    artifact.fileExtension?.trim().replace(/^\./, "").toLowerCase() ??
+    path.extname(artifact.fileName).replace(/^\./, "").toLowerCase();
+
+  if (fileExtension) {
+    return fileExtension;
+  }
+
+  if (/^[a-z0-9-]+$/i.test(artifact.format)) {
+    return artifact.format.toLowerCase();
+  }
+
+  return "bin";
+}
+
+function buildTrackLabel(track: RunTrack) {
+  const baseLabel = `${padTrackPosition(track.sourcePosition)} - ${track.artist} - ${track.title}`;
+
+  return sanitizeFileName(track.version ? `${baseLabel} (${track.version})` : baseLabel);
+}
+
+function sanitizeFileName(value: string) {
+  return value
+    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function padTrackPosition(sourcePosition: number) {
+  return String(sourcePosition).padStart(3, "0");
+}
+
+function renderMissesText(tracks: ManifestTrackEntry[]) {
+  const missedTracks = tracks.filter(
+    (track): track is Extract<ManifestTrackEntry, { outcome: "missed" }> =>
+      track.outcome === "missed"
+  );
+
+  if (missedTracks.length === 0) {
+    return "";
+  }
+
+  return `${missedTracks
+    .map(
+      (track) =>
+        `${buildTrackLabelFromManifest(track)} :: ${track.miss.reason} :: ${track.miss.detail}`
+    )
+    .join("\n")}\n`;
+}
+
+function buildTrackLabelFromManifest(track: ManifestTrackEntry) {
+  const baseLabel = `${padTrackPosition(track.sourcePosition)} - ${track.artist} - ${track.title}`;
+
+  return track.version ? `${baseLabel} (${track.version})` : baseLabel;
+}
+
+function resolveWorkspaceRoot(workspaceRoot?: string) {
+  return (
+    workspaceRoot ??
+    process.env.MUSIC_DOWNLOADER_WORKSPACE_ROOT ??
+    path.join(/* turbopackIgnore: true */ process.cwd())
+  );
+}
+
+function getRunArtifactDirectory(workspaceRoot: string, runId: string) {
+  return path.join(workspaceRoot, "data", "runs", sanitizeRunId(runId), "artifacts");
+}
+
+function sanitizeRunId(runId: string) {
+  return runId.replace(/[^a-z0-9-_.]+/gi, "-");
+}
+
+function toRelativeWorkspacePath(workspaceRoot: string, absolutePath: string) {
+  const relativePath = path.relative(workspaceRoot, absolutePath);
+
+  return relativePath.split(path.sep).join("/");
+}
+
+function compareArtifactsByKind(left: RunArtifact, right: RunArtifact) {
+  return (
+    RUN_ARTIFACT_KIND_ORDER.indexOf(left.kind) -
+    RUN_ARTIFACT_KIND_ORDER.indexOf(right.kind)
+  );
+}
+
+const ZIP_UTF8_FLAG = 0x0800;
+const ZIP_STORE_METHOD = 0;
+const ZIP_DOS_TIME = (12 << 11) | (0 << 5);
+const ZIP_DOS_DATE = ((2026 - 1980) << 9) | (3 << 5) | 31;
+const CRC32_TABLE = buildCrc32Table();
+
+async function writeStoreZip(
+  destinationPath: string,
+  entries: Array<{ data: Buffer; name: string }>
+) {
+  const localHeaders: Buffer[] = [];
+  const centralDirectory: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const fileName = Buffer.from(entry.name, "utf8");
+    const crc32 = calculateCrc32(entry.data);
+    const localHeader = Buffer.alloc(30);
+
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(ZIP_UTF8_FLAG, 6);
+    localHeader.writeUInt16LE(ZIP_STORE_METHOD, 8);
+    localHeader.writeUInt16LE(ZIP_DOS_TIME, 10);
+    localHeader.writeUInt16LE(ZIP_DOS_DATE, 12);
+    localHeader.writeUInt32LE(crc32, 14);
+    localHeader.writeUInt32LE(entry.data.length, 18);
+    localHeader.writeUInt32LE(entry.data.length, 22);
+    localHeader.writeUInt16LE(fileName.length, 26);
+    localHeader.writeUInt16LE(0, 28);
+
+    localHeaders.push(localHeader, fileName, entry.data);
+
+    const centralHeader = Buffer.alloc(46);
+
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(ZIP_UTF8_FLAG, 8);
+    centralHeader.writeUInt16LE(ZIP_STORE_METHOD, 10);
+    centralHeader.writeUInt16LE(ZIP_DOS_TIME, 12);
+    centralHeader.writeUInt16LE(ZIP_DOS_DATE, 14);
+    centralHeader.writeUInt32LE(crc32, 16);
+    centralHeader.writeUInt32LE(entry.data.length, 20);
+    centralHeader.writeUInt32LE(entry.data.length, 24);
+    centralHeader.writeUInt16LE(fileName.length, 28);
+    centralHeader.writeUInt16LE(0, 30);
+    centralHeader.writeUInt16LE(0, 32);
+    centralHeader.writeUInt16LE(0, 34);
+    centralHeader.writeUInt16LE(0, 36);
+    centralHeader.writeUInt32LE(0, 38);
+    centralHeader.writeUInt32LE(offset, 42);
+
+    centralDirectory.push(centralHeader, fileName);
+    offset += localHeader.length + fileName.length + entry.data.length;
+  }
+
+  const centralDirectoryBuffer = Buffer.concat(centralDirectory);
+  const endOfCentralDirectory = Buffer.alloc(22);
+
+  endOfCentralDirectory.writeUInt32LE(0x06054b50, 0);
+  endOfCentralDirectory.writeUInt16LE(0, 4);
+  endOfCentralDirectory.writeUInt16LE(0, 6);
+  endOfCentralDirectory.writeUInt16LE(entries.length, 8);
+  endOfCentralDirectory.writeUInt16LE(entries.length, 10);
+  endOfCentralDirectory.writeUInt32LE(centralDirectoryBuffer.length, 12);
+  endOfCentralDirectory.writeUInt32LE(offset, 16);
+  endOfCentralDirectory.writeUInt16LE(0, 20);
+
+  await writeFile(
+    /* turbopackIgnore: true */ destinationPath,
+    Buffer.concat([...localHeaders, centralDirectoryBuffer, endOfCentralDirectory])
+  );
+}
+
+function buildCrc32Table() {
+  const table = new Uint32Array(256);
+
+  for (let index = 0; index < 256; index += 1) {
+    let value = index;
+
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) === 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    }
+
+    table[index] = value >>> 0;
+  }
+
+  return table;
+}
+
+function calculateCrc32(buffer: Buffer) {
+  let crc = 0xffffffff;
+
+  for (const byte of buffer) {
+    crc = CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+
+  return (crc ^ 0xffffffff) >>> 0;
+}

--- a/src/features/runs/run-store.ts
+++ b/src/features/runs/run-store.ts
@@ -70,6 +70,15 @@ type RunArtifactRow = {
   created_at: string;
 };
 
+type AcquisitionAttemptRow = {
+  created_at: string;
+  id: string;
+  note: string | null;
+  outcome: AcquisitionAttemptOutcome;
+  provider_key: string;
+  run_track_id: string;
+};
+
 export type RunSummary = {
   id: string;
   sourceType: PlaylistSource;
@@ -102,6 +111,15 @@ export type RunArtifact = {
   kind: ArtifactKind;
   relativePath: string;
   createdAt: string;
+};
+
+export type RunTrackAcquisitionAttempt = {
+  createdAt: string;
+  id: string;
+  note: string | null;
+  outcome: AcquisitionAttemptOutcome;
+  providerKey: string;
+  runTrackId: string;
 };
 
 export type RunDetail = RunSummary & {
@@ -219,6 +237,19 @@ function mapRunArtifact(row: RunArtifactRow): RunArtifact {
     kind: row.artifact_kind,
     relativePath: row.relative_path,
     runId: row.run_id
+  };
+}
+
+function mapRunTrackAcquisitionAttempt(
+  row: AcquisitionAttemptRow
+): RunTrackAcquisitionAttempt {
+  return {
+    createdAt: row.created_at,
+    id: row.id,
+    note: row.note,
+    outcome: row.outcome,
+    providerKey: row.provider_key,
+    runTrackId: row.run_track_id
   };
 }
 
@@ -566,6 +597,65 @@ export function createRunStore(options: RunStoreOptions = {}) {
       return this.getRun(input.runId)?.artifacts.at(-1) ?? null;
     },
 
+    replaceRunArtifacts(runId: string, artifacts: RecordRunArtifactInput[]) {
+      const now = getTimestamp();
+
+      getRunOrThrow(runId);
+
+      database.exec("BEGIN");
+
+      try {
+        const kinds = [...new Set(artifacts.map((artifact) => artifact.kind))];
+
+        if (kinds.length > 0) {
+          const placeholders = kinds.map(() => "?").join(", ");
+
+          database
+            .prepare(
+              `
+                DELETE FROM run_artifacts
+                WHERE run_id = ?
+                  AND artifact_kind IN (${placeholders})
+              `
+            )
+            .run(runId, ...kinds);
+        }
+
+        const insertArtifact = database.prepare(
+          `
+            INSERT INTO run_artifacts (
+              id,
+              run_id,
+              artifact_kind,
+              relative_path,
+              created_at
+            )
+            VALUES (?, ?, ?, ?, ?)
+          `
+        );
+
+        for (const artifact of artifacts) {
+          insertArtifact.run(
+            crypto.randomUUID(),
+            artifact.runId,
+            artifact.kind,
+            artifact.relativePath,
+            now
+          );
+        }
+
+        database
+          .prepare("UPDATE runs SET updated_at = ? WHERE id = ?")
+          .run(now, runId);
+        database.exec("COMMIT");
+      } catch (error) {
+        database.exec("ROLLBACK");
+        throw error;
+      }
+
+      return this.getRun(runId)?.artifacts ?? [];
+    },
+
     replaceRunTracks(runId: string, tracks: ReplaceRunTrackInput[]): RunTrack[] {
       const now = getTimestamp();
 
@@ -623,6 +713,25 @@ export function createRunStore(options: RunStoreOptions = {}) {
 
     resumeInterruptedRuns() {
       return requeueInterruptedRuns();
+    },
+
+    listRunTrackAttempts(runId: string): RunTrackAcquisitionAttempt[] {
+      getRunOrThrow(runId);
+
+      const attempts = database
+        .prepare(
+          `
+            SELECT acquisition_attempts.*
+            FROM acquisition_attempts
+            INNER JOIN run_tracks
+              ON run_tracks.id = acquisition_attempts.run_track_id
+            WHERE run_tracks.run_id = ?
+            ORDER BY acquisition_attempts.created_at DESC, acquisition_attempts.id DESC
+          `
+        )
+        .all(runId) as AcquisitionAttemptRow[];
+
+      return attempts.map(mapRunTrackAcquisitionAttempt);
     },
 
     transitionRunStatus(runId: string, nextStatus: RunStatus): RunDetail {


### PR DESCRIPTION
**@worker-01**

## Summary
- generate local `downloads.zip`, `misses.txt`, and `manifest.json` artifacts from persisted run data and acquisition-attempt notes
- add run artifact API routes for generate/list/download flows the UI can call later
- cover artifact contents and download-link behavior with local fixture-driven tests

## Verification
- `npm test`
- `npm run lint`
- `npm run build` (passes; Turbopack still emits a non-blocking NFT tracing warning for this filesystem-backed route)

Refs #12
