### PR TITLE
test: harden integrated flow verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,25 @@ npm run test
 npm run test:e2e
 ```
 
+## Local Verification
+
+`npm run test:e2e` starts the app with an isolated `.e2e/runtime` workspace and
+deterministic local fixtures for the end-to-end flow. The Playwright coverage
+exercises:
+
+- playlist submission through the real intake form
+- completed run reports with `downloads.zip`, `manifest.json`, and `misses.txt`
+- miss-heavy reports with Beatport review-lane visibility
+- resumability after a persisted in-flight run is re-opened
+
+No live provider credentials are required for that verification path, and the
+fixtures stay within authorized-source-only scenarios. The normal `npm run dev`
+path still uses real Spotify and SoundCloud credentials when you want to test
+live playlist intake locally.
+
 ## Notes
 
-- The landing page currently provides the shared shell, form controls, and persisted recent-runs area for later tasks.
-- Background jobs, provider matching, manifests, misses, and artifact packaging land in later issues.
+- The app persists runs in local SQLite and renders run-report detail pages from
+  that shared store.
+- End-to-end verification uses fixture-backed runs so local coverage can stay
+  deterministic without introducing unauthorized acquisition behavior.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
@@ -10,8 +12,19 @@ export default defineConfig({
   },
   webServer: {
     command: "npm run dev -- --hostname 127.0.0.1 --port 3000",
+    env: {
+      MUSIC_DOWNLOADER_DB_PATH: path.join(
+        process.cwd(),
+        ".e2e",
+        "runtime",
+        "data",
+        "music-downloader.sqlite"
+      ),
+      MUSIC_DOWNLOADER_E2E_FIXTURES: "1",
+      MUSIC_DOWNLOADER_WORKSPACE_ROOT: path.join(process.cwd(), ".e2e", "runtime")
+    },
     url: "http://127.0.0.1:3000",
-    reuseExistingServer: !process.env.CI
+    reuseExistingServer: false
   },
   projects: [
     {

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { maybeCreateFixtureRunFromPlaylistUrl } from "@/features/e2e/e2e-fixtures";
 import { createRunFromPlaylistUrl } from "@/features/ingestion/playlist-intake";
 import { PlaylistIntakeError } from "@/features/ingestion/playlist-intake-error";
 import { getRunStore } from "@/features/runs/run-store";
@@ -22,6 +23,14 @@ export async function POST(request: Request) {
   }
 
   try {
+    const fixtureRun = await maybeCreateFixtureRunFromPlaylistUrl(playlistUrl);
+
+    if (fixtureRun) {
+      return NextResponse.json(fixtureRun, {
+        status: 201
+      });
+    }
+
     return NextResponse.json(await createRunFromPlaylistUrl(playlistUrl), {
       status: 201
     });

--- a/src/app/api/test/e2e/reset/route.ts
+++ b/src/app/api/test/e2e/reset/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import {
+  isE2eFixtureModeEnabled,
+  resetE2eFixtureState
+} from "@/features/e2e/e2e-fixtures";
+
+export async function POST() {
+  if (!isE2eFixtureModeEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  resetE2eFixtureState();
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/test/e2e/restart/route.ts
+++ b/src/app/api/test/e2e/restart/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+import {
+  isE2eFixtureModeEnabled,
+  restartE2eRunStore
+} from "@/features/e2e/e2e-fixtures";
+
+export async function POST() {
+  if (!isE2eFixtureModeEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const result = restartE2eRunStore();
+
+  return NextResponse.json({
+    ok: true,
+    runCount: result.runCount
+  });
+}

--- a/src/app/api/test/e2e/seed/route.ts
+++ b/src/app/api/test/e2e/seed/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+
+import {
+  e2eFixtureScenarios,
+  isE2eFixtureModeEnabled,
+  seedE2eScenario,
+  type E2eFixtureScenario
+} from "@/features/e2e/e2e-fixtures";
+
+const supportedScenarios = new Set<E2eFixtureScenario>(e2eFixtureScenarios);
+
+export async function POST(request: Request) {
+  if (!isE2eFixtureModeEnabled()) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const payload = (await request.json().catch(() => null)) as
+    | {
+        scenario?: string;
+      }
+    | null;
+
+  if (!isE2eFixtureScenario(payload?.scenario)) {
+    return NextResponse.json(
+      {
+        error:
+          "scenario must be one of resume-matching, soundcloud-miss-heavy, or spotify-happy-path"
+      },
+      { status: 400 }
+    );
+  }
+
+  const run = await seedE2eScenario(payload.scenario);
+
+  return NextResponse.json({
+    run: {
+      id: run.id,
+      playlistTitle: run.playlistTitle,
+      playlistUrl: run.playlistUrl
+    }
+  });
+}
+
+function isE2eFixtureScenario(value: string | undefined): value is E2eFixtureScenario {
+  return value !== undefined && supportedScenarios.has(value as E2eFixtureScenario);
+}

--- a/src/features/e2e/e2e-fixtures.ts
+++ b/src/features/e2e/e2e-fixtures.ts
@@ -1,0 +1,392 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import {
+  buildAcquiredArtifactSourceNote,
+  buildMissedArtifactSourceNote,
+  generateRunArtifacts
+} from "@/features/artifacts/run-artifacts";
+import {
+  createRunStore,
+  getRunStore,
+  resetRunStoreForTests,
+  type RunDetail,
+  type RunStore
+} from "@/features/runs/run-store";
+
+export const e2eFixtureScenarios = [
+  "resume-matching",
+  "soundcloud-miss-heavy",
+  "spotify-happy-path"
+] as const;
+
+export type E2eFixtureScenario = (typeof e2eFixtureScenarios)[number];
+
+const SPOTIFY_HAPPY_PATH_URL =
+  "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9";
+const SOUNDCLOUD_MISS_HEAVY_URL =
+  "https://soundcloud.com/dj-nova/sets/warehouse-finds";
+
+export function isE2eFixtureModeEnabled() {
+  return process.env.MUSIC_DOWNLOADER_E2E_FIXTURES === "1";
+}
+
+export async function maybeCreateFixtureRunFromPlaylistUrl(playlistUrl: string) {
+  if (!isE2eFixtureModeEnabled()) {
+    return null;
+  }
+
+  if (playlistUrl === SPOTIFY_HAPPY_PATH_URL) {
+    return seedE2eScenario("spotify-happy-path");
+  }
+
+  if (playlistUrl === SOUNDCLOUD_MISS_HEAVY_URL) {
+    return seedE2eScenario("soundcloud-miss-heavy");
+  }
+
+  return null;
+}
+
+export async function seedE2eScenario(
+  scenario: E2eFixtureScenario,
+  input: {
+    runStore?: RunStore;
+    workspaceRoot?: string;
+  } = {}
+) {
+  const workspaceRoot = resolveWorkspaceRoot(input.workspaceRoot);
+  const runStore = input.runStore ?? getRunStore();
+
+  switch (scenario) {
+    case "spotify-happy-path":
+      return seedSpotifyHappyPath({ runStore, workspaceRoot });
+    case "soundcloud-miss-heavy":
+      return seedSoundCloudMissHeavy({ runStore });
+    case "resume-matching":
+      return seedResumeMatching({ runStore });
+    default:
+      throw new Error(`Unsupported e2e fixture scenario: ${scenario}`);
+  }
+}
+
+export function resetE2eFixtureState() {
+  const workspaceRoot = resolveWorkspaceRoot();
+  const databasePath = resolveDatabasePath(workspaceRoot);
+
+  ensureFixtureEnvironment(workspaceRoot);
+  mkdirSync(path.dirname(databasePath), { recursive: true });
+  mkdirSync(workspaceRoot, { recursive: true });
+
+  const bootStore = createRunStore({ databasePath });
+
+  bootStore.close();
+  clearFixtureDatabase(databasePath);
+  rmSync(path.join(workspaceRoot, "downloads"), {
+    force: true,
+    recursive: true
+  });
+  rmSync(path.join(workspaceRoot, "data", "runs"), {
+    force: true,
+    recursive: true
+  });
+
+  resetRunStoreForTests();
+  getRunStore();
+}
+
+export function restartE2eRunStore() {
+  const workspaceRoot = resolveWorkspaceRoot();
+  const databasePath = resolveDatabasePath(workspaceRoot);
+
+  ensureFixtureEnvironment(workspaceRoot);
+  resetRunStoreForTests();
+
+  const bootStore = createRunStore({ databasePath });
+  const runCount = bootStore.listRuns().length;
+
+  bootStore.close();
+
+  return { runCount };
+}
+
+function ensureFixtureEnvironment(workspaceRoot = resolveWorkspaceRoot()) {
+  process.env.MUSIC_DOWNLOADER_WORKSPACE_ROOT = workspaceRoot;
+  process.env.MUSIC_DOWNLOADER_DB_PATH = resolveDatabasePath(workspaceRoot);
+}
+
+function resolveWorkspaceRoot(workspaceRoot?: string) {
+  return (
+    workspaceRoot ??
+    process.env.MUSIC_DOWNLOADER_WORKSPACE_ROOT ??
+    path.join(process.cwd(), ".e2e", "runtime")
+  );
+}
+
+function resolveDatabasePath(workspaceRoot: string) {
+  return (
+    process.env.MUSIC_DOWNLOADER_DB_PATH ??
+    path.join(workspaceRoot, "data", "music-downloader.sqlite")
+  );
+}
+
+function clearFixtureDatabase(databasePath: string) {
+  const database = new DatabaseSync(databasePath);
+
+  database.exec("PRAGMA foreign_keys = ON");
+  database.exec("BEGIN");
+
+  try {
+    database.exec("DELETE FROM acquisition_attempts");
+    database.exec("DELETE FROM run_track_reviews");
+    database.exec("DELETE FROM run_artifacts");
+    database.exec("DELETE FROM run_tracks");
+    database.exec("DELETE FROM runs");
+    database.exec("COMMIT");
+  } catch (error) {
+    database.exec("ROLLBACK");
+    throw error;
+  } finally {
+    database.close();
+  }
+}
+
+async function seedSpotifyHappyPath(input: {
+  runStore: RunStore;
+  workspaceRoot: string;
+}) {
+  const run = input.runStore.createRun({
+    playlistTitle: "Warehouse Starters",
+    playlistUrl: SPOTIFY_HAPPY_PATH_URL,
+    sourceType: "spotify"
+  });
+  const tracks = input.runStore.replaceRunTracks(run.id, [
+    {
+      artist: "Anyma",
+      sourcePosition: 1,
+      title: "Consciousness",
+      version: "Extended Mix"
+    },
+    {
+      artist: "Kx5",
+      sourcePosition: 2,
+      title: "Escape"
+    }
+  ]);
+
+  input.runStore.transitionRunStatus(run.id, "ingesting");
+  input.runStore.transitionRunStatus(run.id, "matching");
+
+  const firstArtifact = writeFixtureArtifact({
+    contents: "fixture consciousness payload\n",
+    fileName: "anyma-consciousness-extended-mix.mp3",
+    workspaceRoot: input.workspaceRoot
+  });
+  const secondArtifact = writeFixtureArtifact({
+    contents: "fixture escape payload\n",
+    fileName: "kx5-escape.mp3",
+    workspaceRoot: input.workspaceRoot
+  });
+
+  input.runStore.updateRunTrackStatus(tracks[0].id, "acquired");
+  input.runStore.recordAcquisitionAttempt({
+    note: JSON.stringify(
+      buildAcquiredArtifactSourceNote({
+        artifact: firstArtifact,
+        provider: {
+          authorizationBasis: "uploader-enabled-download",
+          candidateId: "soundcloud-201",
+          discoveredVia: "search",
+          priceTier: "free",
+          providerId: "soundcloud-direct-downloads",
+          providerName: "SoundCloud Direct Downloads",
+          providerUrl: "https://soundcloud.com/anyma/consciousness"
+        },
+        selection: {
+          details: "Extended Mix matched the highest-priority mix preference.",
+          reason: "accepted-extended-mix",
+          selectedFormat: "mp3"
+        }
+      })
+    ),
+    outcome: "matched",
+    providerKey: "soundcloud-direct-downloads",
+    runTrackId: tracks[0].id
+  });
+
+  input.runStore.updateRunTrackStatus(tracks[1].id, "acquired");
+  input.runStore.recordAcquisitionAttempt({
+    note: JSON.stringify(
+      buildAcquiredArtifactSourceNote({
+        artifact: secondArtifact,
+        provider: {
+          authorizationBasis: "rights-holder-storefront",
+          candidateId: "bandcamp-301",
+          discoveredVia: "catalog",
+          priceTier: "free",
+          providerId: "bandcamp",
+          providerName: "Bandcamp",
+          providerUrl: "https://artist.bandcamp.com/track/escape"
+        },
+        selection: {
+          details:
+            "No exact preferred mix existed, so the long base version passed fallback rules.",
+          reason: "accepted-base-version-fallback",
+          selectedFormat: "mp3"
+        }
+      })
+    ),
+    outcome: "matched",
+    providerKey: "bandcamp",
+    runTrackId: tracks[1].id
+  });
+
+  input.runStore.transitionRunStatus(run.id, "packaging");
+  await generateRunArtifacts({
+    runId: run.id,
+    runStore: input.runStore,
+    workspaceRoot: input.workspaceRoot
+  });
+  input.runStore.transitionRunStatus(run.id, "completed");
+
+  return requireRun(input.runStore, run.id);
+}
+
+function seedSoundCloudMissHeavy(input: { runStore: RunStore }) {
+  const run = input.runStore.createRun({
+    playlistTitle: "Warehouse Finds",
+    playlistUrl: SOUNDCLOUD_MISS_HEAVY_URL,
+    sourceType: "soundcloud"
+  });
+  const tracks = input.runStore.replaceRunTracks(run.id, [
+    {
+      artist: "DJ Sealer",
+      sourcePosition: 1,
+      title: "Warehouse Tool",
+      version: "Extended Mix"
+    },
+    {
+      artist: "Selector Two",
+      sourcePosition: 2,
+      title: "Loft Shaker"
+    },
+    {
+      artist: "Afterhours Unit",
+      sourcePosition: 3,
+      title: "Rotor Glow"
+    }
+  ]);
+
+  input.runStore.transitionRunStatus(run.id, "ingesting");
+  input.runStore.transitionRunStatus(run.id, "matching");
+
+  input.runStore.updateRunTrackStatus(tracks[1].id, "missed");
+  input.runStore.recordAcquisitionAttempt({
+    note: JSON.stringify(
+      buildMissedArtifactSourceNote({
+        miss: {
+          detail: "No authorized direct-download source matched the required version.",
+          providerId: "track-matcher",
+          providerName: "Track matcher",
+          reason: "no-authorized-source-match"
+        }
+      })
+    ),
+    outcome: "missed",
+    providerKey: "track-matcher",
+    runTrackId: tracks[1].id
+  });
+
+  input.runStore.queueRunTrackReview({
+    authorizationBasis: "purchase-entitlement",
+    availableFormats: ["mp3", "wav"],
+    candidateId: "beatport-queue-1",
+    mixLabel: "Extended Mix",
+    priceTier: "paid",
+    providerKey: "beatport",
+    providerName: "Beatport",
+    providerUrl: "https://www.beatport.com/track/warehouse-tool/queue-1",
+    queueName: "beatport-review",
+    runTrackId: tracks[0].id,
+    summary: "Queued after all automatic free-source providers missed."
+  });
+  const rejectedReview = input.runStore.queueRunTrackReview({
+    authorizationBasis: "purchase-entitlement",
+    availableFormats: ["mp3"],
+    candidateId: "beatport-queue-2",
+    mixLabel: null,
+    priceTier: "paid",
+    providerKey: "beatport",
+    providerName: "Beatport",
+    providerUrl: "https://www.beatport.com/track/rotor-glow/queue-2",
+    queueName: "beatport-review",
+    runTrackId: tracks[2].id,
+    summary: "Queued after all automatic free-source providers missed."
+  });
+
+  input.runStore.transitionRunTrackReviewStatus(rejectedReview.id, "rejected");
+
+  return requireRun(input.runStore, run.id);
+}
+
+function seedResumeMatching(input: { runStore: RunStore }) {
+  const run = input.runStore.createRun({
+    playlistTitle: "Resume Matching Fixture",
+    playlistUrl: "https://open.spotify.com/playlist/37i9dQZF1DWZxZ8T6qM2Yj",
+    sourceType: "spotify"
+  });
+  const tracks = input.runStore.replaceRunTracks(run.id, [
+    {
+      artist: "Anyma",
+      sourcePosition: 1,
+      title: "Pictures Of You",
+      version: "Extended Mix"
+    },
+    {
+      artist: "Cassian",
+      sourcePosition: 2,
+      title: "React"
+    }
+  ]);
+
+  input.runStore.transitionRunStatus(run.id, "ingesting");
+  input.runStore.transitionRunStatus(run.id, "matching");
+  input.runStore.updateRunTrackStatus(tracks[0].id, "matched");
+  input.runStore.updateRunTrackStatus(tracks[1].id, "failed");
+
+  return requireRun(input.runStore, run.id);
+}
+
+function requireRun(runStore: RunStore, runId: string): RunDetail {
+  const run = runStore.getRun(runId);
+
+  if (!run) {
+    throw new Error(`Fixture run not found after seeding: ${runId}`);
+  }
+
+  return run;
+}
+
+function writeFixtureArtifact(input: {
+  contents: string;
+  fileName: string;
+  workspaceRoot: string;
+}) {
+  const artifactDirectory = path.join(input.workspaceRoot, "downloads");
+  const absolutePath = path.join(artifactDirectory, input.fileName);
+  const fileBuffer = Buffer.from(input.contents, "utf8");
+
+  mkdirSync(artifactDirectory, { recursive: true });
+  writeFileSync(absolutePath, fileBuffer);
+
+  return {
+    contentType: "audio/mpeg",
+    fileExtension: "mp3",
+    fileName: input.fileName,
+    format: "mp3" as const,
+    localFilePath: absolutePath,
+    sha256: createHash("sha256").update(fileBuffer).digest("hex"),
+    sizeBytes: fileBuffer.length
+  };
+}

--- a/tests/e2e/integrated-flow.spec.ts
+++ b/tests/e2e/integrated-flow.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+type SeedResponse = {
+  run: {
+    id: string;
+    playlistTitle: string | null;
+    playlistUrl: string;
+  };
+};
+
+test.describe.configure({ mode: "serial" });
+
+async function resetHarness(request: APIRequestContext) {
+  const response = await request.post("/api/test/e2e/reset");
+
+  expect(response.ok()).toBeTruthy();
+}
+
+async function seedScenario(
+  request: APIRequestContext,
+  scenario: string
+) {
+  const response = await request.post("/api/test/e2e/seed", {
+    data: { scenario }
+  });
+
+  expect(response.ok()).toBeTruthy();
+
+  return (await response.json()) as SeedResponse;
+}
+
+test.beforeEach(async ({ request }) => {
+  await resetHarness(request);
+});
+
+test("submits a deterministic fixture playlist and exposes completed artifacts in the run report", async ({
+  page
+}) => {
+  await page.goto("/");
+  await page.getByLabel(/playlist url/i).fill(
+    "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9"
+  );
+  await page.getByRole("button", { name: /queue playlist/i }).click();
+
+  await expect(page.getByText(/warehouse starters/i)).toBeVisible();
+  await expect(page.getByText(/^completed$/i)).toBeVisible();
+
+  await page
+    .getByRole("link", { name: /open report for warehouse starters/i })
+    .click();
+
+  await expect(page).toHaveURL(/\/runs\/.+/);
+  await expect(page.getByText(/downloads\.zip/i)).toBeVisible();
+  await expect(page.getByText(/manifest\.json/i)).toBeVisible();
+  await expect(page.getByText(/misses\.txt/i)).toBeVisible();
+
+  const manifestLink = page.getByRole("link", { name: /manifest\.json/i });
+  const manifestHref = await manifestLink.getAttribute("href");
+
+  expect(manifestHref).toBeTruthy();
+
+  const manifestResponse = await page.request.get(String(manifestHref));
+
+  expect(manifestResponse.ok()).toBeTruthy();
+  await expect(manifestResponse.json()).resolves.toMatchObject({
+    run: {
+      playlistTitle: "Warehouse Starters"
+    },
+    summary: {
+      acquiredCount: 2,
+      missCount: 0
+    }
+  });
+});
+
+test("covers a miss-heavy report with Beatport review visibility via deterministic fixtures", async ({
+  page
+}) => {
+  await page.goto("/");
+  await page.getByLabel(/playlist url/i).fill(
+    "https://soundcloud.com/dj-nova/sets/warehouse-finds"
+  );
+  await page.getByRole("button", { name: /queue playlist/i }).click();
+
+  await expect(page.getByText(/warehouse finds/i)).toBeVisible();
+  await page
+    .getByRole("link", { name: /open report for warehouse finds/i })
+    .click();
+
+  await expect(page.getByRole("heading", { name: /warehouse finds/i })).toBeVisible();
+  await expect(
+    page
+      .getByText(/queued after all automatic free-source providers missed/i)
+      .first()
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", {
+      name: /approve beatport candidate for dj sealer - warehouse tool/i
+    })
+  ).toBeVisible();
+  await expect(page.getByText(/paid-review-rejected/i)).toBeVisible();
+});
+
+test("shows persisted resume metadata after the run store is restarted", async ({
+  page,
+  request
+}) => {
+  const seedPayload = await seedScenario(request, "resume-matching");
+  const restartResponse = await request.post("/api/test/e2e/restart");
+
+  expect(restartResponse.ok()).toBeTruthy();
+
+  await page.goto("/");
+
+  const runCard = page
+    .locator("article")
+    .filter({ hasText: seedPayload.run.playlistTitle ?? seedPayload.run.playlistUrl });
+
+  await expect(runCard).toContainText(/queued/i);
+  await expect(runCard).toContainText(/matching/i);
+  await expect(
+    runCard.getByRole("link", {
+      name: new RegExp(
+        `open report for ${(seedPayload.run.playlistTitle ?? "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`,
+        "i"
+      )
+    })
+  ).toBeVisible();
+});


### PR DESCRIPTION
**@worker-03**

## Summary
- add guarded end-to-end fixture routes and deterministic SQLite/workspace seeding for integrated verification
- route Playwright fixture playlist submissions through the real intake endpoint during e2e runs
- cover happy-path artifacts, miss-heavy Beatport review visibility, and persisted resumability in Playwright
- document the local verification flow and prerequisites in the README

## Testing
- npm run lint
- npm run test
- npm run test:e2e
- npm run build
