### PR TITLE
fix: execute live automatic acquisition pipeline

### DIFF
--- a/src/app/api/runs/route.test.ts
+++ b/src/app/api/runs/route.test.ts
@@ -23,186 +23,60 @@ async function withTempDatabase(
   }
 }
 
+afterEach(() => {
+  vi.doUnmock("@/features/e2e/e2e-fixtures");
+  vi.doUnmock("@/features/runs/live-run-orchestrator");
+  vi.resetModules();
+});
+
 describe("/api/runs", () => {
-  it("ingests a Spotify playlist into persisted run data and exposes its pollable status", async () => {
+  it("returns fixture-backed runs without invoking the live orchestrator", async () => {
     await withTempDatabase(async (databasePath) => {
       vi.resetModules();
 
-      const originalClientId = process.env.SPOTIFY_CLIENT_ID;
-      const originalClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
-      const originalMarket = process.env.SPOTIFY_MARKET;
+      const playlistUrl = "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9";
+      const fixtureRun = {
+        artifactCount: 3,
+        artifacts: [],
+        createdAt: "2026-03-31T21:00:00.000Z",
+        id: "run-fixture",
+        playlistTitle: "Fixture Warehouse Starters",
+        playlistUrl,
+        resumeAfterStatus: null,
+        reviewQueue: [],
+        sourceType: "spotify",
+        status: "completed",
+        trackCount: 2,
+        tracks: [],
+        updatedAt: "2026-03-31T21:05:00.000Z"
+      };
+      const maybeCreateFixtureRunFromPlaylistUrl = vi.fn().mockResolvedValue(fixtureRun);
+      const submitLiveRunFromPlaylistUrl = vi.fn();
 
-      process.env.SPOTIFY_CLIENT_ID = "spotify-client-id";
-      process.env.SPOTIFY_CLIENT_SECRET = "spotify-client-secret";
-      process.env.SPOTIFY_MARKET = "US";
+      vi.doMock("@/features/e2e/e2e-fixtures", () => ({
+        maybeCreateFixtureRunFromPlaylistUrl
+      }));
+      vi.doMock("@/features/runs/live-run-orchestrator", () => ({
+        submitLiveRunFromPlaylistUrl
+      }));
 
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ access_token: "spotify-access-token" }), {
-            headers: {
-              "content-type": "application/json"
-            },
-            status: 200
-          })
-        )
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              external_urls: {
-                spotify:
-                  "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9"
-              },
-              name: "Warehouse Starters"
-            }),
-            {
-              headers: {
-                "content-type": "application/json"
-              },
-              status: 200
-            }
-          )
-        )
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              items: [
-                {
-                  track: {
-                    artists: [{ name: "Anyma" }, { name: "Chris Avantgarde" }],
-                    duration_ms: 391578,
-                    id: "0abc123",
-                    name: "Consciousness (Extended Mix)",
-                    type: "track"
-                  }
-                },
-                {
-                  track: {
-                    artists: [{ name: "Kx5" }],
-                    duration_ms: 265000,
-                    id: "0def456",
-                    name: "Escape",
-                    type: "track"
-                  }
-                }
-              ],
-              next: null
-            }),
-            {
-              headers: {
-                "content-type": "application/json"
-              },
-              status: 200
-            }
-          )
-        );
+      const { POST } = await import("./route");
 
-      const [{ POST }, { GET }, runStoreModule] = await Promise.all([
-        import("./route"),
-        import("../runs/[runId]/route"),
-        import("@/features/runs/run-store")
-      ]);
+      const createResponse = await POST(
+        new Request("http://localhost/api/runs", {
+          body: JSON.stringify({ playlistUrl }),
+          headers: {
+            "content-type": "application/json"
+          },
+          method: "POST"
+        })
+      );
 
-      try {
-        const createResponse = await POST(
-          new Request("http://localhost/api/runs", {
-            body: JSON.stringify({
-              playlistUrl:
-                "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9"
-            }),
-            headers: {
-              "content-type": "application/json"
-            },
-            method: "POST"
-          })
-        );
-
-        expect(createResponse.status).toBe(201);
-        expect(existsSync(databasePath)).toBe(true);
-        expect(fetchSpy).toHaveBeenCalledTimes(3);
-
-        const createdRun = (await createResponse.json()) as {
-          id: string;
-          playlistTitle: string | null;
-          sourceType: string;
-          status: string;
-          trackCount: number;
-          tracks: Array<{
-            artist: string;
-            title: string;
-            version: string | null;
-          }>;
-        };
-        const pollResponse = await GET(
-          new Request(`http://localhost/api/runs/${createdRun.id}`),
-          {
-            params: Promise.resolve({ runId: createdRun.id })
-          }
-        );
-        const polledRun = (await pollResponse.json()) as {
-          id: string;
-          playlistTitle: string | null;
-          sourceType: string;
-          status: string;
-          trackCount: number;
-          tracks: Array<{
-            artist: string;
-            title: string;
-            version: string | null;
-          }>;
-        };
-
-        expect(createdRun).toEqual(
-          expect.objectContaining({
-            playlistTitle: "Warehouse Starters",
-            sourceType: "spotify",
-            status: "queued",
-            trackCount: 2
-          })
-        );
-        expect(createdRun.tracks).toEqual([
-          expect.objectContaining({
-            artist: "Anyma",
-            title: "Consciousness",
-            version: "Extended Mix"
-          }),
-          expect.objectContaining({
-            artist: "Kx5",
-            title: "Escape",
-            version: null
-          })
-        ]);
-        expect(polledRun).toEqual(
-          expect.objectContaining({
-            id: createdRun.id,
-            playlistTitle: "Warehouse Starters",
-            sourceType: "spotify",
-            status: "queued",
-            trackCount: 2
-          })
-        );
-        expect(runStoreModule.getRunStore().listRuns()).toHaveLength(1);
-      } finally {
-        fetchSpy.mockRestore();
-
-        if (originalClientId === undefined) {
-          delete process.env.SPOTIFY_CLIENT_ID;
-        } else {
-          process.env.SPOTIFY_CLIENT_ID = originalClientId;
-        }
-
-        if (originalClientSecret === undefined) {
-          delete process.env.SPOTIFY_CLIENT_SECRET;
-        } else {
-          process.env.SPOTIFY_CLIENT_SECRET = originalClientSecret;
-        }
-
-        if (originalMarket === undefined) {
-          delete process.env.SPOTIFY_MARKET;
-        } else {
-          process.env.SPOTIFY_MARKET = originalMarket;
-        }
-      }
+      expect(createResponse.status).toBe(201);
+      expect(existsSync(databasePath)).toBe(false);
+      expect(maybeCreateFixtureRunFromPlaylistUrl).toHaveBeenCalledWith(playlistUrl);
+      expect(submitLiveRunFromPlaylistUrl).not.toHaveBeenCalled();
+      await expect(createResponse.json()).resolves.toEqual(fixtureRun);
     });
   });
 
