### PR TITLE
Implement the Beatport aggregated approval queue

### DIFF
--- a/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
+++ b/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
@@ -1,0 +1,170 @@
+/* @vitest-environment node */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+async function withTempDatabase(
+  callback: (databasePath: string) => Promise<void> | void
+) {
+  const tempDirectory = mkdtempSync(
+    path.join(tmpdir(), "music-downloader-review-route-")
+  );
+  const databasePath = path.join(tempDirectory, "music-downloader.sqlite");
+
+  process.env.MUSIC_DOWNLOADER_DB_PATH = databasePath;
+
+  try {
+    await callback(databasePath);
+  } finally {
+    const runStoreModule = await import("@/features/runs/run-store");
+
+    runStoreModule.resetRunStoreForTests();
+    delete process.env.MUSIC_DOWNLOADER_DB_PATH;
+    rmSync(tempDirectory, { force: true, recursive: true });
+  }
+}
+
+describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
+  it("persists approve reject and purchased review actions", async () => {
+    await withTempDatabase(async () => {
+      vi.resetModules();
+
+      const [{ POST }, runStoreModule] = await Promise.all([
+        import("./route"),
+        import("@/features/runs/run-store")
+      ]);
+      const store = runStoreModule.getRunStore();
+      const run = store.createRun({
+        playlistTitle: "Beatport Route Flow",
+        playlistUrl: "https://soundcloud.com/sets/beatport-route-flow",
+        sourceType: "soundcloud"
+      });
+      const tracks = store.replaceRunTracks(run.id, [
+        {
+          artist: "Artist One",
+          sourcePosition: 1,
+          title: "Track One"
+        },
+        {
+          artist: "Artist Two",
+          sourcePosition: 2,
+          title: "Track Two"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+
+      const reviewOne = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3", "wav"],
+        candidateId: "beatport-route-1",
+        mixLabel: "Original Mix",
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/track-one/route-1",
+        queueName: "beatport-review",
+        runTrackId: tracks[0].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+      const reviewTwo = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3"],
+        candidateId: "beatport-route-2",
+        mixLabel: null,
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/track-two/route-2",
+        queueName: "beatport-review",
+        runTrackId: tracks[1].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+
+      const approveResponse = await POST(
+        new Request(`http://localhost/api/runs/${run.id}/review-queue/${reviewOne.id}`, {
+          body: JSON.stringify({ action: "approve" }),
+          headers: {
+            "content-type": "application/json"
+          },
+          method: "POST"
+        }),
+        {
+          params: Promise.resolve({
+            reviewId: reviewOne.id,
+            runId: run.id
+          })
+        }
+      );
+      const purchasedResponse = await POST(
+        new Request(`http://localhost/api/runs/${run.id}/review-queue/${reviewOne.id}`, {
+          body: JSON.stringify({ action: "purchased" }),
+          headers: {
+            "content-type": "application/json"
+          },
+          method: "POST"
+        }),
+        {
+          params: Promise.resolve({
+            reviewId: reviewOne.id,
+            runId: run.id
+          })
+        }
+      );
+      const rejectResponse = await POST(
+        new Request(`http://localhost/api/runs/${run.id}/review-queue/${reviewTwo.id}`, {
+          body: JSON.stringify({ action: "reject" }),
+          headers: {
+            "content-type": "application/json"
+          },
+          method: "POST"
+        }),
+        {
+          params: Promise.resolve({
+            reviewId: reviewTwo.id,
+            runId: run.id
+          })
+        }
+      );
+
+      expect(approveResponse.status).toBe(200);
+      await expect(approveResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          id: reviewOne.id,
+          status: "approved"
+        })
+      );
+      expect(purchasedResponse.status).toBe(200);
+      await expect(purchasedResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          id: reviewOne.id,
+          status: "purchased"
+        })
+      );
+      expect(rejectResponse.status).toBe(200);
+      await expect(rejectResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          id: reviewTwo.id,
+          status: "rejected"
+        })
+      );
+
+      expect(store.getRun(run.id)).toEqual(
+        expect.objectContaining({
+          id: run.id,
+          status: "packaging"
+        })
+      );
+      expect(
+        store
+          .getRun(run.id)
+          ?.reviewQueue.map((review) => [review.candidateId, review.status])
+      ).toEqual([
+        ["beatport-route-1", "purchased"],
+        ["beatport-route-2", "rejected"]
+      ]);
+    });
+  });
+});

