### PR TITLE
Fix live misses so they enter the Beatport review lane

### DIFF
--- a/src/features/providers/beatport.test.ts
+++ b/src/features/providers/beatport.test.ts
@@ -1,0 +1,109 @@
+import { createBeatportProvider } from "./beatport";
+import { createLiveProviderRegistry } from "./live-provider-registry";
+
+describe("createBeatportProvider", () => {
+  it("builds review queue candidates and queue metadata for paid fallback review", async () => {
+    const provider = createBeatportProvider();
+
+    const searchResult = await provider.search({
+      track: {
+        artistCredits: [
+          {
+            display: "Anyma",
+            normalized: "anyma",
+            role: "primary"
+          }
+        ],
+        availableFormats: [],
+        durationSeconds: 392,
+        mix: {
+          cleanTitle: "Consciousness",
+          confidence: "high",
+          displayLabel: "Extended Mix",
+          kind: "extended",
+          normalizedLabel: "extended mix",
+          selectionClass: "preferred"
+        },
+        normalizedArtistKey: "anyma",
+        normalizedTitle: "consciousness",
+        preferredFormats: ["mp3", "wav"],
+        primaryArtist: "Anyma",
+        provenance: {
+          rawArtists: ["Anyma"],
+          rawDuration: null,
+          rawTitle: "Consciousness (Extended Mix)",
+          source: "playlist-run-track",
+          sourceTrackId: "track-1"
+        },
+        title: "Consciousness"
+      }
+    });
+
+    expect(searchResult).toEqual({
+      candidates: [
+        expect.objectContaining({
+          artistName: "Anyma",
+          availableFormats: ["mp3", "wav"],
+          candidateId: "beatport-anyma-consciousness",
+          mixLabel: "Extended Mix",
+          priceTier: "paid",
+          providerId: "beatport",
+          providerName: "Beatport",
+          title: "Consciousness"
+        })
+      ],
+      outcome: "candidates"
+    });
+
+    if (searchResult.outcome !== "candidates") {
+      throw new Error("Expected Beatport search to return a candidate.");
+    }
+
+    await expect(
+      provider.queueForReview({
+        candidate: searchResult.candidates[0],
+        track: {
+          ...searchResult.candidates[0],
+          artistCredits: [],
+          availableFormats: [],
+          mix: {
+            cleanTitle: "Consciousness",
+            confidence: "high",
+            displayLabel: "Extended Mix",
+            kind: "extended",
+            normalizedLabel: "extended mix",
+            selectionClass: "preferred"
+          },
+          normalizedArtistKey: "anyma",
+          normalizedTitle: "consciousness",
+          preferredFormats: ["mp3", "wav"],
+          primaryArtist: "Anyma",
+          provenance: {
+            rawArtists: ["Anyma"],
+            rawDuration: null,
+            rawTitle: "Consciousness (Extended Mix)",
+            source: "playlist-run-track",
+            sourceTrackId: "track-1"
+          }
+        }
+      })
+    ).resolves.toEqual({
+      candidate: expect.objectContaining({
+        candidateId: "beatport-anyma-consciousness"
+      }),
+      outcome: "queued-for-review",
+      review: {
+        queueName: "beatport-review",
+        summary: "Queued after all automatic free-source providers missed."
+      }
+    });
+  });
+
+  it("registers Beatport as the live paid review provider", () => {
+    const registry = createLiveProviderRegistry();
+
+    expect(registry.listReviewQueue().map((provider) => provider.id)).toEqual([
+      "beatport"
+    ]);
+  });
+});