@@ -286,160 +160,6 @@ describe("/api/runs", () => {
     });
   });
 
-  it("ingests a SoundCloud playlist into persisted run data", async () => {
-    await withTempDatabase(async () => {
-      vi.resetModules();
-
-      const originalClientId = process.env.SOUNDCLOUD_CLIENT_ID;
-      const originalClientSecret = process.env.SOUNDCLOUD_CLIENT_SECRET;
-
-      process.env.SOUNDCLOUD_CLIENT_ID = "soundcloud-client-id";
-      process.env.SOUNDCLOUD_CLIENT_SECRET = "soundcloud-client-secret";
-
-      const fetchSpy = vi
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ access_token: "soundcloud-access-token" }), {
-            headers: {
-              "content-type": "application/json"
-            },
-            status: 200
-          })
-        )
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              kind: "playlist",
-              permalink_url:
-                "https://soundcloud.com/dj-nova/sets/warehouse-finds",
-              title: "Warehouse Finds",
-              tracks: [
-                {
-                  id: 111,
-                  metadata_artist: "DJ Sealer",
-                  title: "DJ Sealer - Warehouse Tool (Extended Mix) [Free DL]",
-                  urn: "soundcloud:tracks:111",
-                  user: {
-                    username: "dj-sealer"
-                  }
-                },
-                {
-                  id: 222,
-                  title: "Selector Two - Loft Shaker",
-                  user: {
-                    username: "selector-two"
-                  }
-                }
-              ]
-            }),
-            {
-              headers: {
-                "content-type": "application/json"
-              },
-              status: 200
-            }
-          )
-        );
-
-      try {
-        const [{ POST }, runStoreModule] = await Promise.all([
-          import("./route"),
-          import("@/features/runs/run-store")
-        ]);
-
-        const createResponse = await POST(
-          new Request("http://localhost/api/runs", {
-            body: JSON.stringify({
-              playlistUrl: "https://soundcloud.com/dj-nova/sets/warehouse-finds"
-            }),
-            headers: {
-              "content-type": "application/json"
-            },
-            method: "POST"
-          })
-        );
-
-        expect(createResponse.status).toBe(201);
-        expect(fetchSpy).toHaveBeenCalledTimes(2);
-
-        const [tokenUrl, tokenRequest] = fetchSpy.mock.calls[0] ?? [];
-        const tokenHeaders = tokenRequest?.headers as Record<string, string>;
-        const tokenBody = new URLSearchParams(String(tokenRequest?.body ?? ""));
-
-        expect(String(tokenUrl)).toBe("https://api.soundcloud.com/oauth2/token");
-        expect(tokenRequest?.method).toBe("POST");
-        expect(tokenHeaders).toEqual(
-          expect.objectContaining({
-            Accept: "application/json; charset=utf-8",
-            "Content-Type": "application/x-www-form-urlencoded"
-          })
-        );
-        expect(tokenHeaders.Authorization).toBeUndefined();
-        expect(tokenBody.get("client_id")).toBe("soundcloud-client-id");
-        expect(tokenBody.get("client_secret")).toBe("soundcloud-client-secret");
-        expect(tokenBody.get("grant_type")).toBe("client_credentials");
-
-        const createdRun = (await createResponse.json()) as {
-          id: string;
-          playlistTitle: string | null;
-          sourceType: string;
-          trackCount: number;
-          tracks: Array<{
-            artist: string;
-            title: string;
-            version: string | null;
-          }>;
-        };
-
-        expect(createdRun).toEqual(
-          expect.objectContaining({
-            playlistTitle: "Warehouse Finds",
-            sourceType: "soundcloud",
-            trackCount: 2
-          })
-        );
-        expect(createdRun.tracks).toEqual([
-          expect.objectContaining({
-            artist: "DJ Sealer",
-            title: "Warehouse Tool",
-            version: "Extended Mix"
-          }),
-          expect.objectContaining({
-            artist: "Selector Two",
-            title: "Loft Shaker",
-            version: null
-          })
-        ]);
-        expect(runStoreModule.getRunStore().getRun(createdRun.id)?.tracks).toEqual([
-          expect.objectContaining({
-            artist: "DJ Sealer",
-            title: "Warehouse Tool",
-            version: "Extended Mix"
-          }),
-          expect.objectContaining({
-            artist: "Selector Two",
-            title: "Loft Shaker",
-            version: null
-          })
-        ]);
-      } finally {
-        fetchSpy.mockRestore();
-
-        if (originalClientId === undefined) {
-          delete process.env.SOUNDCLOUD_CLIENT_ID;
-        } else {
-          process.env.SOUNDCLOUD_CLIENT_ID = originalClientId;
-        }
-
-        if (originalClientSecret === undefined) {
-          delete process.env.SOUNDCLOUD_CLIENT_SECRET;
-        } else {
-          process.env.SOUNDCLOUD_CLIENT_SECRET = originalClientSecret;
-        }
-      }
-    });
-  });
-
   it("returns explicit validation errors for unsupported SoundCloud URLs", async () => {
     await withTempDatabase(async () => {
       vi.resetModules();
@@ -509,6 +229,55 @@ describe("/api/runs", () => {
           process.env.SOUNDCLOUD_CLIENT_SECRET = originalClientSecret;
         }
       }
+    });
+  });
+
+  it("delegates non-fixture submissions to the shared live-run orchestrator", async () => {
+    await withTempDatabase(async () => {
+      vi.resetModules();
+
+      const playlistUrl = "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9";
+      const createdRun = {
+        artifactCount: 3,
+        artifacts: [],
+        createdAt: "2026-03-31T21:00:00.000Z",
+        id: "run-live-pipeline",
+        playlistTitle: "Warehouse Starters",
+        playlistUrl,
+        resumeAfterStatus: null,
+        reviewQueue: [],
+        sourceType: "spotify",
+        status: "completed",
+        trackCount: 2,
+        tracks: [],
+        updatedAt: "2026-03-31T21:05:00.000Z"
+      };
+      const maybeCreateFixtureRunFromPlaylistUrl = vi.fn().mockResolvedValue(null);
+      const submitLiveRunFromPlaylistUrl = vi.fn().mockResolvedValue(createdRun);
+
+      vi.doMock("@/features/e2e/e2e-fixtures", () => ({
+        maybeCreateFixtureRunFromPlaylistUrl
+      }));
+      vi.doMock("@/features/runs/live-run-orchestrator", () => ({
+        submitLiveRunFromPlaylistUrl
+      }));
+
+      const { POST } = await import("./route");
+
+      const response = await POST(
+        new Request("http://localhost/api/runs", {
+          body: JSON.stringify({ playlistUrl }),
+          headers: {
+            "content-type": "application/json"
+          },
+          method: "POST"
+        })
+      );
+
+      expect(response.status).toBe(201);
+      expect(maybeCreateFixtureRunFromPlaylistUrl).toHaveBeenCalledWith(playlistUrl);
+      expect(submitLiveRunFromPlaylistUrl).toHaveBeenCalledWith(playlistUrl);
+      await expect(response.json()).resolves.toEqual(createdRun);
     });
   });
 });

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 
 import { maybeCreateFixtureRunFromPlaylistUrl } from "@/features/e2e/e2e-fixtures";