--- a/src/app/api/runs/[runId]/review-queue/[reviewId]/route.ts
+++ b/src/app/api/runs/[runId]/review-queue/[reviewId]/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+
+import {
+  getRunStore,
+  type RunTrackReviewStatus
+} from "@/features/runs/run-store";
+
+type RouteContext = {
+  params: Promise<{
+    reviewId: string;
+    runId: string;
+  }>;
+};
+
+const reviewActionToStatus: Record<string, RunTrackReviewStatus> = {
+  approve: "approved",
+  purchased: "purchased",
+  reject: "rejected"
+};
+
+export async function POST(request: Request, context: RouteContext) {
+  const payload = (await request.json().catch(() => null)) as
+    | {
+        action?: string;
+      }
+    | null;
+  const nextStatus = payload?.action ? reviewActionToStatus[payload.action] : null;
+  const { reviewId, runId } = await context.params;
+  const runStore = getRunStore();
+  const run = runStore.getRun(runId);
+
+  if (!run) {
+    return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  }
+
+  const review = run.reviewQueue.find((candidate) => candidate.id === reviewId);
+
+  if (!review) {
+    return NextResponse.json({ error: "Review candidate not found" }, { status: 404 });
+  }
+
+  if (!nextStatus) {
+    return NextResponse.json(
+      { error: "action must be one of approve, reject, or purchased" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    return NextResponse.json(
+      runStore.transitionRunTrackReviewStatus(reviewId, nextStatus)
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Unable to update review status"
+      },
+      { status: 409 }
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -245,10 +245,29 @@ a {
     0 14px 26px rgba(12, 11, 10, 0.24);
 }
 
+.secondary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.85rem;
+  width: fit-content;
+  padding: 0 1rem;
+  border: 1px solid rgba(255, 243, 228, 0.16);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+  font-weight: 600;
+}
+
 .primary-button:disabled {
   cursor: not-allowed;
   opacity: 0.68;
   filter: saturate(0.65);
+}
+
+.secondary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.68;
 }
 
 .field-hint,
@@ -431,6 +450,39 @@ a {
   text-decoration: none;
 }
 
+.report-review-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.report-review-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid rgba(255, 243, 228, 0.1);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.report-review-card-head,
+.report-review-meta {
+  display: flex;
+  gap: 0.8rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.report-review-title-block {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.report-review-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
 .report-table-wrap {
   overflow-x: auto;
 }
@@ -515,7 +567,9 @@ a {
   }
 
   .panel-header,
-  .run-card-head {
+  .run-card-head,
+  .report-review-card-head,
+  .report-review-meta {
     flex-direction: column;
   }
 
@@ -539,7 +593,8 @@ a {
     border-radius: 20px;
   }
 
-  .primary-button {
+  .primary-button,
+  .secondary-button {
     width: 100%;
   }
 

--- a/src/app/runs/[runId]/page.test.tsx
+++ b/src/app/runs/[runId]/page.test.tsx
@@ -9,6 +9,19 @@ import {
   buildMissedArtifactSourceNote
 } from "@/features/artifacts/run-artifacts";
 
+vi.mock("next/navigation", async () => {
+  const actual = await vi.importActual<typeof import("next/navigation")>(
+    "next/navigation"
+  );
+
+  return {
+    ...actual,
+    useRouter: () => ({
+      refresh: vi.fn()
+    })
+  };
+});
+
 async function withTempDatabase(callback: (databasePath: string) => Promise<void>) {
   const tempDirectory = mkdtempSync(path.join(tmpdir(), "music-downloader-report-"));
   const databasePath = path.join(tempDirectory, "music-downloader.sqlite");
@@ -140,6 +153,108 @@ describe("RunReportPage", () => {
       expect(
         screen.getByText(/no paid fallback approvals are queued for this run yet/i)
       ).toBeVisible();
+    });
+  });
+
+  it("renders the persisted Beatport approval queue and review controls", async () => {
+    await withTempDatabase(async () => {
+      vi.resetModules();
+
+      const runStoreModule = await import("@/features/runs/run-store");
+      const store = runStoreModule.getRunStore();
+      const run = store.createRun({
+        playlistTitle: "Paid Queue Showcase",
+        playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+        sourceType: "spotify"
+      });
+      const tracks = store.replaceRunTracks(run.id, [
+        {
+          artist: "Anyma",
+          sourcePosition: 1,
+          title: "Consciousness",
+          version: "Extended Mix"
+        },
+        {
+          artist: "Mau P",
+          sourcePosition: 2,
+          title: "Drugs From Amsterdam"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+
+      const queuedReview = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3", "wav"],
+        candidateId: "beatport-queue-1",
+        mixLabel: "Extended Mix",
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/consciousness/queue-1",
+        queueName: "beatport-review",
+        runTrackId: tracks[0].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+      const purchasedReview = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3"],
+        candidateId: "beatport-queue-2",
+        mixLabel: null,
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/drugs-from-amsterdam/queue-2",
+        queueName: "beatport-review",
+        runTrackId: tracks[1].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+
+      store.transitionRunTrackReviewStatus(queuedReview.id, "approved");
+      store.transitionRunTrackReviewStatus(purchasedReview.id, "approved");
+      store.transitionRunTrackReviewStatus(purchasedReview.id, "purchased");
+
+      const pageModule = await import("./page");
+
+      render(
+        await pageModule.default({
+          params: Promise.resolve({ runId: run.id })
+        })
+      );
+
+      expect(screen.getByRole("heading", { name: /review lane/i })).toBeVisible();
+      expect(
+        screen.getAllByText(/queued after all automatic free-source providers missed/i)
+          .length
+      ).toBeGreaterThan(0);
+      expect(screen.getAllByText(/approved for manual purchase/i).length).toBeGreaterThan(
+        0
+      );
+      expect(
+        screen.getAllByText(/marked purchased \/ completed/i).length
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getByRole("button", {
+          name: /approve beatport candidate for anyma - consciousness/i
+        })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("button", {
+          name: /reject beatport candidate for anyma - consciousness/i
+        })
+      ).toBeVisible();
+      expect(
+        screen.getByRole("button", {
+          name: /mark beatport candidate purchased for anyma - consciousness/i
+        })
+      ).toBeVisible();
+      expect(
+        screen.queryByRole("button", {
+          name: /approve beatport candidate for mau p - drugs from amsterdam/i
+        })
+      ).not.toBeInTheDocument();
+      expect(queuedReview.candidateId).toBe("beatport-queue-1");
     });
   });
 });

--- a/src/features/reports/beatport-review-lane.tsx
+++ b/src/features/reports/beatport-review-lane.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { StatusBadge } from "@/components/ui/status-badge";
+
+import type { RunReportReviewQueueEntry } from "./run-report";
+
+type ReviewAction = "approve" | "purchased" | "reject";
+
+export function BeatportReviewLane({
+  reviewQueue,
+  runId
+}: {
+  reviewQueue: RunReportReviewQueueEntry[];
+  runId: string;
+}) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<{
+    action: ReviewAction;
+    reviewId: string;
+  } | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  async function handleReviewAction(reviewId: string, action: ReviewAction) {
+    setError(null);
+    setPendingAction({ action, reviewId });
+
+    try {
+      const response = await fetch(
+        `/api/runs/${encodeURIComponent(runId)}/review-queue/${encodeURIComponent(reviewId)}`,
+        {
+          body: JSON.stringify({ action }),
+          headers: {
+            "content-type": "application/json"
+          },
+          method: "POST"
+        }
+      );
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+
+        throw new Error(payload?.error ?? "Unable to update the paid review queue.");
+      }
+
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (caughtError) {
+      setError(
+        caughtError instanceof Error
+          ? caughtError.message
+          : "Unable to update the paid review queue."
+      );
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  return (
+    <div className="report-review-list">
+      {reviewQueue.map((review) => {
+        const actionIsPending = pendingAction?.reviewId === review.id;
+
+        return (
+          <article className="report-review-card" key={review.id}>
+            <div className="report-review-card-head">
+              <div className="report-review-title-block">
+                <p className="report-table-primary">
+                  {padTrackPosition(review.track.sourcePosition)} {review.track.artist} -{" "}
+                  {review.track.title}
+                </p>
+                <p className="report-table-secondary">
+                  {review.mixLabel ?? review.track.version ?? "Version pending"} •{" "}
+                  {formatAvailableFormats(review.availableFormats)}
+                </p>
+              </div>
+              <StatusBadge tone={getReviewStatusTone(review.status)}>
+                {review.status}
+              </StatusBadge>
+            </div>
+
+            <div className="report-review-meta">
+              <div className="report-table-stack">
+                <p className="report-table-primary">
+                  {review.providerUrl ? (
+                    <a className="inline-link" href={review.providerUrl}>
+                      {review.providerName}
+                    </a>
+                  ) : (
+                    review.providerName
+                  )}
+                </p>
+                <p className="report-table-secondary">{review.summary}</p>
+              </div>
+              <div className="report-table-stack">
+                <p className="report-table-primary">{formatReviewPrimaryCopy(review)}</p>
+                <p className="report-table-secondary">
+                  Queue {review.queueName} • candidate {review.candidateId}
+                </p>
+              </div>
+            </div>
+
+            {canMutateReview(review.status) ? (
+              <div className="report-review-actions">
+                <button
+                  className="primary-button"
+                  type="button"
+                  disabled={actionIsPending || isPending}
+                  aria-label={`Approve Beatport candidate for ${review.track.artist} - ${review.track.title}`}
+                  onClick={() => void handleReviewAction(review.id, "approve")}
+                >
+                  {isSpecificActionPending(pendingAction, review.id, "approve")
+                    ? "Approving..."
+                    : "Approve"}
+                </button>
+                <button
+                  className="secondary-button"
+                  type="button"
+                  disabled={actionIsPending || isPending}
+                  aria-label={`Mark Beatport candidate purchased for ${review.track.artist} - ${review.track.title}`}
+                  onClick={() => void handleReviewAction(review.id, "purchased")}
+                >
+                  {isSpecificActionPending(pendingAction, review.id, "purchased")
+                    ? "Saving..."
+                    : "Mark Purchased"}
+                </button>
+                <button
+                  className="secondary-button"
+                  type="button"
+                  disabled={actionIsPending || isPending}
+                  aria-label={`Reject Beatport candidate for ${review.track.artist} - ${review.track.title}`}
+                  onClick={() => void handleReviewAction(review.id, "reject")}
+                >
+                  {isSpecificActionPending(pendingAction, review.id, "reject")
+                    ? "Rejecting..."
+                    : "Reject"}
+                </button>
+              </div>
+            ) : null}
+          </article>
+        );
+      })}
+
+      {error ? (
+        <p className="form-status" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function canMutateReview(status: RunReportReviewQueueEntry["status"]) {
+  return status === "queued" || status === "approved";
+}
+
+function formatAvailableFormats(formats: RunReportReviewQueueEntry["availableFormats"]) {
+  return formats.map((format) => format.toUpperCase()).join(" / ");
+}
+
+function formatReviewPrimaryCopy(review: RunReportReviewQueueEntry) {
+  switch (review.status) {
+    case "approved":
+      return "Approved for manual purchase";
+    case "purchased":
+      return "Marked purchased / completed";
+    case "rejected":
+      return "Rejected during paid review";
+    default:
+      return "Awaiting operator review";
+  }
+}
+
+function getReviewStatusTone(status: RunReportReviewQueueEntry["status"]) {
+  if (status === "purchased") {
+    return "success" as const;
+  }
+
+  if (status === "rejected" || status === "approved") {
+    return "warning" as const;
+  }
+
+  return "muted" as const;
+}
+
+function isSpecificActionPending(
+  pendingAction: {
+    action: ReviewAction;
+    reviewId: string;
+  } | null,
+  reviewId: string,
+  action: ReviewAction
+) {
+  return pendingAction?.reviewId === reviewId && pendingAction.action === action;
+}
+
+function padTrackPosition(sourcePosition: number) {
+  return String(sourcePosition).padStart(3, "0");
+}

--- a/src/features/reports/run-report-screen.beatport-review.test.tsx
+++ b/src/features/reports/run-report-screen.beatport-review.test.tsx
@@ -1,0 +1,194 @@
+vi.mock("next/navigation", async () => {
+  const actual = await vi.importActual<typeof import("next/navigation")>(
+    "next/navigation"
+  );
+
+  return {
+    ...actual,
+    useRouter: () => ({
+      refresh: vi.fn()
+    })
+  };
+});
+
+import { render, screen } from "@testing-library/react";
+
+import { RunReportScreen } from "./run-report-screen";
+
+describe("RunReportScreen Beatport review lane", () => {
+  it("renders persisted Beatport queue entries and operator actions", () => {
+    render(<RunReportScreen report={buildBeatportReviewReport() as never} />);
+
+    expect(
+      screen.getAllByText(/queued after all automatic free-source providers missed/i)
+        .length
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText(/approved for manual purchase/i).length).toBeGreaterThan(
+      0
+    );
+    expect(
+      screen.getAllByText(/marked purchased \/ completed/i).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", {
+        name: /approve beatport candidate for anyma - consciousness/i
+      })
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: /reject beatport candidate for anyma - consciousness/i
+      })
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: /mark beatport candidate purchased for anyma - consciousness/i
+      })
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", {
+        name: /approve beatport candidate for mau p - drugs from amsterdam/i
+      })
+    ).not.toBeInTheDocument();
+  });
+});
+
+function buildBeatportReviewReport() {
+  return {
+    artifactCount: 0,
+    artifacts: [],
+    completedTrackCount: 1,
+    createdAt: "2026-03-31T14:00:00.000Z",
+    id: "run-review",
+    missCount: 0,
+    playlistTitle: "Paid Queue Showcase",
+    playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+    reviewQueue: [
+      {
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3", "wav"],
+        candidateId: "beatport-queue-1",
+        createdAt: "2026-03-31T14:05:00.000Z",
+        id: "review-1",
+        mixLabel: "Extended Mix",
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/consciousness/queue-1",
+        queueName: "beatport-review",
+        runTrackId: "track-1",
+        status: "approved",
+        summary: "Queued after all automatic free-source providers missed.",
+        track: {
+          artist: "Anyma",
+          id: "track-1",
+          sourcePosition: 1,
+          title: "Consciousness",
+          version: "Extended Mix"
+        },
+        updatedAt: "2026-03-31T14:06:00.000Z"
+      },
+      {
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3"],
+        candidateId: "beatport-queue-2",
+        createdAt: "2026-03-31T14:06:00.000Z",
+        id: "review-2",
+        mixLabel: null,
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/drugs-from-amsterdam/queue-2",
+        queueName: "beatport-review",
+        runTrackId: "track-2",
+        status: "purchased",
+        summary: "Queued after all automatic free-source providers missed.",
+        track: {
+          artist: "Mau P",
+          id: "track-2",
+          sourcePosition: 2,
+          title: "Drugs From Amsterdam",
+          version: null
+        },
+        updatedAt: "2026-03-31T14:08:00.000Z"
+      }
+    ],
+    resumeAfterStatus: null,
+    selectedSourceCount: 1,
+    sourceType: "spotify",
+    status: "awaiting-approval",
+    trackCount: 2,
+    tracks: [
+      {
+        artist: "Anyma",
+        id: "track-1",
+        latestAttempt: null,
+        resolution: null,
+        reviewQueueEntry: {
+          authorizationBasis: "purchase-entitlement",
+          availableFormats: ["mp3", "wav"],
+          candidateId: "beatport-queue-1",
+          createdAt: "2026-03-31T14:05:00.000Z",
+          id: "review-1",
+          mixLabel: "Extended Mix",
+          priceTier: "paid",
+          providerKey: "beatport",
+          providerName: "Beatport",
+          providerUrl: "https://www.beatport.com/track/consciousness/queue-1",
+          queueName: "beatport-review",
+          runTrackId: "track-1",
+          status: "approved",
+          summary: "Queued after all automatic free-source providers missed.",
+          track: {
+            artist: "Anyma",
+            id: "track-1",
+            sourcePosition: 1,
+            title: "Consciousness",
+            version: "Extended Mix"
+          },
+          updatedAt: "2026-03-31T14:06:00.000Z"
+        },
+        sourcePosition: 1,
+        sourceTrackId: "sp-101",
+        status: "awaiting-approval",
+        title: "Consciousness",
+        version: "Extended Mix"
+      },
+      {
+        artist: "Mau P",
+        id: "track-2",
+        latestAttempt: null,
+        resolution: null,
+        reviewQueueEntry: {
+          authorizationBasis: "purchase-entitlement",
+          availableFormats: ["mp3"],
+          candidateId: "beatport-queue-2",
+          createdAt: "2026-03-31T14:06:00.000Z",
+          id: "review-2",
+          mixLabel: null,
+          priceTier: "paid",
+          providerKey: "beatport",
+          providerName: "Beatport",
+          providerUrl: "https://www.beatport.com/track/drugs-from-amsterdam/queue-2",
+          queueName: "beatport-review",
+          runTrackId: "track-2",
+          status: "purchased",
+          summary: "Queued after all automatic free-source providers missed.",
+          track: {
+            artist: "Mau P",
+            id: "track-2",
+            sourcePosition: 2,
+            title: "Drugs From Amsterdam",
+            version: null
+          },
+          updatedAt: "2026-03-31T14:08:00.000Z"
+        },
+        sourcePosition: 2,
+        sourceTrackId: "sp-102",
+        status: "acquired",
+        title: "Drugs From Amsterdam",
+        version: null
+      }
+    ],
+    updatedAt: "2026-03-31T14:08:00.000Z"
+  };
+}

--- a/src/features/reports/run-report-screen.test.tsx
+++ b/src/features/reports/run-report-screen.test.tsx
@@ -57,6 +57,7 @@ function buildRunningReport() {
     missCount: 0,
     playlistTitle: "Warehouse Warmup",
     playlistUrl: "https://soundcloud.com/sets/warehouse-warmup",
+    reviewQueue: [],
     resumeAfterStatus: null,
     selectedSourceCount: 0,
     sourceType: "soundcloud",
@@ -114,6 +115,7 @@ function buildCompletedReport() {
     completedTrackCount: 2,
     id: "run-complete",
     playlistTitle: "Warehouse Drivers",
+    reviewQueue: [],
     selectedSourceCount: 1,
     status: "completed",
     tracks: [

--- a/src/features/reports/run-report-screen.tsx
+++ b/src/features/reports/run-report-screen.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { Panel } from "@/components/ui/panel";
 import { StatusBadge } from "@/components/ui/status-badge";
 
+import { BeatportReviewLane } from "./beatport-review-lane";
 import type {
   RunReportDetail,
   RunReportTrack,
@@ -123,9 +124,13 @@ export function RunReportScreen({ report }: { report: RunReportDetail }) {
             <span className="panel-caption">Reserved for paid fallback approvals</span>
           }
         >
-          <p className="report-empty-copy">
-            No paid fallback approvals are queued for this run yet.
-          </p>
+          {report.reviewQueue.length ? (
+            <BeatportReviewLane reviewQueue={report.reviewQueue} runId={report.id} />
+          ) : (
+            <p className="report-empty-copy">
+              No paid fallback approvals are queued for this run yet.
+            </p>
+          )}
         </Panel>
 
         <Panel
@@ -218,6 +223,28 @@ function renderTrackSource(track: RunReportTrack) {
     );
   }
 
+  if (track.reviewQueueEntry) {
+    const providerName = track.reviewQueueEntry.providerUrl ? (
+      <a className="inline-link" href={track.reviewQueueEntry.providerUrl}>
+        {track.reviewQueueEntry.providerName}
+      </a>
+    ) : (
+      track.reviewQueueEntry.providerName
+    );
+
+    return (
+      <div className="report-table-stack">
+        <p className="report-table-primary">{providerName}</p>
+        <p className="report-table-secondary">
+          {track.reviewQueueEntry.mixLabel ?? track.version ?? "Version pending"} •{" "}
+          {track.reviewQueueEntry.availableFormats
+            .map((format) => format.toUpperCase())
+            .join(" / ")}
+        </p>
+      </div>
+    );
+  }
+
   if (track.latestAttempt) {
     return (
       <div className="report-table-stack">
@@ -253,6 +280,17 @@ function renderTrackDecision(track: RunReportTrack) {
     );
   }
 
+  if (track.reviewQueueEntry) {
+    return (
+      <div className="report-table-stack">
+        <p className="report-table-primary">
+          {formatReviewDecision(track.reviewQueueEntry.status)}
+        </p>
+        <p className="report-table-secondary">{track.reviewQueueEntry.summary}</p>
+      </div>
+    );
+  }
+
   if (terminalTrackStatuses.has(track.status)) {
     return (
       <p className="report-empty-copy">
@@ -262,6 +300,21 @@ function renderTrackDecision(track: RunReportTrack) {
   }
 
   return <p className="report-empty-copy">Waiting on matching or packaging work.</p>;
+}
+
+function formatReviewDecision(
+  status: NonNullable<RunReportTrack["reviewQueueEntry"]>["status"]
+) {
+  switch (status) {
+    case "approved":
+      return "Approved for manual purchase";
+    case "purchased":
+      return "Marked purchased / completed";
+    case "rejected":
+      return "Rejected during paid review";
+    default:
+      return "Awaiting operator review";
+  }
 }
 
 function formatCount(value: number, singular: string, plural: string) {

--- a/src/features/reports/run-report.ts
+++ b/src/features/reports/run-report.ts
@@ -9,7 +9,8 @@ import {
   type RunDetail,
   type RunStore,
   type RunTrack,
-  type RunTrackAcquisitionAttempt
+  type RunTrackAcquisitionAttempt,
+  type RunTrackReview
 } from "@/features/runs/run-store";
 import type { TrackAcceptedDecision, TrackAudioFormat } from "@/features/tracks/canonical-track";
 import type {
@@ -47,6 +48,7 @@ export type RunReportTrack = RunTrack & {
     outcome: RunTrackAcquisitionAttempt["outcome"];
     providerKey: string;
   } | null;
+  reviewQueueEntry: RunReportReviewQueueEntry | null;
   resolution: RunReportTrackResolution | null;
 };
 
@@ -56,12 +58,20 @@ export type RunReportArtifact = {
   label: string;
 };
 
-export type RunReportBase = Omit<RunDetail, "artifacts" | "tracks">;
+export type RunReportBase = Omit<RunDetail, "artifacts" | "reviewQueue" | "tracks">;
+
+export type RunReportReviewQueueEntry = RunTrackReview & {
+  track: Pick<
+    RunTrack,
+    "artist" | "id" | "sourcePosition" | "title" | "version"
+  >;
+};
 
 export type RunReportDetail = RunReportBase & {
   artifacts: RunReportArtifact[];
   completedTrackCount: number;
   missCount: number;
+  reviewQueue: RunReportReviewQueueEntry[];
   selectedSourceCount: number;
   tracks: RunReportTrack[];
 };
@@ -76,8 +86,16 @@ export function getRunReport(input: { runId: string; runStore?: RunStore }) {
 
   const attempts = runStore.listRunTrackAttempts(input.runId);
   const attemptsByTrackId = groupAttemptsByTrackId(attempts);
+  const reviewQueue = run.reviewQueue
+    .map((review) => mapRunReportReviewQueueEntry(review, run.tracks))
+    .filter((review): review is RunReportReviewQueueEntry => review !== null);
+  const reviewQueueByTrackId = groupReviewQueueByTrackId(reviewQueue);
   const tracks = run.tracks.map((track) =>
-    mapRunReportTrack(track, attemptsByTrackId.get(track.id) ?? [])
+    mapRunReportTrack(
+      track,
+      attemptsByTrackId.get(track.id) ?? [],
+      reviewQueueByTrackId.get(track.id) ?? null
+    )
   );
 
   return {
@@ -96,8 +114,11 @@ export function getRunReport(input: { runId: string; runStore?: RunStore }) {
       track.status === "failed"
     ).length,
     missCount: tracks.filter((track) => track.status === "missed").length,
+    reviewQueue,
     selectedSourceCount: tracks.filter(
-      (track) => track.resolution?.type === "selected"
+      (track) =>
+        track.resolution?.type === "selected" ||
+        track.reviewQueueEntry?.status === "purchased"
     ).length,
     tracks
   };
@@ -120,9 +141,14 @@ function groupAttemptsByTrackId(attempts: RunTrackAcquisitionAttempt[]) {
   return attemptsByTrackId;
 }
 
+function groupReviewQueueByTrackId(reviewQueue: RunReportReviewQueueEntry[]) {
+  return new Map(reviewQueue.map((review) => [review.runTrackId, review]));
+}
+
 function mapRunReportTrack(
   track: RunTrack,
-  attempts: RunTrackAcquisitionAttempt[]
+  attempts: RunTrackAcquisitionAttempt[],
+  reviewQueueEntry: RunReportReviewQueueEntry | null
 ): RunReportTrack {
   const latestAttempt = attempts.at(0);
   const note = attempts
@@ -139,8 +165,31 @@ function mapRunReportTrack(
           providerKey: latestAttempt.providerKey
         }
       : null,
+    reviewQueueEntry,
     resolution: mapRunReportTrackResolution(note)
   };
+}
+
+function mapRunReportReviewQueueEntry(
+  review: RunTrackReview,
+  tracks: RunTrack[]
+) {
+  const track = tracks.find((candidate) => candidate.id === review.runTrackId);
+
+  if (!track) {
+    return null;
+  }
+
+  return {
+    ...review,
+    track: {
+      artist: track.artist,
+      id: track.id,
+      sourcePosition: track.sourcePosition,
+      title: track.title,
+      version: track.version
+    }
+  } satisfies RunReportReviewQueueEntry;
 }
 
 function mapRunReportTrackResolution(

--- a/src/features/runs/migrations/0002-run-track-review-queue.sql
+++ b/src/features/runs/migrations/0002-run-track-review-queue.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS run_track_reviews (
+  id TEXT PRIMARY KEY,
+  run_track_id TEXT NOT NULL UNIQUE REFERENCES run_tracks(id) ON DELETE CASCADE,
+  provider_key TEXT NOT NULL,
+  provider_name TEXT NOT NULL,
+  provider_url TEXT,
+  authorization_basis TEXT NOT NULL CHECK (
+    authorization_basis IN (
+      'uploader-enabled-download',
+      'rights-holder-storefront',
+      'purchase-entitlement'
+    )
+  ),
+  price_tier TEXT NOT NULL CHECK (
+    price_tier IN ('free', 'free-or-owned', 'paid')
+  ),
+  candidate_id TEXT NOT NULL,
+  mix_label TEXT,
+  available_formats TEXT NOT NULL,
+  queue_name TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (
+    status IN ('queued', 'approved', 'rejected', 'purchased')
+  ),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS run_track_reviews_track_created_idx
+  ON run_track_reviews(run_track_id, created_at DESC);

--- a/src/features/runs/run-store.beatport-review.test.ts
+++ b/src/features/runs/run-store.beatport-review.test.ts
@@ -1,0 +1,203 @@
+/* @vitest-environment node */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { createRunStore, type RunTrackStatus } from "./run-store";
+
+function createTempDatabasePath() {
+  const tempDirectory = mkdtempSync(
+    path.join(tmpdir(), "music-downloader-run-store-beatport-")
+  );
+
+  return {
+    databasePath: path.join(tempDirectory, "music-downloader.sqlite"),
+    cleanup() {
+      rmSync(tempDirectory, { force: true, recursive: true });
+    }
+  };
+}
+
+describe("createRunStore Beatport review queue", () => {
+  it("groups paid fallback candidates into one persisted per-run review queue", () => {
+    const tempDatabase = createTempDatabasePath();
+
+    try {
+      const store = createRunStore({ databasePath: tempDatabase.databasePath });
+      const run = store.createRun({
+        playlistTitle: "Beatport Review Batch",
+        playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+        sourceType: "spotify"
+      });
+      const tracks = store.replaceRunTracks(run.id, [
+        {
+          artist: "Anyma",
+          sourcePosition: 1,
+          title: "Consciousness",
+          version: "Extended Mix"
+        },
+        {
+          artist: "Mau P",
+          sourcePosition: 2,
+          title: "Drugs From Amsterdam"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+
+      const firstReview = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3", "wav"],
+        candidateId: "beatport-1001",
+        mixLabel: "Extended Mix",
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/consciousness/1001",
+        queueName: "beatport-review",
+        runTrackId: tracks[0].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+      const secondReview = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3"],
+        candidateId: "beatport-1002",
+        mixLabel: null,
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/drugs-from-amsterdam/1002",
+        queueName: "beatport-review",
+        runTrackId: tracks[1].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+
+      const persistedRun = store.getRun(run.id);
+
+      expect(persistedRun).toEqual(
+        expect.objectContaining({
+          id: run.id,
+          reviewQueue: [
+            expect.objectContaining({
+              candidateId: "beatport-1001",
+              id: firstReview.id,
+              providerKey: "beatport",
+              queueName: "beatport-review",
+              runTrackId: tracks[0].id,
+              status: "queued"
+            }),
+            expect.objectContaining({
+              candidateId: "beatport-1002",
+              id: secondReview.id,
+              providerKey: "beatport",
+              queueName: "beatport-review",
+              runTrackId: tracks[1].id,
+              status: "queued"
+            })
+          ],
+          status: "awaiting-approval"
+        })
+      );
+      expect(
+        persistedRun?.tracks.map(
+          (track) =>
+            [track.sourcePosition, track.status] satisfies [number, RunTrackStatus]
+        )
+      ).toEqual([
+        [1, "awaiting-approval"],
+        [2, "awaiting-approval"]
+      ]);
+    } finally {
+      tempDatabase.cleanup();
+    }
+  });
+
+  it("persists approve reject and purchased review transitions", () => {
+    const tempDatabase = createTempDatabasePath();
+
+    try {
+      const store = createRunStore({ databasePath: tempDatabase.databasePath });
+      const run = store.createRun({
+        playlistTitle: "Paid Fallback Review",
+        playlistUrl: "https://soundcloud.com/sets/paid-fallback-review",
+        sourceType: "soundcloud"
+      });
+      const tracks = store.replaceRunTracks(run.id, [
+        {
+          artist: "Artist One",
+          sourcePosition: 1,
+          title: "Track One"
+        },
+        {
+          artist: "Artist Two",
+          sourcePosition: 2,
+          title: "Track Two"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+
+      const approvedReview = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3", "wav"],
+        candidateId: "beatport-2001",
+        mixLabel: "Original Mix",
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/track-one/2001",
+        queueName: "beatport-review",
+        runTrackId: tracks[0].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+      const rejectedReview = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3"],
+        candidateId: "beatport-2002",
+        mixLabel: null,
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/track-two/2002",
+        queueName: "beatport-review",
+        runTrackId: tracks[1].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+
+      const approvedResult = store.transitionRunTrackReviewStatus(
+        approvedReview.id,
+        "approved"
+      );
+      const rejectedResult = store.transitionRunTrackReviewStatus(
+        rejectedReview.id,
+        "rejected"
+      );
+      const purchasedResult = store.transitionRunTrackReviewStatus(
+        approvedReview.id,
+        "purchased"
+      );
+      const persistedRun = store.getRun(run.id);
+
+      expect(approvedResult.status).toBe("approved");
+      expect(rejectedResult.status).toBe("rejected");
+      expect(purchasedResult.status).toBe("purchased");
+      expect(persistedRun).toEqual(
+        expect.objectContaining({
+          id: run.id,
+          status: "packaging"
+        })
+      );
+      expect(
+        persistedRun?.reviewQueue.map((review) => [review.candidateId, review.status])
+      ).toEqual([
+        ["beatport-2001", "purchased"],
+        ["beatport-2002", "rejected"]
+      ]);
+    } finally {
+      tempDatabase.cleanup();
+    }
+  });
+});

--- a/src/features/runs/run-store.test.ts
+++ b/src/features/runs/run-store.test.ts
@@ -163,4 +163,191 @@ describe("createRunStore", () => {
       tempDatabase.cleanup();
     }
   });
+
+  it("persists paid review candidates as one per-run approval queue", () => {
+    const tempDatabase = createTempDatabasePath();
+
+    try {
+      const store = createRunStore({ databasePath: tempDatabase.databasePath });
+      const run = store.createRun({
+        playlistTitle: "Beatport Review Batch",
+        playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+        sourceType: "spotify"
+      });
+      const tracks = store.replaceRunTracks(run.id, [
+        {
+          artist: "Anyma",
+          sourcePosition: 1,
+          title: "Consciousness",
+          version: "Extended Mix"
+        },
+        {
+          artist: "Mau P",
+          sourcePosition: 2,
+          title: "Drugs From Amsterdam"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+
+      const firstReview = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3", "wav"],
+        candidateId: "beatport-1001",
+        mixLabel: "Extended Mix",
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/consciousness/1001",
+        queueName: "beatport-review",
+        runTrackId: tracks[0].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+      const secondReview = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3"],
+        candidateId: "beatport-1002",
+        mixLabel: null,
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/drugs-from-amsterdam/1002",
+        queueName: "beatport-review",
+        runTrackId: tracks[1].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+
+      const persistedRun = store.getRun(run.id);
+
+      expect(persistedRun).toEqual(
+        expect.objectContaining({
+          id: run.id,
+          reviewQueue: [
+            expect.objectContaining({
+              candidateId: "beatport-1001",
+              id: firstReview.id,
+              providerKey: "beatport",
+              queueName: "beatport-review",
+              runTrackId: tracks[0].id,
+              status: "queued"
+            }),
+            expect.objectContaining({
+              candidateId: "beatport-1002",
+              id: secondReview.id,
+              providerKey: "beatport",
+              queueName: "beatport-review",
+              runTrackId: tracks[1].id,
+              status: "queued"
+            })
+          ],
+          status: "awaiting-approval"
+        })
+      );
+      expect(
+        persistedRun?.tracks.map((track) => [track.sourcePosition, track.status])
+      ).toEqual([
+        [1, "awaiting-approval"],
+        [2, "awaiting-approval"]
+      ]);
+    } finally {
+      tempDatabase.cleanup();
+    }
+  });
+
+  it("updates review queue, track outcomes, and run lifecycle for approve reject and purchased actions", () => {
+    const tempDatabase = createTempDatabasePath();
+
+    try {
+      const store = createRunStore({ databasePath: tempDatabase.databasePath });
+      const run = store.createRun({
+        playlistTitle: "Paid Fallback Review",
+        playlistUrl: "https://soundcloud.com/sets/paid-fallback-review",
+        sourceType: "soundcloud"
+      });
+      const tracks = store.replaceRunTracks(run.id, [
+        {
+          artist: "Artist One",
+          sourcePosition: 1,
+          title: "Track One"
+        },
+        {
+          artist: "Artist Two",
+          sourcePosition: 2,
+          title: "Track Two"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+
+      const approvedReview = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3", "wav"],
+        candidateId: "beatport-2001",
+        mixLabel: "Original Mix",
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/track-one/2001",
+        queueName: "beatport-review",
+        runTrackId: tracks[0].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+      const rejectedReview = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3"],
+        candidateId: "beatport-2002",
+        mixLabel: null,
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/track-two/2002",
+        queueName: "beatport-review",
+        runTrackId: tracks[1].id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+
+      const approvedResult = store.transitionRunTrackReviewStatus(
+        approvedReview.id,
+        "approved"
+      );
+      const rejectedResult = store.transitionRunTrackReviewStatus(
+        rejectedReview.id,
+        "rejected"
+      );
+      const purchasedResult = store.transitionRunTrackReviewStatus(
+        approvedReview.id,
+        "purchased"
+      );
+      const persistedRun = store.getRun(run.id);
+
+      expect(approvedResult.status).toBe("approved");
+      expect(rejectedResult.status).toBe("rejected");
+      expect(purchasedResult.status).toBe("purchased");
+      expect(persistedRun).toEqual(
+        expect.objectContaining({
+          id: run.id,
+          status: "packaging"
+        })
+      );
+      expect(
+        persistedRun?.reviewQueue.map((review) => [review.candidateId, review.status])
+      ).toEqual([
+        ["beatport-2001", "purchased"],
+        ["beatport-2002", "rejected"]
+      ]);
+      expect(
+        persistedRun?.tracks.map(
+          (track) =>
+            [track.sourcePosition, track.status] satisfies [number, RunTrackStatus]
+        )
+      ).toEqual([
+        [1, "acquired"],
+        [2, "missed"]
+      ]);
+    } finally {
+      tempDatabase.cleanup();
+    }
+  });
 });

--- a/src/features/runs/run-store.ts
+++ b/src/features/runs/run-store.ts
@@ -2,6 +2,12 @@ import { mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
+import type {
+  ProviderArtifactFormat,
+  ProviderAuthorizationBasis,
+  ProviderPriceTier
+} from "@/features/providers/provider-registry";
+
 export const runStatuses = [
   "queued",
   "ingesting",
@@ -21,9 +27,17 @@ export const runTrackStatuses = [
   "failed"
 ] as const;
 
+export const runTrackReviewStatuses = [
+  "queued",
+  "approved",
+  "rejected",
+  "purchased"
+] as const;
+
 export type PlaylistSource = "spotify" | "soundcloud";
 export type RunStatus = (typeof runStatuses)[number];
 export type RunTrackStatus = (typeof runTrackStatuses)[number];
+export type RunTrackReviewStatus = (typeof runTrackReviewStatuses)[number];
 export type ArtifactKind =
   | "downloads-zip"
   | "manifest-json"
@@ -79,6 +93,24 @@ type AcquisitionAttemptRow = {
   run_track_id: string;
 };
 
+type RunTrackReviewRow = {
+  authorization_basis: ProviderAuthorizationBasis;
+  available_formats: string;
+  candidate_id: string;
+  created_at: string;
+  id: string;
+  mix_label: string | null;
+  price_tier: ProviderPriceTier;
+  provider_key: string;
+  provider_name: string;
+  provider_url: string | null;
+  queue_name: string;
+  run_track_id: string;
+  status: RunTrackReviewStatus;
+  summary: string;
+  updated_at: string;
+};
+
 export type RunSummary = {
   id: string;
   sourceType: PlaylistSource;
@@ -122,9 +154,28 @@ export type RunTrackAcquisitionAttempt = {
   runTrackId: string;
 };
 
+export type RunTrackReview = {
+  authorizationBasis: ProviderAuthorizationBasis;
+  availableFormats: ProviderArtifactFormat[];
+  candidateId: string;
+  createdAt: string;
+  id: string;
+  mixLabel: string | null;
+  priceTier: ProviderPriceTier;
+  providerKey: string;
+  providerName: string;
+  providerUrl: string | null;
+  queueName: string;
+  runTrackId: string;
+  status: RunTrackReviewStatus;
+  summary: string;
+  updatedAt: string;
+};
+
 export type RunDetail = RunSummary & {
   tracks: RunTrack[];
   artifacts: RunArtifact[];
+  reviewQueue: RunTrackReview[];
 };
 
 export type RunStatusSnapshot = Pick<
@@ -165,6 +216,20 @@ export type RecordRunArtifactInput = {
   runId: string;
 };
 
+export type QueueRunTrackReviewInput = {
+  authorizationBasis: ProviderAuthorizationBasis;
+  availableFormats: ProviderArtifactFormat[];
+  candidateId: string;
+  mixLabel?: string | null;
+  priceTier: ProviderPriceTier;
+  providerKey: string;
+  providerName: string;
+  providerUrl?: string | null;
+  queueName: string;
+  runTrackId: string;
+  summary: string;
+};
+
 type RunAggregateRow = RunRow & {
   artifact_count: number;
   track_count: number;
@@ -187,12 +252,29 @@ const allowedRunStatusTransitions: Record<RunStatus, RunStatus[]> = {
 };
 
 const resumableRunStatuses: RunStatus[] = ["ingesting", "matching", "packaging"];
+const allowedRunTrackReviewStatusTransitions: Record<
+  RunTrackReviewStatus,
+  RunTrackReviewStatus[]
+> = {
+  approved: ["rejected", "purchased"],
+  purchased: [],
+  queued: ["approved", "rejected", "purchased"],
+  rejected: []
+};
 
-const migrationName = "0001-initial";
-const migrationPath = path.join(
-  process.cwd(),
-  "src/features/runs/migrations/0001-initial.sql"
-);
+const migrations = [
+  {
+    name: "0001-initial",
+    path: path.join(process.cwd(), "src/features/runs/migrations/0001-initial.sql")
+  },
+  {
+    name: "0002-run-track-review-queue",
+    path: path.join(
+      process.cwd(),
+      "src/features/runs/migrations/0002-run-track-review-queue.sql"
+    )
+  }
+] as const;
 
 let defaultRunStore: ReturnType<typeof createRunStore> | null = null;
 
@@ -212,6 +294,14 @@ function assertValidRunTrackStatus(
 ): asserts status is RunTrackStatus {
   if (!runTrackStatuses.includes(status as RunTrackStatus)) {
     throw new Error(`Unsupported run track status: ${status}`);
+  }
+}
+
+function assertValidRunTrackReviewStatus(
+  status: string
+): asserts status is RunTrackReviewStatus {
+  if (!runTrackReviewStatuses.includes(status as RunTrackReviewStatus)) {
+    throw new Error(`Unsupported run track review status: ${status}`);
   }
 }
 
@@ -253,6 +343,26 @@ function mapRunTrackAcquisitionAttempt(
   };
 }
 
+function mapRunTrackReview(row: RunTrackReviewRow): RunTrackReview {
+  return {
+    authorizationBasis: row.authorization_basis,
+    availableFormats: JSON.parse(row.available_formats) as ProviderArtifactFormat[],
+    candidateId: row.candidate_id,
+    createdAt: row.created_at,
+    id: row.id,
+    mixLabel: row.mix_label,
+    priceTier: row.price_tier,
+    providerKey: row.provider_key,
+    providerName: row.provider_name,
+    providerUrl: row.provider_url,
+    queueName: row.queue_name,
+    runTrackId: row.run_track_id,
+    status: row.status,
+    summary: row.summary,
+    updatedAt: row.updated_at
+  };
+}
+
 function mapRunSummary(row: RunAggregateRow): RunSummary {
   return {
     artifactCount: Number(row.artifact_count),
@@ -289,29 +399,31 @@ function ensureSchema(database: DatabaseSync) {
     )
   `);
 
-  const migrationAlreadyApplied = database
-    .prepare("SELECT name FROM schema_migrations WHERE name = ?")
-    .get(migrationName) as { name: string } | undefined;
+  for (const migration of migrations) {
+    const migrationAlreadyApplied = database
+      .prepare("SELECT name FROM schema_migrations WHERE name = ?")
+      .get(migration.name) as { name: string } | undefined;
 
-  if (migrationAlreadyApplied) {
-    return;
-  }
+    if (migrationAlreadyApplied) {
+      continue;
+    }
 
-  const schemaSql = readFileSync(migrationPath, "utf8");
+    const schemaSql = readFileSync(migration.path, "utf8");
 
-  database.exec("BEGIN");
+    database.exec("BEGIN");
 
-  try {
-    database.exec(schemaSql);
-    database
-      .prepare(
-        "INSERT INTO schema_migrations (name, applied_at) VALUES (?, ?)"
-      )
-      .run(migrationName, getTimestamp());
-    database.exec("COMMIT");
-  } catch (error) {
-    database.exec("ROLLBACK");
-    throw error;
+    try {
+      database.exec(schemaSql);
+      database
+        .prepare(
+          "INSERT INTO schema_migrations (name, applied_at) VALUES (?, ?)"
+        )
+        .run(migration.name, getTimestamp());
+      database.exec("COMMIT");
+    } catch (error) {
+      database.exec("ROLLBACK");
+      throw error;
+    }
   }
 }
 
@@ -340,6 +452,18 @@ export function createRunStore(options: RunStoreOptions = {}) {
   const database = new DatabaseSync(databasePath);
 
   ensureSchema(database);
+
+  function readRunTrack(trackId: string) {
+    return database
+      .prepare("SELECT * FROM run_tracks WHERE id = ?")
+      .get(trackId) as RunTrackRow | undefined;
+  }
+
+  function readRunTrackReview(reviewId: string) {
+    return database
+      .prepare("SELECT * FROM run_track_reviews WHERE id = ?")
+      .get(reviewId) as RunTrackReviewRow | undefined;
+  }
 
   function readRunAggregate(runId: string) {
     return database
@@ -372,6 +496,61 @@ export function createRunStore(options: RunStoreOptions = {}) {
     }
 
     return run;
+  }
+
+  function updateRunStatusDirect(
+    runId: string,
+    currentStatus: RunStatus,
+    nextStatus: RunStatus,
+    now: string
+  ) {
+    if (currentStatus === nextStatus) {
+      return;
+    }
+
+    ensureAllowedTransition(currentStatus, nextStatus);
+
+    database
+      .prepare(
+        `
+          UPDATE runs
+          SET status = ?,
+              resume_after_status = ?,
+              updated_at = ?,
+              completed_at = ?,
+              failed_at = ?
+          WHERE id = ?
+        `
+      )
+      .run(nextStatus, null, now, null, null, runId);
+  }
+
+  function syncRunStatusForReviewQueue(runId: string, now: string) {
+    const currentRun = getRunOrThrow(runId);
+    const unresolvedReviews = database
+      .prepare(
+        `
+          SELECT COUNT(*) AS count
+          FROM run_track_reviews
+          INNER JOIN run_tracks
+            ON run_tracks.id = run_track_reviews.run_track_id
+          WHERE run_tracks.run_id = ?
+            AND run_track_reviews.status IN ('queued', 'approved')
+        `
+      )
+      .get(runId) as { count: number };
+
+    if (unresolvedReviews.count > 0) {
+      if (currentRun.status === "matching") {
+        updateRunStatusDirect(runId, currentRun.status, "awaiting-approval", now);
+      }
+
+      return;
+    }
+
+    if (currentRun.status === "awaiting-approval") {
+      updateRunStatusDirect(runId, currentRun.status, "packaging", now);
+    }
   }
 
   function requeueInterruptedRuns() {
@@ -486,10 +665,31 @@ export function createRunStore(options: RunStoreOptions = {}) {
           `
         )
         .all(runId) as RunArtifactRow[];
+      const reviewQueue = database
+        .prepare(
+          `
+            SELECT run_track_reviews.*
+            FROM run_track_reviews
+            INNER JOIN run_tracks
+              ON run_tracks.id = run_track_reviews.run_track_id
+            WHERE run_tracks.run_id = ?
+            ORDER BY
+              CASE run_track_reviews.status
+                WHEN 'queued' THEN 0
+                WHEN 'approved' THEN 1
+                WHEN 'purchased' THEN 2
+                ELSE 3
+              END,
+              run_tracks.source_position ASC,
+              run_track_reviews.created_at ASC
+          `
+        )
+        .all(runId) as RunTrackReviewRow[];
 
       return {
         ...mapRunSummary(row),
         artifacts: artifacts.map(mapRunArtifact),
+        reviewQueue: reviewQueue.map(mapRunTrackReview),
         tracks: tracks.map(mapRunTrack)
       };
     },
@@ -567,6 +767,119 @@ export function createRunStore(options: RunStoreOptions = {}) {
         );
 
       return id;
+    },
+
+    queueRunTrackReview(input: QueueRunTrackReviewInput) {
+      if (input.priceTier !== "paid") {
+        throw new Error(
+          `Run track reviews only support paid fallback providers: ${input.providerKey}`
+        );
+      }
+
+      const track = readRunTrack(input.runTrackId);
+
+      if (!track) {
+        throw new Error(`Run track not found: ${input.runTrackId}`);
+      }
+
+      const run = getRunOrThrow(track.run_id);
+
+      if (run.status !== "matching" && run.status !== "awaiting-approval") {
+        throw new Error(
+          `Run track reviews can only be queued while matching or awaiting approval: ${run.status}`
+        );
+      }
+
+      const existingReview = database
+        .prepare(
+          `
+            SELECT id
+            FROM run_track_reviews
+            WHERE run_track_id = ?
+          `
+        )
+        .get(input.runTrackId) as { id: string } | undefined;
+
+      if (existingReview) {
+        throw new Error(
+          `Run track already has a queued paid review candidate: ${input.runTrackId}`
+        );
+      }
+
+      const now = getTimestamp();
+      const id = crypto.randomUUID();
+
+      database.exec("BEGIN");
+
+      try {
+        database
+          .prepare(
+            `
+              INSERT INTO run_track_reviews (
+                id,
+                run_track_id,
+                provider_key,
+                provider_name,
+                provider_url,
+                authorization_basis,
+                price_tier,
+                candidate_id,
+                mix_label,
+                available_formats,
+                queue_name,
+                summary,
+                status,
+                created_at,
+                updated_at
+              )
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `
+          )
+          .run(
+            id,
+            input.runTrackId,
+            input.providerKey,
+            input.providerName,
+            input.providerUrl ?? null,
+            input.authorizationBasis,
+            input.priceTier,
+            input.candidateId,
+            input.mixLabel ?? null,
+            JSON.stringify(input.availableFormats),
+            input.queueName,
+            input.summary,
+            "queued",
+            now,
+            now
+          );
+
+        database
+          .prepare(
+            `
+              UPDATE run_tracks
+              SET status = ?,
+                  updated_at = ?
+              WHERE id = ?
+            `
+          )
+          .run("awaiting-approval", now, input.runTrackId);
+        database
+          .prepare("UPDATE runs SET updated_at = ? WHERE id = ?")
+          .run(now, track.run_id);
+        syncRunStatusForReviewQueue(track.run_id, now);
+        database.exec("COMMIT");
+      } catch (error) {
+        database.exec("ROLLBACK");
+        throw error;
+      }
+
+      const review = readRunTrackReview(id);
+
+      if (!review) {
+        throw new Error(`Run track review not found after insert: ${id}`);
+      }
+
+      return mapRunTrackReview(review);
     },
 
     recordRunArtifact(input: RecordRunArtifactInput) {
@@ -734,6 +1047,80 @@ export function createRunStore(options: RunStoreOptions = {}) {
       return attempts.map(mapRunTrackAcquisitionAttempt);
     },
 
+    transitionRunTrackReviewStatus(
+      reviewId: string,
+      nextStatus: RunTrackReviewStatus
+    ) {
+      assertValidRunTrackReviewStatus(nextStatus);
+
+      const review = readRunTrackReview(reviewId);
+
+      if (!review) {
+        throw new Error(`Run track review not found: ${reviewId}`);
+      }
+
+      if (!allowedRunTrackReviewStatusTransitions[review.status].includes(nextStatus)) {
+        throw new Error(
+          `Invalid run track review transition: ${review.status} -> ${nextStatus}`
+        );
+      }
+
+      const track = readRunTrack(review.run_track_id);
+
+      if (!track) {
+        throw new Error(`Run track not found: ${review.run_track_id}`);
+      }
+
+      const now = getTimestamp();
+      const nextTrackStatus =
+        nextStatus === "purchased"
+          ? "acquired"
+          : nextStatus === "rejected"
+            ? "missed"
+            : "awaiting-approval";
+
+      database.exec("BEGIN");
+
+      try {
+        database
+          .prepare(
+            `
+              UPDATE run_track_reviews
+              SET status = ?,
+                  updated_at = ?
+              WHERE id = ?
+            `
+          )
+          .run(nextStatus, now, reviewId);
+        database
+          .prepare(
+            `
+              UPDATE run_tracks
+              SET status = ?,
+                  updated_at = ?
+              WHERE id = ?
+            `
+          )
+          .run(nextTrackStatus, now, track.id);
+        database
+          .prepare("UPDATE runs SET updated_at = ? WHERE id = ?")
+          .run(now, track.run_id);
+        syncRunStatusForReviewQueue(track.run_id, now);
+        database.exec("COMMIT");
+      } catch (error) {
+        database.exec("ROLLBACK");
+        throw error;
+      }
+
+      const updatedReview = readRunTrackReview(reviewId);
+
+      if (!updatedReview) {
+        throw new Error(`Run track review not found after update: ${reviewId}`);
+      }
+
+      return mapRunTrackReview(updatedReview);
+    },
+
     transitionRunStatus(runId: string, nextStatus: RunStatus): RunDetail {
       const currentRun = getRunOrThrow(runId);
 
@@ -775,9 +1162,7 @@ export function createRunStore(options: RunStoreOptions = {}) {
     },
 
     updateRunTrackStatus(trackId: string, nextStatus: RunTrackStatus): RunTrack {
-      const track = database
-        .prepare("SELECT * FROM run_tracks WHERE id = ?")
-        .get(trackId) as RunTrackRow | undefined;
+      const track = readRunTrack(trackId);
 
       if (!track) {
         throw new Error(`Run track not found: ${trackId}`);
@@ -801,9 +1186,7 @@ export function createRunStore(options: RunStoreOptions = {}) {
         .prepare("UPDATE runs SET updated_at = ? WHERE id = ?")
         .run(now, track.run_id);
 
-      const updatedTrack = database
-        .prepare("SELECT * FROM run_tracks WHERE id = ?")
-        .get(trackId) as RunTrackRow | undefined;
+      const updatedTrack = readRunTrack(trackId);
 
       if (!updatedTrack) {
         throw new Error(`Run track not found after update: ${trackId}`);


### PR DESCRIPTION
**@worker-01**

## Summary
- add a persisted run-level Beatport review queue for paid fallback candidates
- wire report-lane review actions through a dedicated App Router API endpoint
- cover store, route, page, and screen behavior with approval-queue regression tests

## Verification
- npm run lint
- npm test
- npm run build
