### PR TITLE
Fix Beatport review outcomes for artifact packaging

### DIFF
--- a/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
+++ b/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
@@ -154,7 +154,7 @@ describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
       expect(store.getRun(run.id)).toEqual(
         expect.objectContaining({
           id: run.id,
-          status: "packaging"
+          status: "awaiting-approval"
         })
       );
       expect(
@@ -164,6 +164,14 @@ describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
       ).toEqual([
         ["beatport-route-1", "purchased"],
         ["beatport-route-2", "rejected"]
+      ]);
+      expect(
+        store
+          .getRun(run.id)
+          ?.tracks.map((track) => [track.sourcePosition, track.status])
+      ).toEqual([
+        [1, "awaiting-approval"],
+        [2, "missed"]
       ]);
     });
   });

--- a/src/app/runs/[runId]/page.test.tsx
+++ b/src/app/runs/[runId]/page.test.tsx
@@ -232,7 +232,7 @@ describe("RunReportPage", () => {
         0
       );
       expect(
-        screen.getAllByText(/marked purchased \/ completed/i).length
+        screen.getAllByText(/purchased, awaiting import before packaging/i).length
       ).toBeGreaterThan(0);
       expect(
         screen.getByRole("button", {

--- a/src/features/artifacts/run-artifacts.test.ts
+++ b/src/features/artifacts/run-artifacts.test.ts
@@ -16,7 +16,8 @@ import { createRunStore } from "@/features/runs/run-store";
 import {
   buildAcquiredArtifactSourceNote,
   buildMissedArtifactSourceNote,
-  generateRunArtifacts
+  generateRunArtifacts,
+  RunArtifactsNotReadyError
 } from "./run-artifacts";
 
 function createTempWorkspace() {
@@ -75,6 +76,152 @@ function readStoredZipEntries(zipFilePath: string) {
 }
 
 describe("generateRunArtifacts", () => {
+  it("packages rejected Beatport reviews once the rejection persists a miss note", async () => {
+    const tempWorkspace = createTempWorkspace();
+    const store = createRunStore({ databasePath: tempWorkspace.databasePath });
+
+    try {
+      const run = store.createRun({
+        playlistTitle: "Rejected Beatport Candidate",
+        playlistUrl: "https://soundcloud.com/sets/rejected-beatport-candidate",
+        sourceType: "soundcloud"
+      });
+      const [track] = store.replaceRunTracks(run.id, [
+        {
+          artist: "Anyma",
+          sourcePosition: 1,
+          title: "Consciousness",
+          version: "Original Mix"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+
+      const review = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3", "wav"],
+        candidateId: "beatport-rejected-1",
+        mixLabel: "Original Mix",
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/consciousness/rejected-1",
+        queueName: "beatport-review",
+        runTrackId: track.id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+
+      store.transitionRunTrackReviewStatus(review.id, "rejected");
+
+      expect(store.getRun(run.id)).toEqual(
+        expect.objectContaining({
+          id: run.id,
+          status: "packaging"
+        })
+      );
+
+      const generated = await generateRunArtifacts({
+        runId: run.id,
+        runStore: store,
+        workspaceRoot: tempWorkspace.workspaceRoot
+      });
+
+      expect(generated.manifest.summary).toEqual({
+        acquiredCount: 0,
+        missCount: 1,
+        trackCount: 1
+      });
+      expect(generated.manifest.tracks).toMatchObject([
+        {
+          artist: "Anyma",
+          miss: {
+            detail: "Rejected during Beatport paid review.",
+            providerId: "beatport",
+            providerName: "Beatport",
+            reason: "paid-review-rejected"
+          },
+          outcome: "missed",
+          sourcePosition: 1,
+          title: "Consciousness",
+          version: "Original Mix"
+        }
+      ]);
+    } finally {
+      store.close();
+      tempWorkspace.cleanup();
+    }
+  });
+
+  it("keeps purchased Beatport reviews out of packaging until an owned file is imported", async () => {
+    const tempWorkspace = createTempWorkspace();
+    const store = createRunStore({ databasePath: tempWorkspace.databasePath });
+
+    try {
+      const run = store.createRun({
+        playlistTitle: "Purchased Beatport Candidate",
+        playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DX5trt9i14X7j",
+        sourceType: "spotify"
+      });
+      const [track] = store.replaceRunTracks(run.id, [
+        {
+          artist: "Mau P",
+          sourcePosition: 1,
+          title: "Drugs From Amsterdam"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+
+      const review = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3"],
+        candidateId: "beatport-purchased-1",
+        mixLabel: null,
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl:
+          "https://www.beatport.com/track/drugs-from-amsterdam/purchased-1",
+        queueName: "beatport-review",
+        runTrackId: track.id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+
+      store.transitionRunTrackReviewStatus(review.id, "approved");
+      store.transitionRunTrackReviewStatus(review.id, "purchased");
+
+      expect(store.getRun(run.id)).toEqual(
+        expect.objectContaining({
+          id: run.id,
+          status: "awaiting-approval"
+        })
+      );
+      expect(
+        store
+          .getRun(run.id)
+          ?.tracks.map((candidate) => [candidate.sourcePosition, candidate.status])
+      ).toEqual([[1, "awaiting-approval"]]);
+
+      await expect(
+        generateRunArtifacts({
+          runId: run.id,
+          runStore: store,
+          workspaceRoot: tempWorkspace.workspaceRoot
+        })
+      ).rejects.toThrowError(
+        new RunArtifactsNotReadyError(
+          run.id,
+          `Run track "${track.id}" is still "awaiting-approval" and cannot be packaged yet.`
+        )
+      );
+    } finally {
+      store.close();
+      tempWorkspace.cleanup();
+    }
+  });
+
   it("uses the most recently persisted artifact note when attempts share a timestamp", async () => {
     const tempWorkspace = createTempWorkspace();
     const store = createRunStore({ databasePath: tempWorkspace.databasePath });

--- a/src/features/artifacts/run-artifacts.ts
+++ b/src/features/artifacts/run-artifacts.ts
@@ -1,12 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import type {
-  ProviderArtifactFormat,
-  ProviderAuthorizationBasis,
-  ProviderPriceTier,
-  ProviderProvenance
-} from "@/features/providers/provider-registry";
+import type { ProviderArtifactFormat } from "@/features/providers/provider-registry";
 import {
   getRunStore,
   type ArtifactKind,
@@ -15,14 +10,28 @@ import {
   type RunStore,
   type RunTrack
 } from "@/features/runs/run-store";
-import type {
-  TrackAcceptedDecision,
-  TrackAudioFormat,
-  TrackMissReason
-} from "@/features/tracks/canonical-track";
-
-export const RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA =
-  "run-track-artifact-source.v1";
+import type { TrackAcceptedDecision, TrackAudioFormat } from "@/features/tracks/canonical-track";
+import {
+  parseRunTrackArtifactSourceNote,
+  type RunTrackArtifactSourceArtifact,
+  type RunTrackArtifactSourceMiss,
+  type RunTrackArtifactSourceNote
+} from "./run-track-artifact-source-note";
+export {
+  buildAcquiredArtifactSourceNote,
+  buildMissedArtifactSourceNote,
+  parseRunTrackArtifactSourceNote,
+  RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA
+} from "./run-track-artifact-source-note";
+export type {
+  AcquiredArtifactSourceNote,
+  MissedArtifactSourceNote,
+  RunTrackArtifactSourceArtifact,
+  RunTrackArtifactSourceMiss,
+  RunTrackArtifactSourceNote,
+  RunTrackArtifactSourceProvider,
+  RunTrackArtifactSourceSelection
+} from "./run-track-artifact-source-note";
 
 const RUN_ARTIFACT_KIND_ORDER: ArtifactKind[] = [
   "downloads-zip",
@@ -30,62 +39,6 @@ const RUN_ARTIFACT_KIND_ORDER: ArtifactKind[] = [
   "manifest-json",
   "run-report"
 ];
-
-type ArtifactSourceNoteSchema =
-  typeof RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA;
-
-type ArtifactSourceProviderDiscovery = ProviderProvenance["discoveredVia"];
-
-export type RunTrackArtifactSourceProvider = {
-  authorizationBasis: ProviderAuthorizationBasis;
-  candidateId?: string | null;
-  discoveredVia?: ArtifactSourceProviderDiscovery;
-  priceTier: ProviderPriceTier;
-  providerId: string;
-  providerName: string;
-  providerUrl?: string | null;
-};
-
-export type RunTrackArtifactSourceSelection = {
-  details: string;
-  reason: TrackAcceptedDecision["reason"];
-  selectedFormat: TrackAudioFormat | null;
-};
-
-export type RunTrackArtifactSourceArtifact = {
-  contentType?: string | null;
-  fileExtension: string | null;
-  fileName: string;
-  format: ProviderArtifactFormat;
-  localFilePath: string;
-  sha256?: string | null;
-  sizeBytes: number | null;
-};
-
-export type RunTrackArtifactSourceMiss = {
-  detail: string;
-  providerId?: string | null;
-  providerName?: string | null;
-  reason: TrackMissReason | string;
-};
-
-export type AcquiredArtifactSourceNote = {
-  artifact: RunTrackArtifactSourceArtifact;
-  outcome: "acquired";
-  provider: RunTrackArtifactSourceProvider;
-  schema: ArtifactSourceNoteSchema;
-  selection: RunTrackArtifactSourceSelection;
-};
-
-export type MissedArtifactSourceNote = {
-  miss: RunTrackArtifactSourceMiss;
-  outcome: "missed";
-  schema: ArtifactSourceNoteSchema;
-};
-
-export type RunTrackArtifactSourceNote =
-  | AcquiredArtifactSourceNote
-  | MissedArtifactSourceNote;
 
 export type GeneratedRunArtifact = {
   absolutePath: string;
@@ -172,30 +125,6 @@ export class RunArtifactNotFoundError extends Error {
     this.artifactKind = artifactKind;
     this.runId = runId;
   }
-}
-
-export function buildAcquiredArtifactSourceNote(input: {
-  artifact: RunTrackArtifactSourceArtifact;
-  provider: RunTrackArtifactSourceProvider;
-  selection: RunTrackArtifactSourceSelection;
-}): AcquiredArtifactSourceNote {
-  return {
-    artifact: input.artifact,
-    outcome: "acquired",
-    provider: input.provider,
-    schema: RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA,
-    selection: input.selection
-  };
-}
-
-export function buildMissedArtifactSourceNote(input: {
-  miss: RunTrackArtifactSourceMiss;
-}): MissedArtifactSourceNote {
-  return {
-    miss: input.miss,
-    outcome: "missed",
-    schema: RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA
-  };
 }
 
 export function buildRunArtifactDownloadUrl(runId: string, kind: ArtifactKind) {
@@ -426,27 +355,6 @@ function getLatestArtifactSourceNotesByTrackId(
   }
 
   return notesByTrackId;
-}
-
-export function parseRunTrackArtifactSourceNote(note: string | null) {
-  if (!note) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(note) as Record<string, unknown>;
-
-    if (
-      parsed.schema !== RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA ||
-      (parsed.outcome !== "acquired" && parsed.outcome !== "missed")
-    ) {
-      return null;
-    }
-
-    return parsed as RunTrackArtifactSourceNote;
-  } catch {
-    return null;
-  }
 }
 
 function buildZipEntryName(

--- a/src/features/artifacts/run-track-artifact-source-note.ts
+++ b/src/features/artifacts/run-track-artifact-source-note.ts
@@ -1,0 +1,115 @@
+import type {
+  ProviderArtifactFormat,
+  ProviderAuthorizationBasis,
+  ProviderPriceTier,
+  ProviderProvenance
+} from "@/features/providers/provider-registry";
+import type {
+  TrackAcceptedDecision,
+  TrackAudioFormat,
+  TrackMissReason
+} from "@/features/tracks/canonical-track";
+
+export const RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA =
+  "run-track-artifact-source.v1";
+
+export type ArtifactSourceNoteSchema =
+  typeof RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA;
+
+type ArtifactSourceProviderDiscovery = ProviderProvenance["discoveredVia"];
+
+export type RunTrackArtifactSourceProvider = {
+  authorizationBasis: ProviderAuthorizationBasis;
+  candidateId?: string | null;
+  discoveredVia?: ArtifactSourceProviderDiscovery;
+  priceTier: ProviderPriceTier;
+  providerId: string;
+  providerName: string;
+  providerUrl?: string | null;
+};
+
+export type RunTrackArtifactSourceSelection = {
+  details: string;
+  reason: TrackAcceptedDecision["reason"];
+  selectedFormat: TrackAudioFormat | null;
+};
+
+export type RunTrackArtifactSourceArtifact = {
+  contentType?: string | null;
+  fileExtension: string | null;
+  fileName: string;
+  format: ProviderArtifactFormat;
+  localFilePath: string;
+  sha256?: string | null;
+  sizeBytes: number | null;
+};
+
+export type RunTrackArtifactSourceMiss = {
+  detail: string;
+  providerId?: string | null;
+  providerName?: string | null;
+  reason: TrackMissReason | string;
+};
+
+export type AcquiredArtifactSourceNote = {
+  artifact: RunTrackArtifactSourceArtifact;
+  outcome: "acquired";
+  provider: RunTrackArtifactSourceProvider;
+  schema: ArtifactSourceNoteSchema;
+  selection: RunTrackArtifactSourceSelection;
+};
+
+export type MissedArtifactSourceNote = {
+  miss: RunTrackArtifactSourceMiss;
+  outcome: "missed";
+  schema: ArtifactSourceNoteSchema;
+};
+
+export type RunTrackArtifactSourceNote =
+  | AcquiredArtifactSourceNote
+  | MissedArtifactSourceNote;
+
+export function buildAcquiredArtifactSourceNote(input: {
+  artifact: RunTrackArtifactSourceArtifact;
+  provider: RunTrackArtifactSourceProvider;
+  selection: RunTrackArtifactSourceSelection;
+}): AcquiredArtifactSourceNote {
+  return {
+    artifact: input.artifact,
+    outcome: "acquired",
+    provider: input.provider,
+    schema: RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA,
+    selection: input.selection
+  };
+}
+
+export function buildMissedArtifactSourceNote(input: {
+  miss: RunTrackArtifactSourceMiss;
+}): MissedArtifactSourceNote {
+  return {
+    miss: input.miss,
+    outcome: "missed",
+    schema: RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA
+  };
+}
+
+export function parseRunTrackArtifactSourceNote(note: string | null) {
+  if (!note) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(note) as Record<string, unknown>;
+
+    if (
+      parsed.schema !== RUN_TRACK_ARTIFACT_SOURCE_NOTE_SCHEMA ||
+      (parsed.outcome !== "acquired" && parsed.outcome !== "missed")
+    ) {
+      return null;
+    }
+
+    return parsed as RunTrackArtifactSourceNote;
+  } catch {
+    return null;
+  }
+}

--- a/src/features/reports/beatport-review-lane.tsx
+++ b/src/features/reports/beatport-review-lane.tsx
@@ -169,7 +169,7 @@ function formatReviewPrimaryCopy(review: RunReportReviewQueueEntry) {
     case "approved":
       return "Approved for manual purchase";
     case "purchased":
-      return "Marked purchased / completed";
+      return "Purchased, awaiting import before packaging";
     case "rejected":
       return "Rejected during paid review";
     default:

--- a/src/features/reports/run-report-screen.beatport-review.test.tsx
+++ b/src/features/reports/run-report-screen.beatport-review.test.tsx
@@ -27,7 +27,7 @@ describe("RunReportScreen Beatport review lane", () => {
       0
     );
     expect(
-      screen.getAllByText(/marked purchased \/ completed/i).length
+      screen.getAllByText(/purchased, awaiting import before packaging/i).length
     ).toBeGreaterThan(0);
     expect(
       screen.getByRole("button", {
@@ -184,7 +184,7 @@ function buildBeatportReviewReport() {
         },
         sourcePosition: 2,
         sourceTrackId: "sp-102",
-        status: "acquired",
+        status: "awaiting-approval",
         title: "Drugs From Amsterdam",
         version: null
       }

--- a/src/features/reports/run-report-screen.tsx
+++ b/src/features/reports/run-report-screen.tsx
@@ -309,7 +309,7 @@ function formatReviewDecision(
     case "approved":
       return "Approved for manual purchase";
     case "purchased":
-      return "Marked purchased / completed";
+      return "Purchased, awaiting import before packaging";
     case "rejected":
       return "Rejected during paid review";
     default:

--- a/src/features/runs/run-store.beatport-review.test.ts
+++ b/src/features/runs/run-store.beatport-review.test.ts
@@ -4,6 +4,8 @@ import { mkdtempSync, rmSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 
+import { parseRunTrackArtifactSourceNote } from "@/features/artifacts/run-artifacts";
+
 import { createRunStore, type RunTrackStatus } from "./run-store";
 
 function createTempDatabasePath() {
@@ -114,7 +116,7 @@ describe("createRunStore Beatport review queue", () => {
     }
   });
 
-  it("persists approve reject and purchased review transitions", () => {
+  it("keeps purchased reviews awaiting import and persists rejected reviews as misses", () => {
     const tempDatabase = createTempDatabasePath();
 
     try {
@@ -180,6 +182,7 @@ describe("createRunStore Beatport review queue", () => {
         "purchased"
       );
       const persistedRun = store.getRun(run.id);
+      const attempts = store.listRunTrackAttempts(run.id);
 
       expect(approvedResult.status).toBe("approved");
       expect(rejectedResult.status).toBe("rejected");
@@ -187,7 +190,7 @@ describe("createRunStore Beatport review queue", () => {
       expect(persistedRun).toEqual(
         expect.objectContaining({
           id: run.id,
-          status: "packaging"
+          status: "awaiting-approval"
         })
       );
       expect(
@@ -195,6 +198,33 @@ describe("createRunStore Beatport review queue", () => {
       ).toEqual([
         ["beatport-2001", "purchased"],
         ["beatport-2002", "rejected"]
+      ]);
+      expect(attempts).toEqual([
+        expect.objectContaining({
+          outcome: "missed",
+          providerKey: "beatport",
+          runTrackId: tracks[1].id
+        })
+      ]);
+      expect(parseRunTrackArtifactSourceNote(attempts[0]?.note ?? null)).toEqual(
+        expect.objectContaining({
+          miss: expect.objectContaining({
+            detail: "Rejected during Beatport paid review.",
+            providerId: "beatport",
+            providerName: "Beatport",
+            reason: "paid-review-rejected"
+          }),
+          outcome: "missed"
+        })
+      );
+      expect(
+        persistedRun?.tracks.map(
+          (track) =>
+            [track.sourcePosition, track.status] satisfies [number, RunTrackStatus]
+        )
+      ).toEqual([
+        [1, "awaiting-approval"],
+        [2, "missed"]
       ]);
     } finally {
       tempDatabase.cleanup();

--- a/src/features/runs/run-store.test.ts
+++ b/src/features/runs/run-store.test.ts
@@ -255,7 +255,7 @@ describe("createRunStore", () => {
     }
   });
 
-  it("updates review queue, track outcomes, and run lifecycle for approve reject and purchased actions", () => {
+  it("updates review queue while keeping purchased tracks out of packaging until import", () => {
     const tempDatabase = createTempDatabasePath();
 
     try {
@@ -328,7 +328,7 @@ describe("createRunStore", () => {
       expect(persistedRun).toEqual(
         expect.objectContaining({
           id: run.id,
-          status: "packaging"
+          status: "awaiting-approval"
         })
       );
       expect(
@@ -343,7 +343,7 @@ describe("createRunStore", () => {
             [track.sourcePosition, track.status] satisfies [number, RunTrackStatus]
         )
       ).toEqual([
-        [1, "acquired"],
+        [1, "awaiting-approval"],
         [2, "missed"]
       ]);
     } finally {

--- a/src/features/runs/run-store.ts
+++ b/src/features/runs/run-store.ts
@@ -2,6 +2,7 @@ import { mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
+import { buildMissedArtifactSourceNote } from "@/features/artifacts/run-track-artifact-source-note";
 import type {
   ProviderArtifactFormat,
   ProviderAuthorizationBasis,
@@ -525,6 +526,50 @@ export function createRunStore(options: RunStoreOptions = {}) {
       .run(nextStatus, null, now, null, null, runId);
   }
 
+  function insertAcquisitionAttemptDirect(input: {
+    note?: string | null;
+    now: string;
+    outcome: AcquisitionAttemptOutcome;
+    providerKey: string;
+    runTrackId: string;
+  }) {
+    database
+      .prepare(
+        `
+          INSERT INTO acquisition_attempts (
+            id,
+            run_track_id,
+            provider_key,
+            outcome,
+            note,
+            created_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        crypto.randomUUID(),
+        input.runTrackId,
+        input.providerKey,
+        input.outcome,
+        input.note ?? null,
+        input.now
+      );
+  }
+
+  function buildRejectedReviewMissNote(review: RunTrackReviewRow) {
+    return JSON.stringify(
+      buildMissedArtifactSourceNote({
+        miss: {
+          detail: `Rejected during ${review.provider_name} paid review.`,
+          providerId: review.provider_key,
+          providerName: review.provider_name,
+          reason: "paid-review-rejected"
+        }
+      })
+    );
+  }
+
   function syncRunStatusForReviewQueue(runId: string, now: string) {
     const currentRun = getRunOrThrow(runId);
     const unresolvedReviews = database
@@ -535,7 +580,7 @@ export function createRunStore(options: RunStoreOptions = {}) {
           INNER JOIN run_tracks
             ON run_tracks.id = run_track_reviews.run_track_id
           WHERE run_tracks.run_id = ?
-            AND run_track_reviews.status IN ('queued', 'approved')
+            AND run_track_reviews.status IN ('queued', 'approved', 'purchased')
         `
       )
       .get(runId) as { count: number };
@@ -1073,11 +1118,7 @@ export function createRunStore(options: RunStoreOptions = {}) {
 
       const now = getTimestamp();
       const nextTrackStatus =
-        nextStatus === "purchased"
-          ? "acquired"
-          : nextStatus === "rejected"
-            ? "missed"
-            : "awaiting-approval";
+        nextStatus === "rejected" ? "missed" : "awaiting-approval";
 
       database.exec("BEGIN");
 
@@ -1102,6 +1143,15 @@ export function createRunStore(options: RunStoreOptions = {}) {
             `
           )
           .run(nextTrackStatus, now, track.id);
+        if (nextStatus === "rejected") {
+          insertAcquisitionAttemptDirect({
+            note: buildRejectedReviewMissNote(review),
+            now,
+            outcome: "missed",
+            providerKey: review.provider_key,
+            runTrackId: track.id
+          });
+        }
         database
           .prepare("UPDATE runs SET updated_at = ? WHERE id = ?")
           .run(now, track.run_id);


### PR DESCRIPTION
**@worker-01**

## Summary
- keep purchased Beatport review items in `awaiting-approval` until owned files are imported, instead of advancing them into packaging
- persist miss notes for rejected Beatport review items so artifact generation stays compatible with the existing packaging contract
- add regression coverage for run-store, artifact generation, route, page, and run-report copy updates around the new lifecycle

## Verification
- `npm run lint`
- `npm test`
- `npm run build`