-import { createRunFromPlaylistUrl } from "@/features/ingestion/playlist-intake";
 import { PlaylistIntakeError } from "@/features/ingestion/playlist-intake-error";
 import { getRunStore } from "@/features/runs/run-store";
+import { submitLiveRunFromPlaylistUrl } from "@/features/runs/live-run-orchestrator";
 
 export async function GET() {
   return NextResponse.json(getRunStore().listRuns());
@@ -31,7 +31,7 @@ export async function POST(request: Request) {
       });
     }
 
-    return NextResponse.json(await createRunFromPlaylistUrl(playlistUrl), {
+    return NextResponse.json(await submitLiveRunFromPlaylistUrl(playlistUrl), {
       status: 201
     });
   } catch (error) {

--- a/src/features/ingestion/playlist-intake.test.ts
+++ b/src/features/ingestion/playlist-intake.test.ts
@@ -1,0 +1,274 @@
+/* @vitest-environment node */
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+async function withTempDatabase(
+  callback: (databasePath: string) => Promise<void> | void
+) {
+  const tempDirectory = mkdtempSync(
+    path.join(tmpdir(), "music-downloader-playlist-intake-")
+  );
+  const databasePath = path.join(tempDirectory, "music-downloader.sqlite");
+
+  process.env.MUSIC_DOWNLOADER_DB_PATH = databasePath;
+
+  try {
+    await callback(databasePath);
+  } finally {
+    const runStoreModule = await import("@/features/runs/run-store");
+
+    runStoreModule.resetRunStoreForTests();
+    delete process.env.MUSIC_DOWNLOADER_DB_PATH;
+    rmSync(tempDirectory, { force: true, recursive: true });
+  }
+}
+
+describe("createRunFromPlaylistUrl", () => {
+  it("ingests a Spotify playlist into persisted queued run data", async () => {
+    await withTempDatabase(async (databasePath) => {
+      vi.resetModules();
+
+      const originalClientId = process.env.SPOTIFY_CLIENT_ID;
+      const originalClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+      const originalMarket = process.env.SPOTIFY_MARKET;
+
+      process.env.SPOTIFY_CLIENT_ID = "spotify-client-id";
+      process.env.SPOTIFY_CLIENT_SECRET = "spotify-client-secret";
+      process.env.SPOTIFY_MARKET = "US";
+
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ access_token: "spotify-access-token" }), {
+            headers: {
+              "content-type": "application/json"
+            },
+            status: 200
+          })
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              external_urls: {
+                spotify:
+                  "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9"
+              },
+              name: "Warehouse Starters"
+            }),
+            {
+              headers: {
+                "content-type": "application/json"
+              },
+              status: 200
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              items: [
+                {
+                  track: {
+                    artists: [{ name: "Anyma" }, { name: "Chris Avantgarde" }],
+                    duration_ms: 391578,
+                    id: "0abc123",
+                    name: "Consciousness (Extended Mix)",
+                    type: "track"
+                  }
+                },
+                {
+                  track: {
+                    artists: [{ name: "Kx5" }],
+                    duration_ms: 265000,
+                    id: "0def456",
+                    name: "Escape",
+                    type: "track"
+                  }
+                }
+              ],
+              next: null
+            }),
+            {
+              headers: {
+                "content-type": "application/json"
+              },
+              status: 200
+            }
+          )
+        );
+
+      const [{ createRunFromPlaylistUrl }, runStoreModule] = await Promise.all([
+        import("./playlist-intake"),
+        import("@/features/runs/run-store")
+      ]);
+
+      try {
+        const createdRun = await createRunFromPlaylistUrl(
+          "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9"
+        );
+
+        expect(existsSync(databasePath)).toBe(true);
+        expect(fetchSpy).toHaveBeenCalledTimes(3);
+        expect(createdRun).toEqual(
+          expect.objectContaining({
+            playlistTitle: "Warehouse Starters",
+            sourceType: "spotify",
+            status: "queued",
+            trackCount: 2
+          })
+        );
+        expect(createdRun.tracks).toEqual([
+          expect.objectContaining({
+            artist: "Anyma",
+            title: "Consciousness",
+            version: "Extended Mix"
+          }),
+          expect.objectContaining({
+            artist: "Kx5",
+            title: "Escape",
+            version: null
+          })
+        ]);
+        expect(runStoreModule.getRunStore().listRuns()).toHaveLength(1);
+      } finally {
+        fetchSpy.mockRestore();
+
+        if (originalClientId === undefined) {
+          delete process.env.SPOTIFY_CLIENT_ID;
+        } else {
+          process.env.SPOTIFY_CLIENT_ID = originalClientId;
+        }
+
+        if (originalClientSecret === undefined) {
+          delete process.env.SPOTIFY_CLIENT_SECRET;
+        } else {
+          process.env.SPOTIFY_CLIENT_SECRET = originalClientSecret;
+        }
+
+        if (originalMarket === undefined) {
+          delete process.env.SPOTIFY_MARKET;
+        } else {
+          process.env.SPOTIFY_MARKET = originalMarket;
+        }
+      }
+    });
+  });
+
+  it("ingests a SoundCloud playlist into persisted queued run data", async () => {
+    await withTempDatabase(async () => {
+      vi.resetModules();
+
+      const originalClientId = process.env.SOUNDCLOUD_CLIENT_ID;
+      const originalClientSecret = process.env.SOUNDCLOUD_CLIENT_SECRET;
+
+      process.env.SOUNDCLOUD_CLIENT_ID = "soundcloud-client-id";
+      process.env.SOUNDCLOUD_CLIENT_SECRET = "soundcloud-client-secret";
+
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ access_token: "soundcloud-access-token" }), {
+            headers: {
+              "content-type": "application/json"
+            },
+            status: 200
+          })
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              kind: "playlist",
+              permalink_url:
+                "https://soundcloud.com/dj-nova/sets/warehouse-finds",
+              title: "Warehouse Finds",
+              tracks: [
+                {
+                  id: 111,
+                  metadata_artist: "DJ Sealer",
+                  title: "DJ Sealer - Warehouse Tool (Extended Mix) [Free DL]",
+                  urn: "soundcloud:tracks:111",
+                  user: {
+                    username: "dj-sealer"
+                  }
+                },
+                {
+                  id: 222,
+                  title: "Selector Two - Loft Shaker",
+                  user: {
+                    username: "selector-two"
+                  }
+                }
+              ]
+            }),
+            {
+              headers: {
+                "content-type": "application/json"
+              },
+              status: 200
+            }
+          )
+        );
+
+      try {
+        const [{ createRunFromPlaylistUrl }, runStoreModule] = await Promise.all([
+          import("./playlist-intake"),
+          import("@/features/runs/run-store")
+        ]);
+
+        const createdRun = await createRunFromPlaylistUrl(
+          "https://soundcloud.com/dj-nova/sets/warehouse-finds"
+        );
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(createdRun).toEqual(
+          expect.objectContaining({
+            playlistTitle: "Warehouse Finds",
+            sourceType: "soundcloud",
+            status: "queued",
+            trackCount: 2
+          })
+        );
+        expect(createdRun.tracks).toEqual([
+          expect.objectContaining({
+            artist: "DJ Sealer",
+            title: "Warehouse Tool",
+            version: "Extended Mix"
+          }),
+          expect.objectContaining({
+            artist: "Selector Two",
+            title: "Loft Shaker",
+            version: null
+          })
+        ]);
+        expect(runStoreModule.getRunStore().getRun(createdRun.id)?.tracks).toEqual([
+          expect.objectContaining({
+            artist: "DJ Sealer",
+            title: "Warehouse Tool",
+            version: "Extended Mix"
+          }),
+          expect.objectContaining({
+            artist: "Selector Two",
+            title: "Loft Shaker",
+            version: null
+          })
+        ]);
+      } finally {
+        fetchSpy.mockRestore();
+
+        if (originalClientId === undefined) {
+          delete process.env.SOUNDCLOUD_CLIENT_ID;
+        } else {
+          process.env.SOUNDCLOUD_CLIENT_ID = originalClientId;
+        }
+
+        if (originalClientSecret === undefined) {
+          delete process.env.SOUNDCLOUD_CLIENT_SECRET;
+        } else {
+          process.env.SOUNDCLOUD_CLIENT_SECRET = originalClientSecret;
+        }
+      }
+    });
+  });
+});