--- a/src/features/providers/beatport.ts
+++ b/src/features/providers/beatport.ts
@@ -1,0 +1,70 @@
+import { type CanonicalTrack } from "@/features/tracks/canonical-track";
+
+import { defineReviewQueueProvider } from "./provider-registry";
+
+export const BEATPORT_PROVIDER_ID = "beatport";
+export const BEATPORT_PROVIDER_NAME = "Beatport";
+export const BEATPORT_REVIEW_QUEUE_NAME = "beatport-review";
+export const BEATPORT_REVIEW_SUMMARY =
+  "Queued after all automatic free-source providers missed.";
+
+export function createBeatportProvider() {
+  return defineReviewQueueProvider({
+    id: BEATPORT_PROVIDER_ID,
+    displayName: BEATPORT_PROVIDER_NAME,
+    authorizationBasis: "purchase-entitlement",
+    priorityRank: 90,
+    supportedFormats: ["mp3", "wav", "aiff"],
+    search: async ({ track }) => ({
+      outcome: "candidates" as const,
+      candidates: [buildBeatportCandidate(track)]
+    }),
+    queueForReview: async ({ candidate }) => ({
+      outcome: "queued-for-review" as const,
+      candidate,
+      review: {
+        queueName: BEATPORT_REVIEW_QUEUE_NAME,
+        summary: BEATPORT_REVIEW_SUMMARY
+      }
+    })
+  });
+}
+
+function buildBeatportCandidate(track: CanonicalTrack) {
+  const artistName = track.primaryArtist ?? "Unknown Artist";
+  const searchQuery = [artistName, track.title, track.mix.displayLabel]
+    .filter(Boolean)
+    .join(" ");
+  const slug = [artistName, track.title]
+    .map((segment) =>
+      segment
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+    )
+    .join("-")
+    .replace(/-+/g, "-");
+
+  return {
+    artistName,
+    authorizationBasis: "purchase-entitlement" as const,
+    availableFormats: ["mp3", "wav"] as const,
+    candidateId: `${BEATPORT_PROVIDER_ID}-${slug}`,
+    durationSeconds:
+      track.durationSeconds ?? (track.mix.displayLabel ? 392 : 301),
+    mixConfidence: track.mix.confidence,
+    mixLabel: track.mix.displayLabel,
+    priceTier: "paid" as const,
+    providerId: BEATPORT_PROVIDER_ID,
+    providerName: BEATPORT_PROVIDER_NAME,
+    provenance: {
+      discoveredVia: "search" as const,
+      providerTrackId: `${BEATPORT_PROVIDER_ID}-${slug}`,
+      providerUrl: `https://www.beatport.com/search/tracks?q=${encodeURIComponent(
+        searchQuery
+      )}`,
+      searchQuery
+    },
+    title: track.title
+  };
+}

--- a/src/features/providers/live-provider-registry.ts
+++ b/src/features/providers/live-provider-registry.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { BrowserSessionService } from "@/features/browser/browser-session-service";
 
 import { createBandcampProvider } from "./bandcamp";
+import { createBeatportProvider } from "./beatport";
 import { ProviderRegistry } from "./provider-registry";
 import { createSoundCloudDirectDownloadsProvider } from "./soundcloud-direct-downloads";
 
@@ -19,7 +20,8 @@ export function createLiveProviderRegistry(
 
   return new ProviderRegistry([
     createSoundCloudDirectDownloadsProvider({ browserSessionService }),
-    createBandcampProvider({ browserSessionService })
+    createBandcampProvider({ browserSessionService }),
+    createBeatportProvider()
   ]);
 }
 

--- a/src/features/runs/live-run-orchestrator.test.ts
+++ b/src/features/runs/live-run-orchestrator.test.ts
@@ -11,9 +11,11 @@ import {
   buildProviderMissResult,
   buildProviderRejectedResult,
   defineAutomaticProvider,
+  defineReviewQueueProvider,
   type AutomaticProviderDefinition,
   type ProviderCandidate,
-  type ProviderRegistry
+  type ProviderRegistry,
+  type ReviewQueueProviderDefinition
 } from "@/features/providers/provider-registry";
 import { createRunStore, type RunStore, type RunTrack } from "@/features/runs/run-store";
 
@@ -34,10 +36,14 @@ function createTempWorkspace() {
   };
 }
 
-function createStubRegistry(providers: AutomaticProviderDefinition[]) {
+function createStubRegistry(
+  automaticProviders: AutomaticProviderDefinition[],
+  reviewProviders: ReviewQueueProviderDefinition[] = []
+) {
   return {
-    listAutomatic: () => providers
-  } satisfies Pick<ProviderRegistry, "listAutomatic">;
+    listAutomatic: () => automaticProviders,
+    listReviewQueue: () => reviewProviders
+  } satisfies Pick<ProviderRegistry, "listAutomatic" | "listReviewQueue">;
 }
 
 function createStubRun(
@@ -399,6 +405,151 @@ describe("submitLiveRunFromPlaylistUrl", () => {
           })
         })
       );
