### PR TITLE
feat: add run report detail view (#13)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,6 +52,10 @@ input {
   font: inherit;
 }
 
+a {
+  color: inherit;
+}
+
 .app-shell {
   width: min(1120px, calc(100% - 2rem));
   margin: 0 auto;
@@ -96,9 +100,12 @@ input {
 .status-list dd,
 .run-card dd,
 .run-card-url,
+.run-card-title,
 .run-card-source,
 .form-status,
-.panel-caption {
+.panel-caption,
+.report-empty-copy,
+.report-table-secondary {
   margin: 0;
   color: rgba(39, 32, 27, 0.74);
   line-height: 1.45;
@@ -262,6 +269,17 @@ input {
   gap: 0.55rem;
 }
 
+.inline-link {
+  width: fit-content;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(242, 186, 98, 0.28);
+}
+
+.inline-link:hover {
+  border-bottom-color: rgba(242, 186, 98, 0.68);
+}
+
 .status-badge,
 .file-badge {
   display: inline-flex;
@@ -355,6 +373,13 @@ input {
   text-transform: uppercase;
 }
 
+.run-card-title {
+  margin-top: 0.3rem;
+  color: var(--text);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
 .run-card-url {
   margin-top: 0.35rem;
   color: var(--text);
@@ -377,6 +402,92 @@ input {
   margin: 0;
 }
 
+.run-card-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.report-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.report-track-panel {
+  grid-column: 1 / -1;
+}
+
+.report-summary-list {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.report-artifact-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.report-artifact-link {
+  text-decoration: none;
+}
+
+.report-table-wrap {
+  overflow-x: auto;
+}
+
+.report-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.report-table th,
+.report-table td {
+  padding: 0.9rem 0.75rem;
+  border-top: 1px solid rgba(255, 243, 228, 0.08);
+  text-align: left;
+  vertical-align: top;
+}
+
+.report-table th {
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.report-track-cell,
+.report-table-stack {
+  display: grid;
+  gap: 0.28rem;
+}
+
+.report-track-cell {
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 0.75rem;
+}
+
+.report-track-position {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.2rem;
+  min-height: 2rem;
+  padding: 0 0.65rem;
+  border: 1px solid rgba(255, 243, 228, 0.1);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-soft);
+  font-size: 0.82rem;
+  font-family: var(--font-mono);
+}
+
+.report-table-primary {
+  margin: 0;
+  color: var(--text);
+}
+
 @keyframes lift-in {
   from {
     opacity: 0;
@@ -392,8 +503,10 @@ input {
 @media (max-width: 900px) {
   .hero,
   .dashboard-grid,
+  .report-grid,
   .status-list,
-  .run-card-stats {
+  .run-card-stats,
+  .report-summary-list {
     grid-template-columns: 1fr;
   }
 
@@ -404,6 +517,10 @@ input {
   .panel-header,
   .run-card-head {
     flex-direction: column;
+  }
+
+  .report-track-panel {
+    grid-column: auto;
   }
 }
 
@@ -424,5 +541,9 @@ input {
 
   .primary-button {
     width: 100%;
+  }
+
+  .run-card-actions {
+    justify-content: flex-start;
   }
 }

--- a/src/app/runs/[runId]/page.test.tsx
+++ b/src/app/runs/[runId]/page.test.tsx
@@ -1,0 +1,145 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { render, screen } from "@testing-library/react";
+
+import {
+  buildAcquiredArtifactSourceNote,
+  buildMissedArtifactSourceNote
+} from "@/features/artifacts/run-artifacts";
+
+async function withTempDatabase(callback: (databasePath: string) => Promise<void>) {
+  const tempDirectory = mkdtempSync(path.join(tmpdir(), "music-downloader-report-"));
+  const databasePath = path.join(tempDirectory, "music-downloader.sqlite");
+
+  process.env.MUSIC_DOWNLOADER_DB_PATH = databasePath;
+
+  try {
+    await callback(databasePath);
+  } finally {
+    const runStoreModule = await import("@/features/runs/run-store");
+
+    runStoreModule.resetRunStoreForTests();
+    delete process.env.MUSIC_DOWNLOADER_DB_PATH;
+    rmSync(tempDirectory, { force: true, recursive: true });
+  }
+}
+
+describe("RunReportPage", () => {
+  it("renders persisted run details, source selections, misses, and artifact links", async () => {
+    await withTempDatabase(async () => {
+      vi.resetModules();
+
+      const runStoreModule = await import("@/features/runs/run-store");
+      const store = runStoreModule.getRunStore();
+      const run = store.createRun({
+        playlistTitle: "Night Drive",
+        playlistUrl: "https://soundcloud.com/sets/night-drive",
+        sourceType: "soundcloud"
+      });
+      const tracks = store.replaceRunTracks(run.id, [
+        {
+          artist: "Nora En Pure",
+          sourcePosition: 1,
+          title: "Lake Arrowhead",
+          version: "Original Mix"
+        },
+        {
+          artist: "Artist Two",
+          sourcePosition: 2,
+          title: "Unknown Track"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+      store.transitionRunStatus(run.id, "packaging");
+      store.updateRunTrackStatus(tracks[0].id, "acquired");
+      store.updateRunTrackStatus(tracks[1].id, "missed");
+      store.recordAcquisitionAttempt({
+        note: JSON.stringify(
+          buildAcquiredArtifactSourceNote({
+            artifact: {
+              fileExtension: "mp3",
+              fileName: "lake-arrowhead.mp3",
+              format: "mp3",
+              localFilePath: "/tmp/lake-arrowhead.mp3",
+              sizeBytes: 1024
+            },
+            provider: {
+              authorizationBasis: "uploader-enabled-download",
+              priceTier: "free",
+              providerId: "soundcloud-direct-downloads",
+              providerName: "SoundCloud Direct Downloads",
+              providerUrl: "https://soundcloud.com/noraenpure/lake-arrowhead"
+            },
+            selection: {
+              details: "Original Mix matched the approved fallback preference order.",
+              reason: "accepted-original-mix",
+              selectedFormat: "mp3"
+            }
+          })
+        ),
+        outcome: "matched",
+        providerKey: "soundcloud-direct-downloads",
+        runTrackId: tracks[0].id
+      });
+      store.recordAcquisitionAttempt({
+        note: JSON.stringify(
+          buildMissedArtifactSourceNote({
+            miss: {
+              detail: "No authorized source matched the requested track.",
+              reason: "no-authorized-source-match"
+            }
+          })
+        ),
+        outcome: "missed",
+        providerKey: "track-matcher",
+        runTrackId: tracks[1].id
+      });
+      store.replaceRunArtifacts(run.id, [
+        {
+          kind: "downloads-zip",
+          relativePath: `data/runs/${run.id}/artifacts/downloads.zip`,
+          runId: run.id
+        },
+        {
+          kind: "misses-txt",
+          relativePath: `data/runs/${run.id}/artifacts/misses.txt`,
+          runId: run.id
+        },
+        {
+          kind: "manifest-json",
+          relativePath: `data/runs/${run.id}/artifacts/manifest.json`,
+          runId: run.id
+        }
+      ]);
+      store.transitionRunStatus(run.id, "completed");
+
+      const pageModule = await import("./page");
+
+      render(
+        await pageModule.default({
+          params: Promise.resolve({ runId: run.id })
+        })
+      );
+
+      expect(
+        screen.getByRole("heading", { name: /night drive/i })
+      ).toBeVisible();
+      expect(screen.getByText(/^completed$/i)).toBeVisible();
+      expect(screen.getByText(/soundcloud direct downloads/i)).toBeVisible();
+      expect(
+        screen.getByText(/original mix matched the approved fallback preference order/i)
+      ).toBeVisible();
+      expect(screen.getByText(/no-authorized-source-match/i)).toBeVisible();
+      expect(
+        screen.getByRole("link", { name: /downloads\.zip/i })
+      ).toHaveAttribute("href", `/api/runs/${run.id}/artifacts/downloads-zip`);
+      expect(
+        screen.getByText(/no paid fallback approvals are queued for this run yet/i)
+      ).toBeVisible();
+    });
+  });
+});

--- a/src/app/runs/[runId]/page.tsx
+++ b/src/app/runs/[runId]/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from "next/navigation";
+
+import { getRunReport } from "@/features/reports/run-report";
+import { RunReportScreen } from "@/features/reports/run-report-screen";
+
+export const dynamic = "force-dynamic";
+
+type RunReportPageProps = {
+  params: Promise<{
+    runId: string;
+  }>;
+};
+
+export default async function RunReportPage({ params }: RunReportPageProps) {
+  const { runId } = await params;
+  const report = getRunReport({ runId });
+
+  if (!report) {
+    notFound();
+  }
+
+  return <RunReportScreen report={report} />;
+}

--- a/src/features/artifacts/run-artifacts.ts
+++ b/src/features/artifacts/run-artifacts.ts
@@ -428,7 +428,7 @@ function getLatestArtifactSourceNotesByTrackId(
   return notesByTrackId;
 }
 
-function parseRunTrackArtifactSourceNote(note: string | null) {
+export function parseRunTrackArtifactSourceNote(note: string | null) {
   if (!note) {
     return null;
   }

--- a/src/features/home/home-screen.test.tsx
+++ b/src/features/home/home-screen.test.tsx
@@ -20,4 +20,30 @@ describe("HomeScreen", () => {
       screen.getByText(/sqlite persistence is active for new acquisition jobs/i)
     ).toBeVisible();
   });
+
+  it("links recent runs into the run report detail flow", () => {
+    render(
+      <HomeScreen
+        initialRuns={[
+          {
+            artifactCount: 3,
+            createdAt: "2026-03-31T15:00:00.000Z",
+            id: "run-42",
+            playlistTitle: "Warehouse Drivers",
+            playlistUrl:
+              "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+            resumeAfterStatus: null,
+            sourceType: "spotify",
+            status: "completed",
+            trackCount: 12,
+            updatedAt: "2026-03-31T15:15:00.000Z"
+          }
+        ]}
+      />
+    );
+
+    expect(
+      screen.getByRole("link", { name: /open report for warehouse drivers/i })
+    ).toHaveAttribute("href", "/runs/run-42");
+  });
 });

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { startTransition, useEffect, useEffectEvent, useState } from "react";
 
 import { FileBadge } from "@/components/ui/file-badge";
@@ -250,6 +251,9 @@ export function HomeScreen({ initialRuns = [] }: HomeScreenProps) {
                       <p className="run-card-source">
                         {formatSourceLabel(run.sourceType)}
                       </p>
+                      {run.playlistTitle ? (
+                        <p className="run-card-title">{run.playlistTitle}</p>
+                      ) : null}
                       <p className="run-card-url">{run.playlistUrl}</p>
                     </div>
                     <StatusBadge tone={getStatusTone(run.status)}>
@@ -271,6 +275,16 @@ export function HomeScreen({ initialRuns = [] }: HomeScreenProps) {
                       <dd>{run.resumeAfterStatus ?? "fresh run"}</dd>
                     </div>
                   </dl>
+
+                  <div className="run-card-actions">
+                    <Link
+                      className="inline-link"
+                      href={`/runs/${run.id}`}
+                      aria-label={`Open report for ${run.playlistTitle ?? run.playlistUrl}`}
+                    >
+                      Open report
+                    </Link>
+                  </div>
                 </article>
               ))}
             </div>

--- a/src/features/reports/run-report-screen.test.tsx
+++ b/src/features/reports/run-report-screen.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen } from "@testing-library/react";
+
+import { RunReportScreen } from "./run-report-screen";
+
+describe("RunReportScreen", () => {
+  it("renders an in-progress run with artifact and review placeholders", () => {
+    render(<RunReportScreen report={buildRunningReport() as never} />);
+
+    expect(
+      screen.getByRole("heading", { name: /warehouse warmup/i })
+    ).toBeVisible();
+    expect(screen.getByText(/^matching$/i)).toBeVisible();
+    expect(
+      screen.getByText(/artifacts will appear after packaging completes/i)
+    ).toBeVisible();
+    expect(
+      screen.getByText(/no paid fallback approvals are queued for this run yet/i)
+    ).toBeVisible();
+  });
+
+  it("renders completed track outcomes and artifact download links", () => {
+    render(<RunReportScreen report={buildCompletedReport() as never} />);
+
+    expect(
+      screen.getByRole("link", { name: /downloads\.zip/i })
+    ).toHaveAttribute("href", "/api/runs/run-complete/artifacts/downloads-zip");
+    expect(
+      screen.getByRole("link", { name: /manifest\.json/i })
+    ).toHaveAttribute("href", "/api/runs/run-complete/artifacts/manifest-json");
+    expect(screen.getByText(/soundcloud direct downloads/i)).toBeVisible();
+    expect(
+      screen.getByText(/extended mix matched the highest-priority mix preference/i)
+    ).toBeVisible();
+  });
+
+  it("renders miss-heavy review details with explicit rejection reasons", () => {
+    render(<RunReportScreen report={buildMissHeavyReport() as never} />);
+
+    expect(screen.getAllByText(/missed/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/no-authorized-source-match/i).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/no authorized source matched the requested track/i).length
+    ).toBeGreaterThan(0);
+    expect(screen.getByText(/3 misses/i)).toBeVisible();
+  });
+});
+
+function buildRunningReport() {
+  return {
+    artifactCount: 0,
+    artifacts: [],
+    completedTrackCount: 0,
+    createdAt: "2026-03-31T14:00:00.000Z",
+    id: "run-running",
+    missCount: 0,
+    playlistTitle: "Warehouse Warmup",
+    playlistUrl: "https://soundcloud.com/sets/warehouse-warmup",
+    resumeAfterStatus: null,
+    selectedSourceCount: 0,
+    sourceType: "soundcloud",
+    status: "matching",
+    trackCount: 2,
+    tracks: [
+      {
+        artist: "Anyma",
+        id: "track-1",
+        latestAttempt: null,
+        resolution: null,
+        sourcePosition: 1,
+        sourceTrackId: "sc-101",
+        status: "matched",
+        title: "Consciousness",
+        version: "Extended Mix"
+      },
+      {
+        artist: "Fred again..",
+        id: "track-2",
+        latestAttempt: null,
+        resolution: null,
+        sourcePosition: 2,
+        sourceTrackId: "sc-102",
+        status: "queued",
+        title: "Delilah",
+        version: null
+      }
+    ],
+    updatedAt: "2026-03-31T14:05:00.000Z"
+  };
+}
+
+function buildCompletedReport() {
+  return {
+    ...buildRunningReport(),
+    artifactCount: 3,
+    artifacts: [
+      {
+        downloadUrl: "/api/runs/run-complete/artifacts/downloads-zip",
+        kind: "downloads-zip",
+        label: "downloads.zip"
+      },
+      {
+        downloadUrl: "/api/runs/run-complete/artifacts/misses-txt",
+        kind: "misses-txt",
+        label: "misses.txt"
+      },
+      {
+        downloadUrl: "/api/runs/run-complete/artifacts/manifest-json",
+        kind: "manifest-json",
+        label: "manifest.json"
+      }
+    ],
+    completedTrackCount: 2,
+    id: "run-complete",
+    playlistTitle: "Warehouse Drivers",
+    selectedSourceCount: 1,
+    status: "completed",
+    tracks: [
+      {
+        artist: "Anyma",
+        id: "track-1",
+        latestAttempt: {
+          outcome: "matched",
+          providerKey: "soundcloud-direct-downloads"
+        },
+        resolution: {
+          details: "Extended Mix matched the highest-priority mix preference.",
+          provider: {
+            authorizationBasis: "uploader-enabled-download",
+            name: "SoundCloud Direct Downloads",
+            priceTier: "free",
+            url: "https://soundcloud.com/anyma/consciousness"
+          },
+          selectedFormat: "mp3",
+          type: "selected",
+          selectionReason: "accepted-extended-mix"
+        },
+        sourcePosition: 1,
+        sourceTrackId: "sc-101",
+        status: "acquired",
+        title: "Consciousness",
+        version: "Extended Mix"
+      },
+      {
+        artist: "Fred again..",
+        id: "track-2",
+        latestAttempt: {
+          outcome: "missed",
+          providerKey: "track-matcher"
+        },
+        resolution: {
+          details: "No authorized source matched the requested track.",
+          reason: "no-authorized-source-match",
+          type: "miss"
+        },
+        sourcePosition: 2,
+        sourceTrackId: "sc-102",
+        status: "missed",
+        title: "Delilah",
+        version: null
+      }
+    ],
+    updatedAt: "2026-03-31T14:25:00.000Z"
+  };
+}
+
+function buildMissHeavyReport() {
+  return {
+    ...buildCompletedReport(),
+    completedTrackCount: 3,
+    missCount: 3,
+    selectedSourceCount: 0,
+    trackCount: 3,
+    tracks: [
+      {
+        artist: "Artist One",
+        id: "track-1",
+        latestAttempt: {
+          outcome: "missed",
+          providerKey: "track-matcher"
+        },
+        resolution: {
+          details: "No authorized source matched the requested track.",
+          reason: "no-authorized-source-match",
+          type: "miss"
+        },
+        sourcePosition: 1,
+        sourceTrackId: "sc-101",
+        status: "missed",
+        title: "Track One",
+        version: "Extended Mix"
+      },
+      {
+        artist: "Artist Two",
+        id: "track-2",
+        latestAttempt: {
+          outcome: "missed",
+          providerKey: "track-matcher"
+        },
+        resolution: {
+          details: "No authorized source matched the requested track.",
+          reason: "no-authorized-source-match",
+          type: "miss"
+        },
+        sourcePosition: 2,
+        sourceTrackId: "sc-102",
+        status: "missed",
+        title: "Track Two",
+        version: null
+      },
+      {
+        artist: "Artist Three",
+        id: "track-3",
+        latestAttempt: {
+          outcome: "missed",
+          providerKey: "track-matcher"
+        },
+        resolution: {
+          details: "No authorized source matched the requested track.",
+          reason: "no-authorized-source-match",
+          type: "miss"
+        },
+        sourcePosition: 3,
+        sourceTrackId: "sc-103",
+        status: "missed",
+        title: "Track Three",
+        version: "Original Mix"
+      }
+    ]
+  };
+}

--- a/src/features/reports/run-report-screen.tsx
+++ b/src/features/reports/run-report-screen.tsx
@@ -1,0 +1,344 @@
+import Link from "next/link";
+
+import { Panel } from "@/components/ui/panel";
+import { StatusBadge } from "@/components/ui/status-badge";
+
+import type {
+  RunReportDetail,
+  RunReportTrack,
+  RunReportTrackResolution
+} from "./run-report";
+
+const terminalTrackStatuses = new Set(["acquired", "missed", "failed"]);
+
+export function RunReportScreen({ report }: { report: RunReportDetail }) {
+  const trackCount = report.tracks.length || report.trackCount;
+  const completedTrackCount = report.tracks.filter((track) =>
+    track.status === "acquired" ||
+    track.status === "missed" ||
+    track.status === "failed"
+  ).length;
+
+  return (
+    <main className="app-shell">
+      <header className="hero">
+        <div>
+          <p className="hero-kicker">Run report</p>
+          <Link className="inline-link" href="/">
+            Back to intake
+          </Link>
+          <h1>{report.playlistTitle ?? report.playlistUrl}</h1>
+          <p className="hero-copy">{report.playlistUrl}</p>
+        </div>
+
+        <div className="hero-sidecar">
+          <StatusBadge tone={getStatusTone(report.status)}>
+            {report.status}
+          </StatusBadge>
+          <p className="hero-note">
+            {formatSourceLabel(report.sourceType)} run {report.id} tracks selected
+            sources, misses, and packaged artifacts in one local view.
+          </p>
+          <dl className="status-list">
+            <div>
+              <dt>Tracks</dt>
+              <dd>{formatCount(trackCount, "track", "tracks")}</dd>
+            </div>
+            <div>
+              <dt>Selected</dt>
+              <dd>
+                {formatCount(
+                  report.selectedSourceCount,
+                  "selected source",
+                  "selected sources"
+                )}
+              </dd>
+            </div>
+            <div>
+              <dt>Misses</dt>
+              <dd>{formatCount(report.missCount, "miss", "misses")}</dd>
+            </div>
+          </dl>
+        </div>
+      </header>
+
+      <div className="report-grid">
+        <Panel
+          eyebrow="Summary"
+          title="Run Summary"
+          footer={
+            <span className="panel-caption">
+              {completedTrackCount === trackCount
+                ? "All current track outcomes are resolved"
+                : `${trackCount - completedTrackCount} tracks still moving`}
+            </span>
+          }
+        >
+          <dl className="status-list report-summary-list">
+            <div>
+              <dt>Source</dt>
+              <dd>{formatSourceLabel(report.sourceType)}</dd>
+            </div>
+            <div>
+              <dt>Artifacts</dt>
+              <dd>
+                {formatCount(report.artifactCount, "artifact", "artifacts")}
+              </dd>
+            </div>
+            <div>
+              <dt>Resume</dt>
+              <dd>{report.resumeAfterStatus ?? "fresh run"}</dd>
+            </div>
+          </dl>
+        </Panel>
+
+        <Panel
+          eyebrow="Artifacts"
+          title="Downloads"
+          footer={<span className="panel-caption">Generation-task URLs</span>}
+        >
+          {report.artifacts.length ? (
+            <div className="report-artifact-list">
+              {report.artifacts.map((artifact) => (
+                <a
+                  key={artifact.kind}
+                  className="file-badge report-artifact-link"
+                  href={artifact.downloadUrl}
+                >
+                  {artifact.label}
+                </a>
+              ))}
+            </div>
+          ) : (
+            <p className="report-empty-copy">
+              Artifacts will appear after packaging completes.
+            </p>
+          )}
+        </Panel>
+
+        <Panel
+          eyebrow="Beatport"
+          title="Review Lane"
+          footer={
+            <span className="panel-caption">Reserved for paid fallback approvals</span>
+          }
+        >
+          <p className="report-empty-copy">
+            No paid fallback approvals are queued for this run yet.
+          </p>
+        </Panel>
+
+        <Panel
+          className="report-track-panel"
+          eyebrow="Per-track review"
+          title="Track Outcomes"
+          footer={<span className="panel-caption">DJ workflow review table</span>}
+        >
+          {report.tracks.length ? (
+            <div className="report-table-wrap">
+              <table className="report-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Track</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Selected Source / Miss</th>
+                    <th scope="col">Decision</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.tracks.map((track) => (
+                    <tr key={track.id}>
+                      <td>
+                        <div className="report-track-cell">
+                          <span className="report-track-position">
+                            {String(track.sourcePosition).padStart(3, "0")}
+                          </span>
+                          <div>
+                            <p className="report-table-primary">
+                              {track.artist} - {track.title}
+                            </p>
+                            <p className="report-table-secondary">
+                              {track.version ?? "Version pending"}
+                            </p>
+                          </div>
+                        </div>
+                      </td>
+                      <td>
+                        <StatusBadge tone={getTrackStatusTone(track)}>
+                          {track.status}
+                        </StatusBadge>
+                      </td>
+                      <td>{renderTrackSource(track)}</td>
+                      <td>{renderTrackDecision(track)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="report-empty-copy">
+              Track outcomes will appear after playlist intake writes the run rows.
+            </p>
+          )}
+        </Panel>
+      </div>
+    </main>
+  );
+}
+
+function renderTrackSource(track: RunReportTrack) {
+  if (track.resolution?.type === "selected") {
+    const providerName = track.resolution.provider.url ? (
+      <a className="inline-link" href={track.resolution.provider.url}>
+        {track.resolution.provider.name}
+      </a>
+    ) : (
+      track.resolution.provider.name
+    );
+
+    return (
+      <div className="report-table-stack">
+        <p className="report-table-primary">{providerName}</p>
+        <p className="report-table-secondary">
+          {formatAuthorizationBasis(track.resolution.provider.authorizationBasis)} •{" "}
+          {track.resolution.selectedFormat?.toUpperCase() ?? "format pending"}
+        </p>
+      </div>
+    );
+  }
+
+  if (track.resolution?.type === "miss") {
+    return (
+      <div className="report-table-stack">
+        <p className="report-table-primary">
+          {track.resolution.provider?.name ?? "Track matcher"}
+        </p>
+        <p className="report-table-secondary">Missed track</p>
+      </div>
+    );
+  }
+
+  if (track.latestAttempt) {
+    return (
+      <div className="report-table-stack">
+        <p className="report-table-primary">{track.latestAttempt.providerKey}</p>
+        <p className="report-table-secondary">
+          {formatAttemptOutcome(track.latestAttempt.outcome)}
+        </p>
+      </div>
+    );
+  }
+
+  return <p className="report-empty-copy">No provider decision recorded yet.</p>;
+}
+
+function renderTrackDecision(track: RunReportTrack) {
+  if (track.resolution?.type === "selected") {
+    return (
+      <div className="report-table-stack">
+        <p className="report-table-primary">
+          {formatSelectionReason(track.resolution.selectionReason)}
+        </p>
+        <p className="report-table-secondary">{track.resolution.details}</p>
+      </div>
+    );
+  }
+
+  if (track.resolution?.type === "miss") {
+    return (
+      <div className="report-table-stack">
+        <p className="report-table-primary">{track.resolution.reason}</p>
+        <p className="report-table-secondary">{track.resolution.details}</p>
+      </div>
+    );
+  }
+
+  if (terminalTrackStatuses.has(track.status)) {
+    return (
+      <p className="report-empty-copy">
+        Final outcome recorded without a structured source note.
+      </p>
+    );
+  }
+
+  return <p className="report-empty-copy">Waiting on matching or packaging work.</p>;
+}
+
+function formatCount(value: number, singular: string, plural: string) {
+  return `${value} ${value === 1 ? singular : plural}`;
+}
+
+function formatSourceLabel(sourceType: RunReportDetail["sourceType"]) {
+  return sourceType === "spotify" ? "Spotify" : "SoundCloud";
+}
+
+function formatSelectionReason(
+  reason: Extract<RunReportTrackResolution, { type: "selected" }>["selectionReason"]
+) {
+  switch (reason) {
+    case "accepted-extended-mix":
+      return "Extended Mix";
+    case "accepted-original-mix":
+      return "Original Mix";
+    case "accepted-base-version-fallback":
+      return "High-confidence fallback";
+    default:
+      return reason;
+  }
+}
+
+function formatAttemptOutcome(
+  outcome: NonNullable<RunReportTrack["latestAttempt"]>["outcome"]
+) {
+  switch (outcome) {
+    case "matched":
+      return "Matched candidate selected";
+    case "missed":
+      return "Miss recorded";
+    case "failed":
+      return "Attempt failed";
+    case "purchased":
+      return "Queued for purchase";
+    case "skipped":
+      return "Attempt skipped";
+    default:
+      return outcome;
+  }
+}
+
+function formatAuthorizationBasis(value: string) {
+  switch (value) {
+    case "uploader-enabled-download":
+      return "Uploader-enabled download";
+    case "rights-holder-storefront":
+      return "Rights-holder storefront";
+    case "purchase-entitlement":
+      return "Purchase entitlement";
+    default:
+      return value;
+  }
+}
+
+function getStatusTone(status: RunReportDetail["status"]) {
+  if (status === "completed") {
+    return "success" as const;
+  }
+
+  if (status === "failed" || status === "awaiting-approval") {
+    return "warning" as const;
+  }
+
+  return "muted" as const;
+}
+
+function getTrackStatusTone(track: RunReportTrack) {
+  if (track.status === "acquired") {
+    return "success" as const;
+  }
+
+  if (track.status === "missed" || track.status === "failed") {
+    return "warning" as const;
+  }
+
+  return "muted" as const;
+}

--- a/src/features/reports/run-report.ts
+++ b/src/features/reports/run-report.ts
@@ -1,0 +1,196 @@
+import {
+  listRunArtifactDownloads,
+  parseRunTrackArtifactSourceNote,
+  type RunTrackArtifactSourceNote
+} from "@/features/artifacts/run-artifacts";
+import {
+  type ArtifactKind,
+  getRunStore,
+  type RunDetail,
+  type RunStore,
+  type RunTrack,
+  type RunTrackAcquisitionAttempt
+} from "@/features/runs/run-store";
+import type { TrackAcceptedDecision, TrackAudioFormat } from "@/features/tracks/canonical-track";
+import type {
+  ProviderAuthorizationBasis,
+  ProviderPriceTier,
+  ProviderProvenance
+} from "@/features/providers/provider-registry";
+
+export type RunReportTrackResolution =
+  | {
+      details: string;
+      provider: {
+        authorizationBasis: ProviderAuthorizationBasis;
+        discoveredVia: ProviderProvenance["discoveredVia"] | null;
+        name: string;
+        priceTier: ProviderPriceTier;
+        url: string | null;
+      };
+      selectedFormat: TrackAudioFormat | null;
+      selectionReason: TrackAcceptedDecision["reason"];
+      type: "selected";
+    }
+  | {
+      details: string;
+      provider: {
+        id: string | null;
+        name: string | null;
+      } | null;
+      reason: string;
+      type: "miss";
+    };
+
+export type RunReportTrack = RunTrack & {
+  latestAttempt: {
+    outcome: RunTrackAcquisitionAttempt["outcome"];
+    providerKey: string;
+  } | null;
+  resolution: RunReportTrackResolution | null;
+};
+
+export type RunReportArtifact = {
+  downloadUrl: string;
+  kind: ArtifactKind;
+  label: string;
+};
+
+export type RunReportBase = Omit<RunDetail, "artifacts" | "tracks">;
+
+export type RunReportDetail = RunReportBase & {
+  artifacts: RunReportArtifact[];
+  completedTrackCount: number;
+  missCount: number;
+  selectedSourceCount: number;
+  tracks: RunReportTrack[];
+};
+
+export function getRunReport(input: { runId: string; runStore?: RunStore }) {
+  const runStore = input.runStore ?? getRunStore();
+  const run = runStore.getRun(input.runId);
+
+  if (!run) {
+    return null;
+  }
+
+  const attempts = runStore.listRunTrackAttempts(input.runId);
+  const attemptsByTrackId = groupAttemptsByTrackId(attempts);
+  const tracks = run.tracks.map((track) =>
+    mapRunReportTrack(track, attemptsByTrackId.get(track.id) ?? [])
+  );
+
+  return {
+    ...run,
+    artifactCount: run.artifactCount,
+    artifacts: listRunArtifactDownloads({
+      runId: run.id,
+      runStore
+    }).map((artifact) => ({
+      ...artifact,
+      label: formatArtifactLabel(artifact.kind)
+    })),
+    completedTrackCount: tracks.filter((track) =>
+      track.status === "acquired" ||
+      track.status === "missed" ||
+      track.status === "failed"
+    ).length,
+    missCount: tracks.filter((track) => track.status === "missed").length,
+    selectedSourceCount: tracks.filter(
+      (track) => track.resolution?.type === "selected"
+    ).length,
+    tracks
+  };
+}
+
+function groupAttemptsByTrackId(attempts: RunTrackAcquisitionAttempt[]) {
+  const attemptsByTrackId = new Map<string, RunTrackAcquisitionAttempt[]>();
+
+  for (const attempt of attempts) {
+    const existingAttempts = attemptsByTrackId.get(attempt.runTrackId);
+
+    if (existingAttempts) {
+      existingAttempts.push(attempt);
+      continue;
+    }
+
+    attemptsByTrackId.set(attempt.runTrackId, [attempt]);
+  }
+
+  return attemptsByTrackId;
+}
+
+function mapRunReportTrack(
+  track: RunTrack,
+  attempts: RunTrackAcquisitionAttempt[]
+): RunReportTrack {
+  const latestAttempt = attempts.at(0);
+  const note = attempts
+    .map((attempt) => parseRunTrackArtifactSourceNote(attempt.note))
+    .find(
+      (candidate): candidate is RunTrackArtifactSourceNote => candidate !== null
+    ) ?? null;
+
+  return {
+    ...track,
+    latestAttempt: latestAttempt
+      ? {
+          outcome: latestAttempt.outcome,
+          providerKey: latestAttempt.providerKey
+        }
+      : null,
+    resolution: mapRunReportTrackResolution(note)
+  };
+}
+
+function mapRunReportTrackResolution(
+  note: RunTrackArtifactSourceNote | null
+): RunReportTrackResolution | null {
+  if (!note) {
+    return null;
+  }
+
+  if (note.outcome === "acquired") {
+    return {
+      details: note.selection.details,
+      provider: {
+        authorizationBasis: note.provider.authorizationBasis,
+        discoveredVia: note.provider.discoveredVia ?? null,
+        name: note.provider.providerName,
+        priceTier: note.provider.priceTier,
+        url: note.provider.providerUrl ?? null
+      },
+      selectedFormat: note.selection.selectedFormat,
+      selectionReason: note.selection.reason,
+      type: "selected"
+    };
+  }
+
+  return {
+    details: note.miss.detail,
+    provider:
+      note.miss.providerId || note.miss.providerName
+        ? {
+            id: note.miss.providerId ?? null,
+            name: note.miss.providerName ?? null
+          }
+        : null,
+    reason: note.miss.reason,
+    type: "miss"
+  };
+}
+
+function formatArtifactLabel(kind: string) {
+  switch (kind) {
+    case "downloads-zip":
+      return "downloads.zip";
+    case "manifest-json":
+      return "manifest.json";
+    case "misses-txt":
+      return "misses.txt";
+    case "run-report":
+      return "run-report.html";
+    default:
+      return kind;
+  }
+}


### PR DESCRIPTION
## Summary
- add the run report detail page and supporting report domain model
- surface report navigation from the home screen and expose artifact downloads
- cover report rendering states with focused UI tests

## Verification
- npm test
- npm run lint
- npm run build