--- a/src/features/providers/bandcamp.test.ts
+++ b/src/features/providers/bandcamp.test.ts
@@ -229,6 +229,7 @@ describe("createBandcampProvider", () => {
             fileExtension: "mp3",
             fileName: "warehouse-tool--320.mp3",
             format: "mp3",
+            localFilePath: expect.stringContaining("warehouse-tool--320.mp3"),
             sha256: createHash("sha256")
               .update("mp3 320 fixture payload\n")
               .digest("hex"),
@@ -323,6 +324,7 @@ describe("createBandcampProvider", () => {
             fileExtension: "mp3",
             fileName: "warehouse-tool--320.mp3",
             format: "mp3",
+            localFilePath: expect.stringContaining("warehouse-tool--320.mp3"),
             sha256: createHash("sha256")
               .update("mp3 320 fixture payload\n")
               .digest("hex"),

--- a/src/features/providers/bandcamp.ts
+++ b/src/features/providers/bandcamp.ts
@@ -1004,6 +1004,7 @@ async function buildArtifactMetadata(
     fileExtension,
     fileName: suggestedFilename,
     format: inferArtifactFormat(fileExtension, normalizedContentType),
+    localFilePath: downloadPath,
     sha256: createHash("sha256").update(fileBuffer).digest("hex"),
     sizeBytes: fileStats.size
   };

--- a/src/features/providers/live-provider-registry.ts
+++ b/src/features/providers/live-provider-registry.ts
@@ -1,0 +1,32 @@
+import path from "node:path";
+
+import { BrowserSessionService } from "@/features/browser/browser-session-service";
+
+import { createBandcampProvider } from "./bandcamp";
+import { ProviderRegistry } from "./provider-registry";
+import { createSoundCloudDirectDownloadsProvider } from "./soundcloud-direct-downloads";
+
+type CreateLiveProviderRegistryOptions = {
+  workspaceRoot?: string;
+};
+
+export function createLiveProviderRegistry(
+  options: CreateLiveProviderRegistryOptions = {}
+) {
+  const browserSessionService = new BrowserSessionService({
+    workspaceRoot: resolveWorkspaceRoot(options.workspaceRoot)
+  });
+
+  return new ProviderRegistry([
+    createSoundCloudDirectDownloadsProvider({ browserSessionService }),
+    createBandcampProvider({ browserSessionService })
+  ]);
+}
+
+function resolveWorkspaceRoot(workspaceRoot?: string) {
+  return (
+    workspaceRoot ??
+    process.env.MUSIC_DOWNLOADER_WORKSPACE_ROOT ??
+    path.join(/* turbopackIgnore: true */ process.cwd())
+  );
+}

--- a/src/features/providers/provider-registry.ts
+++ b/src/features/providers/provider-registry.ts
@@ -94,6 +94,7 @@ export interface ProviderArtifactMetadata {
   fileExtension: string | null;
   fileName: string;
   format: ProviderArtifactFormat;
+  localFilePath: string;
   sha256?: string | null;
   sizeBytes: number | null;
 }

--- a/src/features/providers/soundcloud-direct-downloads.test.ts
+++ b/src/features/providers/soundcloud-direct-downloads.test.ts
@@ -499,6 +499,7 @@ describe("createSoundCloudDirectDownloadsProvider", () => {
             fileExtension: "flac",
             fileName: "warehouse-tool.flac",
             format: "flac",
+            localFilePath: expect.stringContaining("warehouse-tool.flac"),
             sha256:
               "93d31421dcf5b0f8fc767062a4ed9241b3fe0b3774ea70589e95128a7b56b703",
             sizeBytes: 25

--- a/src/features/providers/soundcloud-direct-downloads.ts
+++ b/src/features/providers/soundcloud-direct-downloads.ts
@@ -749,6 +749,7 @@ async function buildArtifactMetadata(
     fileExtension,
     fileName: suggestedFilename,
     format: inferArtifactFormat(fileExtension, normalizedContentType),
+    localFilePath: downloadPath,
     sha256: createHash("sha256").update(fileBuffer).digest("hex"),
     sizeBytes: fileStats.size
   };

--- a/src/features/runs/live-run-orchestrator.test.ts
+++ b/src/features/runs/live-run-orchestrator.test.ts
@@ -1,0 +1,406 @@
+/* @vitest-environment node */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  parseRunTrackArtifactSourceNote
+} from "@/features/artifacts/run-artifacts";
+import {
+  buildProviderMissResult,
+  defineAutomaticProvider,
+  type AutomaticProviderDefinition,
+  type ProviderCandidate,
+  type ProviderRegistry
+} from "@/features/providers/provider-registry";
+import { createRunStore, type RunStore, type RunTrack } from "@/features/runs/run-store";
+
+import { submitLiveRunFromPlaylistUrl } from "./live-run-orchestrator";
+
+function createTempWorkspace() {
+  const workspaceRoot = mkdtempSync(
+    path.join(tmpdir(), "music-downloader-live-orchestrator-")
+  );
+  const databasePath = path.join(workspaceRoot, "data", "music-downloader.sqlite");
+
+  return {
+    cleanup() {
+      rmSync(workspaceRoot, { force: true, recursive: true });
+    },
+    databasePath,
+    workspaceRoot
+  };
+}
+
+function createStubRegistry(providers: AutomaticProviderDefinition[]) {
+  return {
+    listAutomatic: () => providers
+  } satisfies Pick<ProviderRegistry, "listAutomatic">;
+}
+
+function createStubRun(
+  runStore: RunStore,
+  playlistUrl: string,
+  tracks: Array<{
+    artist: string;
+    sourcePosition: number;
+    title: string;
+    version?: string | null;
+  }>
+) {
+  const sourceType = playlistUrl.includes("spotify.com") ? "spotify" : "soundcloud";
+  const run = runStore.createRun({
+    playlistTitle: "Live Pipeline Fixture",
+    playlistUrl,
+    sourceType
+  });
+
+  runStore.replaceRunTracks(run.id, tracks);
+
+  const hydratedRun = runStore.getRun(run.id);
+
+  if (!hydratedRun) {
+    throw new Error(`Expected stub run to exist after intake: ${run.id}`);
+  }
+
+  return hydratedRun;
+}
+
+function buildMatchingCandidate(
+  provider: AutomaticProviderDefinition,
+  track: RunTrack
+): ProviderCandidate {
+  return {
+    artistName: track.artist,
+    authorizationBasis: provider.authorizationBasis,
+    availableFormats: ["mp3"],
+    candidateId: `${provider.id}-${track.sourcePosition}`,
+    durationSeconds: track.version ? 392 : 301,
+    mixConfidence: "high",
+    mixLabel: track.version ?? null,
+    priceTier: provider.priceTier,
+    providerId: provider.id,
+    providerName: provider.displayName,
+    provenance: {
+      discoveredVia: "search",
+      providerTrackId: `${provider.id}-${track.sourcePosition}`,
+      providerUrl: `https://example.test/${provider.id}/${track.sourcePosition}`,
+      searchQuery: `${track.artist} ${track.title}`
+    },
+    title: track.title
+  };
+}
+
+describe("submitLiveRunFromPlaylistUrl", () => {
+  it("executes automatic providers in priority order, persists selected outcomes, and packages fully auto-resolved runs", async () => {
+    const tempWorkspace = createTempWorkspace();
+    const runStore = createRunStore({ databasePath: tempWorkspace.databasePath });
+    const searchCalls: string[] = [];
+
+    const soundCloudProvider = defineAutomaticProvider({
+      id: "soundcloud-direct-downloads",
+      displayName: "SoundCloud Direct Downloads",
+      authorizationBasis: "uploader-enabled-download",
+      priceTier: "free",
+      priorityRank: 10,
+      supportedFormats: ["original-upload-format"],
+      search: async ({ track }) => {
+        searchCalls.push(`soundcloud:${track.primaryArtist}:${track.title}`);
+
+        return buildProviderMissResult({
+          detail: "No uploader-enabled download matched this track on SoundCloud.",
+          providerId: "soundcloud-direct-downloads",
+          providerName: "SoundCloud Direct Downloads",
+          reason: "no-search-results",
+          trackMissReason: "no-authorized-source-match"
+        });
+      },
+      acquire: async () => {
+        throw new Error("SoundCloud acquire should not run after a miss.");
+      }
+    });
+    const bandcampProvider = defineAutomaticProvider({
+      id: "bandcamp",
+      displayName: "Bandcamp",
+      authorizationBasis: "rights-holder-storefront",
+      priceTier: "free-or-owned",
+      priorityRank: 20,
+      supportedFormats: ["mp3", "wav"],
+      search: async ({ track }) => {
+        searchCalls.push(`bandcamp:${track.primaryArtist}:${track.title}`);
+
+        return {
+          outcome: "candidates" as const,
+          candidates: [
+            buildMatchingCandidate(bandcampProvider, {
+              artist: track.primaryArtist ?? "Unknown Artist",
+              createdAt: "",
+              id: `track-${track.title}`,
+              runId: "run",
+              sourcePosition: searchCalls.length,
+              sourceTrackId: null,
+              status: "queued",
+              title: track.title,
+              updatedAt: "",
+              version: track.mix.displayLabel
+            })
+          ]
+        };
+      },
+      acquire: async ({ candidate, track }) => {
+        const downloadDirectory = path.join(tempWorkspace.workspaceRoot, "downloads");
+        const artifactFileName = `${track.title.toLowerCase().replace(/\s+/g, "-")}.mp3`;
+        const localFilePath = path.join(downloadDirectory, artifactFileName);
+
+        mkdirSync(downloadDirectory, { recursive: true });
+        writeFileSync(localFilePath, `${candidate.providerName}:${track.title}\n`, "utf8");
+
+        return {
+          outcome: "acquired" as const,
+          artifact: {
+            contentType: "audio/mpeg",
+            fileExtension: "mp3",
+            fileName: artifactFileName,
+            format: "mp3",
+            localFilePath,
+            sha256: null,
+            sizeBytes: readFileSync(localFilePath).byteLength
+          },
+          candidate
+        };
+      }
+    });
+
+    try {
+      const run = await submitLiveRunFromPlaylistUrl(
+        "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+        {
+          createRunFromPlaylistUrl: async (playlistUrl) =>
+            createStubRun(runStore, playlistUrl, [
+              {
+                artist: "Anyma",
+                sourcePosition: 1,
+                title: "Consciousness",
+                version: "Extended Mix"
+              },
+              {
+                artist: "Kx5",
+                sourcePosition: 2,
+                title: "Escape"
+              }
+            ]),
+          providerRegistry: createStubRegistry([soundCloudProvider, bandcampProvider]),
+          runStore,
+          workspaceRoot: tempWorkspace.workspaceRoot
+        }
+      );
+
+      expect(searchCalls).toEqual([
+        "soundcloud:Anyma:Consciousness",
+        "bandcamp:Anyma:Consciousness",
+        "soundcloud:Kx5:Escape",
+        "bandcamp:Kx5:Escape"
+      ]);
+      expect(run.status).toBe("completed");
+      expect([...run.artifacts.map((artifact) => artifact.kind)].sort()).toEqual([
+        "downloads-zip",
+        "manifest-json",
+        "misses-txt"
+      ]);
+
+      const persistedRun = runStore.getRun(run.id);
+
+      expect(persistedRun?.tracks.map((track) => [track.sourcePosition, track.status])).toEqual(
+        [
+          [1, "acquired"],
+          [2, "acquired"]
+        ]
+      );
+
+      const attempts = runStore.listRunTrackAttempts(run.id);
+
+      expect(attempts.map((attempt) => [attempt.providerKey, attempt.outcome])).toEqual([
+        ["bandcamp", "matched"],
+        ["soundcloud-direct-downloads", "skipped"],
+        ["bandcamp", "matched"],
+        ["soundcloud-direct-downloads", "skipped"]
+      ]);
+      expect(
+        parseRunTrackArtifactSourceNote(
+          attempts.find((attempt) => attempt.providerKey === "bandcamp")?.note ?? null
+        )
+      ).toEqual(
+        expect.objectContaining({
+          outcome: "acquired"
+        })
+      );
+
+      const manifestArtifact = persistedRun?.artifacts.find(
+        (artifact) => artifact.kind === "manifest-json"
+      );
+
+      expect(manifestArtifact).toBeDefined();
+
+      const manifest = JSON.parse(
+        readFileSync(
+          path.join(tempWorkspace.workspaceRoot, manifestArtifact?.relativePath ?? ""),
+          "utf8"
+        )
+      ) as {
+        summary: {
+          acquiredCount: number;
+          missCount: number;
+          trackCount: number;
+        };
+      };
+
+      expect(manifest.summary).toEqual({
+        acquiredCount: 2,
+        missCount: 0,
+        trackCount: 2
+      });
+    } finally {
+      runStore.close();
+      tempWorkspace.cleanup();
+    }
+  });
+
+  it("persists unresolved automatic misses without falsely completing or packaging the run", async () => {
+    const tempWorkspace = createTempWorkspace();
+    const runStore = createRunStore({ databasePath: tempWorkspace.databasePath });
+
+    const soundCloudProvider = defineAutomaticProvider({
+      id: "soundcloud-direct-downloads",
+      displayName: "SoundCloud Direct Downloads",
+      authorizationBasis: "uploader-enabled-download",
+      priceTier: "free",
+      priorityRank: 10,
+      supportedFormats: ["original-upload-format"],
+      search: async ({ track }) => {
+        if (track.title === "Consciousness") {
+          return {
+            outcome: "candidates" as const,
+            candidates: [
+              buildMatchingCandidate(soundCloudProvider, {
+                artist: track.primaryArtist ?? "Unknown Artist",
+                createdAt: "",
+                id: `track-${track.title}`,
+                runId: "run",
+                sourcePosition: 1,
+                sourceTrackId: null,
+                status: "queued",
+                title: track.title,
+                updatedAt: "",
+                version: track.mix.displayLabel
+              })
+            ]
+          };
+        }
+
+        return buildProviderMissResult({
+          detail: "No uploader-enabled download matched this track on SoundCloud.",
+          providerId: "soundcloud-direct-downloads",
+          providerName: "SoundCloud Direct Downloads",
+          reason: "no-search-results",
+          trackMissReason: "no-authorized-source-match"
+        });
+      },
+      acquire: async ({ candidate, track }) => {
+        const downloadDirectory = path.join(tempWorkspace.workspaceRoot, "downloads");
+        const artifactFileName = `${track.title.toLowerCase().replace(/\s+/g, "-")}.mp3`;
+        const localFilePath = path.join(downloadDirectory, artifactFileName);
+
+        mkdirSync(downloadDirectory, { recursive: true });
+        writeFileSync(localFilePath, `${candidate.providerName}:${track.title}\n`, "utf8");
+
+        return {
+          outcome: "acquired" as const,
+          artifact: {
+            contentType: "audio/mpeg",
+            fileExtension: "mp3",
+            fileName: artifactFileName,
+            format: "mp3",
+            localFilePath,
+            sha256: null,
+            sizeBytes: readFileSync(localFilePath).byteLength
+          },
+          candidate
+        };
+      }
+    });
+    const bandcampProvider = defineAutomaticProvider({
+      id: "bandcamp",
+      displayName: "Bandcamp",
+      authorizationBasis: "rights-holder-storefront",
+      priceTier: "free-or-owned",
+      priorityRank: 20,
+      supportedFormats: ["mp3", "wav"],
+      search: async () =>
+        buildProviderMissResult({
+          detail: "No Bandcamp result matched the requested track.",
+          providerId: "bandcamp",
+          providerName: "Bandcamp",
+          reason: "no-search-results",
+          trackMissReason: "no-authorized-source-match"
+        }),
+      acquire: async () => {
+        throw new Error("Bandcamp acquire should not run after a miss.");
+      }
+    });
+
+    try {
+      const run = await submitLiveRunFromPlaylistUrl(
+        "https://soundcloud.com/dj-nova/sets/warehouse-finds",
+        {
+          createRunFromPlaylistUrl: async (playlistUrl) =>
+            createStubRun(runStore, playlistUrl, [
+              {
+                artist: "Anyma",
+                sourcePosition: 1,
+                title: "Consciousness",
+                version: "Extended Mix"
+              },
+              {
+                artist: "Unknown Artist",
+                sourcePosition: 2,
+                title: "Missing Track"
+              }
+            ]),
+          providerRegistry: createStubRegistry([soundCloudProvider, bandcampProvider]),
+          runStore,
+          workspaceRoot: tempWorkspace.workspaceRoot
+        }
+      );
+
+      expect(run.status).toBe("matching");
+      expect(run.artifacts).toEqual([]);
+      expect(run.tracks.map((track) => [track.sourcePosition, track.status])).toEqual([
+        [1, "acquired"],
+        [2, "missed"]
+      ]);
+
+      const attempts = runStore.listRunTrackAttempts(run.id);
+      const latestMissAttempt = attempts.find(
+        (attempt) => attempt.providerKey === "track-matcher"
+      );
+
+      expect(latestMissAttempt).toEqual(
+        expect.objectContaining({
+          outcome: "missed"
+        })
+      );
+      expect(parseRunTrackArtifactSourceNote(latestMissAttempt?.note ?? null)).toEqual(
+        expect.objectContaining({
+          outcome: "missed",
+          miss: expect.objectContaining({
+            reason: "no-authorized-source-match"
+          })
+        })
+      );
+    } finally {
+      runStore.close();
+      tempWorkspace.cleanup();
+    }
+  });
+});

--- a/src/features/runs/live-run-orchestrator.ts
+++ b/src/features/runs/live-run-orchestrator.ts
@@ -1,0 +1,261 @@
+import {
+  buildAcquiredArtifactSourceNote,
+  buildMissedArtifactSourceNote,
+  generateRunArtifacts
+} from "@/features/artifacts/run-artifacts";
+import {
+  matchTrackCandidates,
+  type SelectedTrackCandidate
+} from "@/features/matching/track-matcher";
+import { createLiveProviderRegistry } from "@/features/providers/live-provider-registry";
+import type {
+  AutomaticProviderDefinition,
+  ProviderAcquiredResult,
+  ProviderRegistry
+} from "@/features/providers/provider-registry";
+import {
+  getRunStore,
+  type RunDetail,
+  type RunStore,
+  type RunTrack
+} from "@/features/runs/run-store";
+import { canonicalizeTrack } from "@/features/tracks/canonical-track";
+
+import { createRunFromPlaylistUrl } from "../ingestion/playlist-intake";
+
+type SubmitLiveRunDependencies = {
+  createRunFromPlaylistUrl?: typeof createRunFromPlaylistUrl;
+  providerRegistry?: Pick<ProviderRegistry, "listAutomatic">;
+  runStore?: RunStore;
+  workspaceRoot?: string;
+};
+
+export async function submitLiveRunFromPlaylistUrl(
+  playlistUrl: string,
+  dependencies: SubmitLiveRunDependencies = {}
+): Promise<RunDetail> {
+  const runStore = dependencies.runStore ?? getRunStore();
+  const providerRegistry =
+    dependencies.providerRegistry ??
+    createLiveProviderRegistry({ workspaceRoot: dependencies.workspaceRoot });
+  let runId: string | null = null;
+
+  try {
+    const createdRun = await (
+      dependencies.createRunFromPlaylistUrl ?? createRunFromPlaylistUrl
+    )(playlistUrl, { runStore });
+
+    runId = createdRun.id;
+
+    runStore.transitionRunStatus(runId, "ingesting");
+    runStore.transitionRunStatus(runId, "matching");
+
+    const hydratedRun = requireRun(runStore, runId);
+
+    for (const track of hydratedRun.tracks) {
+      await resolveTrackWithAutomaticProviders({
+        providers: providerRegistry.listAutomatic(),
+        runStore,
+        track
+      });
+    }
+
+    const resolvedRun = requireRun(runStore, runId);
+
+    if (resolvedRun.tracks.every((track) => track.status === "acquired")) {
+      runStore.transitionRunStatus(runId, "packaging");
+      await generateRunArtifacts({
+        runId,
+        runStore,
+        workspaceRoot: dependencies.workspaceRoot
+      });
+
+      return runStore.transitionRunStatus(runId, "completed");
+    }
+
+    return resolvedRun;
+  } catch (error) {
+    if (runId) {
+      failRunIfPossible(runStore, runId);
+    }
+
+    throw error;
+  }
+}
+
+async function resolveTrackWithAutomaticProviders(input: {
+  providers: AutomaticProviderDefinition[];
+  runStore: RunStore;
+  track: RunTrack;
+}) {
+  const canonicalTrack = canonicalizeTrack({
+    artistName: input.track.artist,
+    source: "playlist-run-track",
+    sourceTrackId: input.track.sourceTrackId ?? input.track.id,
+    title: buildRequestedTrackTitle(input.track)
+  });
+  let hasRetryableFailure = false;
+
+  for (const provider of input.providers) {
+    const searchResult = await provider.search({ track: canonicalTrack });
+
+    if (searchResult.outcome === "miss") {
+      input.runStore.recordAcquisitionAttempt({
+        note: searchResult.miss.detail,
+        outcome: "skipped",
+        providerKey: provider.id,
+        runTrackId: input.track.id
+      });
+      continue;
+    }
+
+    if (searchResult.outcome === "rejected") {
+      input.runStore.recordAcquisitionAttempt({
+        note: searchResult.rejection.detail,
+        outcome: searchResult.rejection.retryable ? "failed" : "skipped",
+        providerKey: provider.id,
+        runTrackId: input.track.id
+      });
+      hasRetryableFailure ||= searchResult.rejection.retryable;
+      continue;
+    }
+
+    const matchResult = matchTrackCandidates({
+      candidates: searchResult.candidates,
+      track: canonicalTrack
+    });
+
+    if (matchResult.outcome === "miss") {
+      input.runStore.recordAcquisitionAttempt({
+        note: matchResult.miss.details,
+        outcome: "skipped",
+        providerKey: provider.id,
+        runTrackId: input.track.id
+      });
+      continue;
+    }
+
+    input.runStore.updateRunTrackStatus(input.track.id, "matched");
+
+    const acquisitionResult = await provider.acquire({
+      candidate: matchResult.selected.candidate,
+      track: canonicalTrack
+    });
+
+    if (acquisitionResult.outcome === "acquired") {
+      persistAcquiredTrack({
+        acquisitionResult,
+        provider,
+        runStore: input.runStore,
+        selectedDetails: matchResult.selected,
+        track: input.track
+      });
+      return;
+    }
+
+    if (acquisitionResult.outcome === "miss") {
+      input.runStore.recordAcquisitionAttempt({
+        note: acquisitionResult.miss.detail,
+        outcome: "skipped",
+        providerKey: provider.id,
+        runTrackId: input.track.id
+      });
+      continue;
+    }
+
+    input.runStore.recordAcquisitionAttempt({
+      note: acquisitionResult.rejection.detail,
+      outcome: acquisitionResult.rejection.retryable ? "failed" : "skipped",
+      providerKey: provider.id,
+      runTrackId: input.track.id
+    });
+    hasRetryableFailure ||= acquisitionResult.rejection.retryable;
+  }
+
+  if (hasRetryableFailure) {
+    input.runStore.updateRunTrackStatus(input.track.id, "failed");
+    return;
+  }
+
+  input.runStore.updateRunTrackStatus(input.track.id, "missed");
+  input.runStore.recordAcquisitionAttempt({
+    note: JSON.stringify(
+      buildMissedArtifactSourceNote({
+        miss: {
+          detail:
+            "All automatic authorized-source providers were exhausted without selecting an eligible acquisition candidate.",
+          providerId: "track-matcher",
+          providerName: "Track matcher",
+          reason: "no-authorized-source-match"
+        }
+      })
+    ),
+    outcome: "missed",
+    providerKey: "track-matcher",
+    runTrackId: input.track.id
+  });
+}
+
+function persistAcquiredTrack(input: {
+  acquisitionResult: ProviderAcquiredResult;
+  provider: AutomaticProviderDefinition;
+  runStore: RunStore;
+  selectedDetails: SelectedTrackCandidate;
+  track: RunTrack;
+}) {
+  input.runStore.updateRunTrackStatus(input.track.id, "acquired");
+  input.runStore.recordAcquisitionAttempt({
+    note: JSON.stringify(
+      buildAcquiredArtifactSourceNote({
+        artifact: {
+          ...input.acquisitionResult.artifact
+        },
+        provider: {
+          authorizationBasis: input.provider.authorizationBasis,
+          candidateId: input.acquisitionResult.candidate.candidateId,
+          discoveredVia:
+            input.acquisitionResult.candidate.provenance.discoveredVia ?? "search",
+          priceTier: input.provider.priceTier,
+          providerId: input.provider.id,
+          providerName: input.provider.displayName,
+          providerUrl:
+            input.acquisitionResult.candidate.provenance.providerUrl ??
+            input.acquisitionResult.candidate.provenance.sourcePageUrl ??
+            null
+        },
+        selection: {
+          details: input.selectedDetails.details,
+          reason: input.selectedDetails.reason,
+          selectedFormat: input.selectedDetails.selectedFormat
+        }
+      })
+    ),
+    outcome: "matched",
+    providerKey: input.provider.id,
+    runTrackId: input.track.id
+  });
+}
+
+function buildRequestedTrackTitle(track: RunTrack) {
+  return track.version ? `${track.title} (${track.version})` : track.title;
+}
+
+function failRunIfPossible(runStore: RunStore, runId: string) {
+  const run = runStore.getRun(runId);
+
+  if (!run || run.status === "completed" || run.status === "failed") {
+    return;
+  }
+
+  runStore.transitionRunStatus(runId, "failed");
+}
+
+function requireRun(runStore: RunStore, runId: string) {
+  const run = runStore.getRun(runId);
+
+  if (!run) {
+    throw new Error(`Run not found: ${runId}`);
+  }
+
+  return run;
+}


### PR DESCRIPTION
**@worker-01**

## Summary
- wire non-fixture `POST /api/runs` submissions through a shared live-run orchestrator instead of stopping after playlist intake
- execute the automatic provider registry in priority order, persist track/provider outcomes, and package fully auto-resolved runs
- carry real downloaded file paths through provider acquisition metadata so packaging can build artifacts from actual acquired files
- move the old intake happy-path assertions into dedicated `playlist-intake` unit tests and keep route tests focused on fixture-vs-live orchestration behavior

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