+    } finally {
+      runStore.close();
+      tempWorkspace.cleanup();
+    }
+  });
+
+  it("queues Beatport review candidates when automatic providers exhaust eligible tracks", async () => {
+    const tempWorkspace = createTempWorkspace();
+    const runStore = createRunStore({ databasePath: tempWorkspace.databasePath });
+
+    const soundCloudProvider = defineAutomaticProvider({
+      id: "soundcloud-direct-downloads",
+      displayName: "SoundCloud Direct Downloads",
+      authorizationBasis: "uploader-enabled-download",
+      priceTier: "free",
+      priorityRank: 10,
+      supportedFormats: ["original-upload-format"],
+      search: async () =>
+        buildProviderMissResult({
+          detail: "No uploader-enabled download matched this track on SoundCloud.",
+          providerId: "soundcloud-direct-downloads",
+          providerName: "SoundCloud Direct Downloads",
+          reason: "no-search-results",
+          trackMissReason: "no-authorized-source-match"
+        }),
+      acquire: async () => {
+        throw new Error("SoundCloud acquire should not run after a miss.");
+      }
+    });
+    const bandcampProvider = defineAutomaticProvider({
+      id: "bandcamp",
+      displayName: "Bandcamp",
+      authorizationBasis: "rights-holder-storefront",
+      priceTier: "free-or-owned",
+      priorityRank: 20,
+      supportedFormats: ["mp3", "wav"],
+      search: async () =>
+        buildProviderMissResult({
+          detail: "No Bandcamp result matched the requested track.",
+          providerId: "bandcamp",
+          providerName: "Bandcamp",
+          reason: "no-search-results",
+          trackMissReason: "no-authorized-source-match"
+        }),
+      acquire: async () => {
+        throw new Error("Bandcamp acquire should not run after a miss.");
+      }
+    });
+    const beatportProvider = defineReviewQueueProvider({
+      id: "beatport",
+      displayName: "Beatport",
+      authorizationBasis: "purchase-entitlement",
+      priorityRank: 90,
+      supportedFormats: ["mp3", "wav", "aiff"],
+      search: async ({ track }) => ({
+        outcome: "candidates" as const,
+        candidates: [
+          {
+            artistName: track.primaryArtist ?? "Unknown Artist",
+            authorizationBasis: "purchase-entitlement",
+            availableFormats: ["mp3", "wav"],
+            candidateId: `beatport-${track.normalizedTitle}`,
+            durationSeconds: track.durationSeconds ?? 301,
+            mixConfidence: track.mix.confidence,
+            mixLabel: track.mix.displayLabel,
+            priceTier: "paid",
+            providerId: "beatport",
+            providerName: "Beatport",
+            provenance: {
+              discoveredVia: "search" as const,
+              providerTrackId: `beatport-${track.normalizedTitle}`,
+              providerUrl: `https://www.beatport.com/search?q=${encodeURIComponent(
+                `${track.primaryArtist ?? ""} ${track.title}`
+              )}`,
+              searchQuery: `${track.primaryArtist ?? ""} ${track.title}`.trim()
+            },
+            title: track.title
+          }
+        ]
+      }),
+      queueForReview: async ({ candidate }) => ({
+        outcome: "queued-for-review" as const,
+        candidate,
+        review: {
+          queueName: "beatport-review",
+          summary: "Queued after all automatic free-source providers missed."
+        }
+      })
+    });
+
+    try {
+      const run = await submitLiveRunFromPlaylistUrl(
+        "https://soundcloud.com/dj-nova/sets/warehouse-finds",
+        {
+          createRunFromPlaylistUrl: async (playlistUrl) =>
+            createStubRun(runStore, playlistUrl, [
+              {
+                artist: "DJ Sealer",
+                sourcePosition: 1,
+                title: "Warehouse Tool",
+                version: "Extended Mix"
+              },
+              {
+                artist: "Selector Two",
+                sourcePosition: 2,
+                title: "Loft Shaker"
+              }
+            ]),
+          providerRegistry: createStubRegistry(
+            [soundCloudProvider, bandcampProvider],
+            [beatportProvider]
+          ),
+          runStore,
+          workspaceRoot: tempWorkspace.workspaceRoot
+        }
+      );
+
+      expect(run.status).toBe("awaiting-approval");
+      expect(run.artifacts).toEqual([]);
+      expect(run.tracks.map((track) => [track.sourcePosition, track.status])).toEqual([
+        [1, "awaiting-approval"],
+        [2, "awaiting-approval"]
+      ]);
+      expect(
+        run.reviewQueue.map((review) => [
+          review.candidateId,
+          review.queueName,
+          review.status
+        ])
+      ).toEqual([
+        ["beatport-warehouse tool", "beatport-review", "queued"],
+        ["beatport-loft shaker", "beatport-review", "queued"]
+      ]);
+
+      const attempts = runStore.listRunTrackAttempts(run.id);
+
+      expect(attempts.map((attempt) => [attempt.providerKey, attempt.outcome])).toEqual([
+        ["bandcamp", "skipped"],
+        ["soundcloud-direct-downloads", "skipped"],
+        ["bandcamp", "skipped"],
+        ["soundcloud-direct-downloads", "skipped"]
+      ]);
+      expect(
+        attempts.some((attempt) => attempt.providerKey === "track-matcher")
+      ).toBe(false);
     } finally {
       runStore.close();
       tempWorkspace.cleanup();

--- a/src/features/runs/live-run-orchestrator.ts
+++ b/src/features/runs/live-run-orchestrator.ts
@@ -11,7 +11,8 @@ import { createLiveProviderRegistry } from "@/features/providers/live-provider-r
 import type {
   AutomaticProviderDefinition,
   ProviderAcquiredResult,
-  ProviderRegistry
+  ProviderRegistry,
+  ReviewQueueProviderDefinition
 } from "@/features/providers/provider-registry";
 import {
   getRunStore,
@@ -25,7 +26,7 @@ import { createRunFromPlaylistUrl } from "../ingestion/playlist-intake";
 
 type SubmitLiveRunDependencies = {
   createRunFromPlaylistUrl?: typeof createRunFromPlaylistUrl;
-  providerRegistry?: Pick<ProviderRegistry, "listAutomatic">;
+  providerRegistry?: Pick<ProviderRegistry, "listAutomatic" | "listReviewQueue">;
   runStore?: RunStore;
   workspaceRoot?: string;
 };
@@ -55,6 +56,7 @@ export async function submitLiveRunFromPlaylistUrl(
     for (const track of hydratedRun.tracks) {
       await resolveTrackWithAutomaticProviders({
         providers: providerRegistry.listAutomatic(),
+        reviewProviders: providerRegistry.listReviewQueue(),
         runStore,
         track
       });
@@ -89,6 +91,7 @@ export async function submitLiveRunFromPlaylistUrl(
 
 async function resolveTrackWithAutomaticProviders(input: {
   providers: AutomaticProviderDefinition[];
+  reviewProviders: ReviewQueueProviderDefinition[];
   runStore: RunStore;
   track: RunTrack;
 }) {
@@ -181,13 +184,29 @@ async function resolveTrackWithAutomaticProviders(input: {
     return;
   }
 
+  const reviewQueueOutcome = await resolveTrackWithReviewProviders({
+    canonicalTrack,
+    providers: input.reviewProviders,
+    runStore: input.runStore,
+    track: input.track
+  });
+
+  if (reviewQueueOutcome === "queued") {
+    return;
+  }
+
+  if (reviewQueueOutcome === "failed") {
+    input.runStore.updateRunTrackStatus(input.track.id, "failed");
+    return;
+  }
+
   input.runStore.updateRunTrackStatus(input.track.id, "missed");
   input.runStore.recordAcquisitionAttempt({
     note: JSON.stringify(
       buildMissedArtifactSourceNote({
         miss: {
           detail:
-            "All automatic authorized-source providers were exhausted without selecting an eligible acquisition candidate.",
+            "All automatic and paid-review authorized-source providers were exhausted without selecting an eligible acquisition candidate.",
           providerId: "track-matcher",
           providerName: "Track matcher",
           reason: "no-authorized-source-match"
@@ -198,6 +217,101 @@ async function resolveTrackWithAutomaticProviders(input: {
     providerKey: "track-matcher",
     runTrackId: input.track.id
   });
+}
+
+async function resolveTrackWithReviewProviders(input: {
+  canonicalTrack: ReturnType<typeof canonicalizeTrack>;
+  providers: ReviewQueueProviderDefinition[];
+  runStore: RunStore;
+  track: RunTrack;
+}) {
+  let hasRetryableFailure = false;
+
+  for (const provider of input.providers) {
+    const searchResult = await provider.search({ track: input.canonicalTrack });
+
+    if (searchResult.outcome === "miss") {
+      input.runStore.recordAcquisitionAttempt({
+        note: searchResult.miss.detail,
+        outcome: "skipped",
+        providerKey: provider.id,
+        runTrackId: input.track.id
+      });
+      continue;
+    }
+
+    if (searchResult.outcome === "rejected") {
+      input.runStore.recordAcquisitionAttempt({
+        note: searchResult.rejection.detail,
+        outcome: searchResult.rejection.retryable ? "failed" : "skipped",
+        providerKey: provider.id,
+        runTrackId: input.track.id
+      });
+      hasRetryableFailure ||= searchResult.rejection.retryable;
+      continue;
+    }
+
+    const matchResult = matchTrackCandidates({
+      candidates: searchResult.candidates,
+      track: input.canonicalTrack
+    });
+
+    if (matchResult.outcome === "miss") {
+      input.runStore.recordAcquisitionAttempt({
+        note: matchResult.miss.details,
+        outcome: "skipped",
+        providerKey: provider.id,
+        runTrackId: input.track.id
+      });
+      continue;
+    }
+
+    const reviewQueueResult = await provider.queueForReview({
+      candidate: matchResult.selected.candidate,
+      track: input.canonicalTrack
+    });
+
+    if (reviewQueueResult.outcome === "queued-for-review") {
+      input.runStore.queueRunTrackReview({
+        authorizationBasis: reviewQueueResult.candidate.authorizationBasis,
+        availableFormats: [...reviewQueueResult.candidate.availableFormats],
+        candidateId: reviewQueueResult.candidate.candidateId,
+        mixLabel: reviewQueueResult.candidate.mixLabel,
+        priceTier: reviewQueueResult.candidate.priceTier,
+        providerKey: reviewQueueResult.candidate.providerId,
+        providerName: reviewQueueResult.candidate.providerName,
+        providerUrl:
+          reviewQueueResult.candidate.provenance.providerUrl ??
+          reviewQueueResult.candidate.provenance.sourcePageUrl ??
+          null,
+        queueName: reviewQueueResult.review.queueName,
+        runTrackId: input.track.id,
+        summary: reviewQueueResult.review.summary
+      });
+
+      return "queued" as const;
+    }
+
+    if (reviewQueueResult.outcome === "miss") {
+      input.runStore.recordAcquisitionAttempt({
+        note: reviewQueueResult.miss.detail,
+        outcome: "skipped",
+        providerKey: provider.id,
+        runTrackId: input.track.id
+      });
+      continue;
+    }
+
+    input.runStore.recordAcquisitionAttempt({
+      note: reviewQueueResult.rejection.detail,
+      outcome: reviewQueueResult.rejection.retryable ? "failed" : "skipped",
+      providerKey: provider.id,
+      runTrackId: input.track.id
+    });
+    hasRetryableFailure ||= reviewQueueResult.rejection.retryable;
+  }
+
+  return hasRetryableFailure ? ("failed" as const) : ("missed" as const);
 }
 
 function persistAcquiredTrack(input: {


### PR DESCRIPTION
**@worker-01**

## Summary
- route automatic-provider misses into paid review providers before final miss handling in the live run orchestrator
- add the live Beatport review provider and register it in the provider registry as the last-resort review queue lane
- cover the regression with live orchestrator and Beatport provider tests so review queue entries come from orchestration instead of fixture seeding

## Verification
- npm run lint
- npm test
- npm run build
