### PR TITLE
Fix deterministic verification to use the live orchestration path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Local web app for authorized-source playlist acquisition, optimized for DJ and e
 - Local-only operator workflow
 - Authorized-source acquisition only
 - No stream-ripping, bypass, or unauthorized-source behavior
-- Current state: app shell with persisted Spotify and SoundCloud playlist intake
+- Current state: live Spotify and SoundCloud playlist intake, automatic
+  authorized-source matching/acquisition, packaged run artifacts, and Beatport
+  paid-review queueing
 
 ## Requirements
 
@@ -20,9 +22,13 @@ Local web app for authorized-source playlist acquisition, optimized for DJ and e
 npm install
 ```
 
+## Live Credentials
+
+The normal local operator runtime (`npm run dev`) uses live playlist intake and
+therefore expects authorized Spotify and SoundCloud API credentials.
+
 To enable authorized Spotify playlist ingestion through the Spotify Web API
-client-credentials flow,
-set these Spotify env vars before running the app:
+client-credentials flow, set these Spotify env vars before starting the app:
 
 ```bash
 export SPOTIFY_CLIENT_ID=your-spotify-client-id
@@ -37,7 +43,7 @@ export SPOTIFY_MARKET=US
 ```
 
 To enable authorized SoundCloud playlist ingestion through the official API,
-set these env vars before running the app:
+set these env vars before starting the app:
 
 ```bash
 export SOUNDCLOUD_CLIENT_ID=your-soundcloud-client-id
@@ -63,23 +69,25 @@ npm run test:e2e
 
 ## Local Verification
 
-`npm run test:e2e` starts the app with an isolated `.e2e/runtime` workspace and
-deterministic local fixtures for the end-to-end flow. The Playwright coverage
+`npm run test:e2e` starts the app with `MUSIC_DOWNLOADER_E2E_FIXTURES=1`, an
+isolated `.e2e/runtime` workspace, and deterministic fixture-mode playlist and
+provider seams. Playwright still submits playlists through `/api/runs` and the
+shared live orchestrator; it does not pre-seed completed runs. The coverage
 exercises:
 
 - playlist submission through the real intake form
 - completed run reports with `downloads.zip`, `manifest.json`, and `misses.txt`
-- miss-heavy reports with Beatport review-lane visibility
+- Beatport review-lane visibility for paid fallback handoff
 - resumability after a persisted in-flight run is re-opened
 
-No live provider credentials are required for that verification path, and the
-fixtures stay within authorized-source-only scenarios. The normal `npm run dev`
-path still uses real Spotify and SoundCloud credentials when you want to test
-live playlist intake locally.
+No live Spotify or SoundCloud credentials are required for that verification
+path, and the fixtures stay within authorized-source-only scenarios. Use
+`npm run dev` with the env vars above when you want to test live playlist
+intake locally.
 
 ## Notes
 
 - The app persists runs in local SQLite and renders run-report detail pages from
   that shared store.
-- End-to-end verification uses fixture-backed runs so local coverage can stay
-  deterministic without introducing unauthorized acquisition behavior.
+- End-to-end verification swaps in deterministic fixture-mode intake/provider
+  seams while keeping the `/api/runs` orchestration path intact.

--- a/src/app/api/runs/route.test.ts
+++ b/src/app/api/runs/route.test.ts
@@ -30,17 +30,17 @@ afterEach(() => {
 });
 
 describe("/api/runs", () => {
-  it("returns fixture-backed runs without invoking the live orchestrator", async () => {
+  it("submits runs through the shared live orchestrator without route-level fixture bypasses", async () => {
     await withTempDatabase(async (databasePath) => {
       vi.resetModules();
 
       const playlistUrl = "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9";
-      const fixtureRun = {
+      const createdRun = {
         artifactCount: 3,
         artifacts: [],
         createdAt: "2026-03-31T21:00:00.000Z",
-        id: "run-fixture",
-        playlistTitle: "Fixture Warehouse Starters",
+        id: "run-live-pipeline",
+        playlistTitle: "Warehouse Starters",
         playlistUrl,
         resumeAfterStatus: null,
         reviewQueue: [],
@@ -50,12 +50,11 @@ describe("/api/runs", () => {
         tracks: [],
         updatedAt: "2026-03-31T21:05:00.000Z"
       };
-      const maybeCreateFixtureRunFromPlaylistUrl = vi.fn().mockResolvedValue(fixtureRun);
-      const submitLiveRunFromPlaylistUrl = vi.fn();
+      const submitLiveRunFromPlaylistUrl = vi.fn().mockResolvedValue(createdRun);
 
-      vi.doMock("@/features/e2e/e2e-fixtures", () => ({
-        maybeCreateFixtureRunFromPlaylistUrl
-      }));
+      vi.doMock("@/features/e2e/e2e-fixtures", () => {
+        throw new Error("route should not import e2e fixture submission bypasses");
+      });
       vi.doMock("@/features/runs/live-run-orchestrator", () => ({
         submitLiveRunFromPlaylistUrl
       }));
@@ -74,9 +73,8 @@ describe("/api/runs", () => {
 
       expect(createResponse.status).toBe(201);
       expect(existsSync(databasePath)).toBe(false);
-      expect(maybeCreateFixtureRunFromPlaylistUrl).toHaveBeenCalledWith(playlistUrl);
-      expect(submitLiveRunFromPlaylistUrl).not.toHaveBeenCalled();
-      await expect(createResponse.json()).resolves.toEqual(fixtureRun);
+      expect(submitLiveRunFromPlaylistUrl).toHaveBeenCalledWith(playlistUrl);
+      await expect(createResponse.json()).resolves.toEqual(createdRun);
     });
   });
 
@@ -252,12 +250,8 @@ describe("/api/runs", () => {
         tracks: [],
         updatedAt: "2026-03-31T21:05:00.000Z"
       };
-      const maybeCreateFixtureRunFromPlaylistUrl = vi.fn().mockResolvedValue(null);
       const submitLiveRunFromPlaylistUrl = vi.fn().mockResolvedValue(createdRun);
 
-      vi.doMock("@/features/e2e/e2e-fixtures", () => ({
-        maybeCreateFixtureRunFromPlaylistUrl
-      }));
       vi.doMock("@/features/runs/live-run-orchestrator", () => ({
         submitLiveRunFromPlaylistUrl
       }));
@@ -275,7 +269,6 @@ describe("/api/runs", () => {
       );
 
       expect(response.status).toBe(201);
-      expect(maybeCreateFixtureRunFromPlaylistUrl).toHaveBeenCalledWith(playlistUrl);
       expect(submitLiveRunFromPlaylistUrl).toHaveBeenCalledWith(playlistUrl);
       await expect(response.json()).resolves.toEqual(createdRun);
     });

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 
-import { maybeCreateFixtureRunFromPlaylistUrl } from "@/features/e2e/e2e-fixtures";
 import { PlaylistIntakeError } from "@/features/ingestion/playlist-intake-error";
 import { getRunStore } from "@/features/runs/run-store";
 import { submitLiveRunFromPlaylistUrl } from "@/features/runs/live-run-orchestrator";
@@ -23,14 +22,6 @@ export async function POST(request: Request) {
   }
 
   try {
-    const fixtureRun = await maybeCreateFixtureRunFromPlaylistUrl(playlistUrl);
-
-    if (fixtureRun) {
-      return NextResponse.json(fixtureRun, {
-        status: 201
-      });
-    }
-
     return NextResponse.json(await submitLiveRunFromPlaylistUrl(playlistUrl), {
       status: 201
     });

--- a/src/features/e2e/e2e-fixtures.ts
+++ b/src/features/e2e/e2e-fixtures.ts
@@ -9,12 +9,24 @@ import {
   generateRunArtifacts
 } from "@/features/artifacts/run-artifacts";
 import {
+  ProviderRegistry,
+  buildProviderMissResult,
+  defineAutomaticProvider,
+  defineReviewQueueProvider,
+  type ProviderArtifactFormat,
+  type ProviderAuthorizationBasis,
+  type ProviderCandidate,
+  type ProviderPriceTier
+} from "@/features/providers/provider-registry";
+import {
   createRunStore,
   getRunStore,
   resetRunStoreForTests,
+  type ReplaceRunTrackInput,
   type RunDetail,
   type RunStore
 } from "@/features/runs/run-store";
+import type { CanonicalTrack } from "@/features/tracks/canonical-track";
 
 export const e2eFixtureScenarios = [
   "resume-matching",
@@ -29,24 +41,217 @@ const SPOTIFY_HAPPY_PATH_URL =
 const SOUNDCLOUD_MISS_HEAVY_URL =
   "https://soundcloud.com/dj-nova/sets/warehouse-finds";
 
+type FixturePlaylistSnapshot = {
+  playlistTitle: string | null;
+  playlistUrl: string;
+  tracks: ReplaceRunTrackInput[];
+};
+
 export function isE2eFixtureModeEnabled() {
   return process.env.MUSIC_DOWNLOADER_E2E_FIXTURES === "1";
 }
 
-export async function maybeCreateFixtureRunFromPlaylistUrl(playlistUrl: string) {
+export function resolveE2eFixturePlaylistSnapshot(
+  playlistUrl: string
+): FixturePlaylistSnapshot | null {
   if (!isE2eFixtureModeEnabled()) {
     return null;
   }
 
   if (playlistUrl === SPOTIFY_HAPPY_PATH_URL) {
-    return seedE2eScenario("spotify-happy-path");
+    return {
+      playlistTitle: "Warehouse Starters",
+      playlistUrl: SPOTIFY_HAPPY_PATH_URL,
+      tracks: buildSpotifyHappyPathTracks()
+    };
   }
 
   if (playlistUrl === SOUNDCLOUD_MISS_HEAVY_URL) {
-    return seedE2eScenario("soundcloud-miss-heavy");
+    return {
+      playlistTitle: "Warehouse Finds",
+      playlistUrl: SOUNDCLOUD_MISS_HEAVY_URL,
+      tracks: buildSoundCloudReviewLaneTracks()
+    };
   }
 
   return null;
+}
+
+export function createE2eFixtureProviderRegistry(
+  input: {
+    workspaceRoot?: string;
+  } = {}
+) {
+  if (!isE2eFixtureModeEnabled()) {
+    return null;
+  }
+
+  const workspaceRoot = resolveWorkspaceRoot(input.workspaceRoot);
+
+  const soundCloudProvider = defineAutomaticProvider({
+    id: "soundcloud-direct-downloads",
+    displayName: "SoundCloud Direct Downloads",
+    authorizationBasis: "uploader-enabled-download",
+    priceTier: "free",
+    priorityRank: 10,
+    supportedFormats: ["original-upload-format"],
+    search: async ({ track }) => {
+      if (
+        track.primaryArtist === "Anyma" &&
+        track.title === "Consciousness" &&
+        track.mix.displayLabel === "Extended Mix"
+      ) {
+        return {
+          outcome: "candidates" as const,
+          candidates: [
+            buildFixtureCandidate({
+              authorizationBasis: "uploader-enabled-download",
+              availableFormats: ["mp3"],
+              candidateId: "soundcloud-201",
+              durationSeconds: 392,
+              priceTier: "free",
+              providerId: "soundcloud-direct-downloads",
+              providerName: "SoundCloud Direct Downloads",
+              providerUrl: "https://soundcloud.com/anyma/consciousness",
+              track
+            })
+          ]
+        };
+      }
+
+      return buildFixtureSearchMiss({
+        detail: "No uploader-enabled download matched this track on SoundCloud.",
+        providerId: "soundcloud-direct-downloads",
+        providerName: "SoundCloud Direct Downloads"
+      });
+    },
+    acquire: async ({ candidate, track }) => {
+      if (track.title !== "Consciousness") {
+        return buildFixtureSearchMiss({
+          detail: "Fixture acquisition only covers the Consciousness happy-path track.",
+          providerId: "soundcloud-direct-downloads",
+          providerName: "SoundCloud Direct Downloads"
+        });
+      }
+
+      return {
+        outcome: "acquired" as const,
+        artifact: writeFixtureArtifact({
+          contents: "fixture consciousness payload\n",
+          fileName: "anyma-consciousness-extended-mix.mp3",
+          workspaceRoot
+        }),
+        candidate
+      };
+    }
+  });
+
+  const bandcampProvider = defineAutomaticProvider({
+    id: "bandcamp",
+    displayName: "Bandcamp",
+    authorizationBasis: "rights-holder-storefront",
+    priceTier: "free-or-owned",
+    priorityRank: 20,
+    supportedFormats: ["mp3", "wav", "flac"],
+    search: async ({ track }) => {
+      if (track.primaryArtist === "Kx5" && track.title === "Escape") {
+        return {
+          outcome: "candidates" as const,
+          candidates: [
+            buildFixtureCandidate({
+              authorizationBasis: "rights-holder-storefront",
+              availableFormats: ["mp3", "wav"],
+              candidateId: "bandcamp-301",
+              durationSeconds: 301,
+              priceTier: "free-or-owned",
+              providerId: "bandcamp",
+              providerName: "Bandcamp",
+              providerUrl: "https://artist.bandcamp.com/track/escape",
+              track
+            })
+          ]
+        };
+      }
+
+      return buildFixtureSearchMiss({
+        detail: "No Bandcamp result matched the requested track.",
+        providerId: "bandcamp",
+        providerName: "Bandcamp"
+      });
+    },
+    acquire: async ({ candidate, track }) => {
+      if (track.title !== "Escape") {
+        return buildFixtureSearchMiss({
+          detail: "Fixture acquisition only covers the Escape fallback track.",
+          providerId: "bandcamp",
+          providerName: "Bandcamp"
+        });
+      }
+
+      return {
+        outcome: "acquired" as const,
+        artifact: writeFixtureArtifact({
+          contents: "fixture escape payload\n",
+          fileName: "kx5-escape.mp3",
+          workspaceRoot
+        }),
+        candidate
+      };
+    }
+  });
+
+  const beatportProvider = defineReviewQueueProvider({
+    id: "beatport",
+    displayName: "Beatport",
+    authorizationBasis: "purchase-entitlement",
+    priorityRank: 90,
+    supportedFormats: ["mp3", "wav", "aiff"],
+    search: async ({ track }) => {
+      if (
+        (track.primaryArtist === "DJ Sealer" &&
+          track.title === "Warehouse Tool" &&
+          track.mix.displayLabel === "Extended Mix") ||
+        (track.primaryArtist === "Selector Two" && track.title === "Loft Shaker")
+      ) {
+        return {
+          outcome: "candidates" as const,
+          candidates: [
+            buildFixtureCandidate({
+              authorizationBasis: "purchase-entitlement",
+              availableFormats: ["mp3", "wav"],
+              candidateId: `beatport-${track.normalizedTitle}`,
+              durationSeconds: track.durationSeconds ?? 301,
+              priceTier: "paid",
+              providerId: "beatport",
+              providerName: "Beatport",
+              providerUrl: `https://www.beatport.com/track/${track.normalizedTitle.replace(/\s+/g, "-")}/queue`,
+              track
+            })
+          ]
+        };
+      }
+
+      return buildFixtureSearchMiss({
+        detail: "No Beatport review candidate matched this fixture track.",
+        providerId: "beatport",
+        providerName: "Beatport"
+      });
+    },
+    queueForReview: async ({ candidate }) => ({
+      outcome: "queued-for-review" as const,
+      candidate,
+      review: {
+        queueName: "beatport-review",
+        summary: "Queued after all automatic free-source providers missed."
+      }
+    })
+  });
+
+  return new ProviderRegistry([
+    soundCloudProvider,
+    bandcampProvider,
+    beatportProvider
+  ]);
 }
 
 export async function seedE2eScenario(
@@ -161,19 +366,7 @@ async function seedSpotifyHappyPath(input: {
     playlistUrl: SPOTIFY_HAPPY_PATH_URL,
     sourceType: "spotify"
   });
-  const tracks = input.runStore.replaceRunTracks(run.id, [
-    {
-      artist: "Anyma",
-      sourcePosition: 1,
-      title: "Consciousness",
-      version: "Extended Mix"
-    },
-    {
-      artist: "Kx5",
-      sourcePosition: 2,
-      title: "Escape"
-    }
-  ]);
+  const tracks = input.runStore.replaceRunTracks(run.id, buildSpotifyHappyPathTracks());
 
   input.runStore.transitionRunStatus(run.id, "ingesting");
   input.runStore.transitionRunStatus(run.id, "matching");
@@ -330,6 +523,38 @@ function seedSoundCloudMissHeavy(input: { runStore: RunStore }) {
   return requireRun(input.runStore, run.id);
 }
 
+function buildSpotifyHappyPathTracks(): ReplaceRunTrackInput[] {
+  return [
+    {
+      artist: "Anyma",
+      sourcePosition: 1,
+      title: "Consciousness",
+      version: "Extended Mix"
+    },
+    {
+      artist: "Kx5",
+      sourcePosition: 2,
+      title: "Escape"
+    }
+  ];
+}
+
+function buildSoundCloudReviewLaneTracks(): ReplaceRunTrackInput[] {
+  return [
+    {
+      artist: "DJ Sealer",
+      sourcePosition: 1,
+      title: "Warehouse Tool",
+      version: "Extended Mix"
+    },
+    {
+      artist: "Selector Two",
+      sourcePosition: 2,
+      title: "Loft Shaker"
+    }
+  ];
+}
+
 function seedResumeMatching(input: { runStore: RunStore }) {
   const run = input.runStore.createRun({
     playlistTitle: "Resume Matching Fixture",
@@ -366,6 +591,58 @@ function requireRun(runStore: RunStore, runId: string): RunDetail {
   }
 
   return run;
+}
+
+function buildFixtureCandidate(input: {
+  authorizationBasis: ProviderAuthorizationBasis;
+  availableFormats: readonly ProviderArtifactFormat[];
+  candidateId: string;
+  durationSeconds: number;
+  priceTier: ProviderPriceTier;
+  providerId: string;
+  providerName: string;
+  providerUrl: string;
+  track: CanonicalTrack;
+}): ProviderCandidate {
+  return {
+    artistName: input.track.primaryArtist ?? "Unknown Artist",
+    authorizationBasis: input.authorizationBasis,
+    availableFormats: input.availableFormats,
+    candidateId: input.candidateId,
+    durationSeconds: input.durationSeconds,
+    mixConfidence: input.track.mix.confidence,
+    mixLabel: input.track.mix.displayLabel,
+    priceTier: input.priceTier,
+    providerId: input.providerId,
+    providerName: input.providerName,
+    provenance: {
+      discoveredVia: "search",
+      providerTrackId: input.candidateId,
+      providerUrl: input.providerUrl,
+      searchQuery: [
+        input.track.primaryArtist,
+        input.track.title,
+        input.track.mix.displayLabel
+      ]
+        .filter(Boolean)
+        .join(" ")
+    },
+    title: input.track.title
+  };
+}
+
+function buildFixtureSearchMiss(input: {
+  detail: string;
+  providerId: string;
+  providerName: string;
+}) {
+  return buildProviderMissResult({
+    detail: input.detail,
+    providerId: input.providerId,
+    providerName: input.providerName,
+    reason: "no-search-results",
+    trackMissReason: "no-authorized-source-match"
+  });
 }
 
 function writeFixtureArtifact(input: {

--- a/src/features/home/home-screen.test.tsx
+++ b/src/features/home/home-screen.test.tsx
@@ -17,7 +17,14 @@ describe("HomeScreen", () => {
     expect(screen.getByText(/downloads\.zip/i)).toBeVisible();
     expect(screen.getAllByText(/no runs yet/i)).toHaveLength(2);
     expect(
-      screen.getByText(/sqlite persistence is active for new acquisition jobs/i)
+      screen.getByText(
+        /let the local orchestrator ingest tracks, match authorized sources, package artifacts, and open beatport review/i
+      )
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        /playwright fixture mode keeps end-to-end verification deterministic\. live operator runs still need spotify and soundcloud credentials configured before intake starts/i
+      )
     ).toBeVisible();
   });
 

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -172,8 +172,9 @@ export function HomeScreen({ initialRuns = [] }: HomeScreenProps) {
           <p className="hero-kicker">Local operator shell</p>
           <h1>Authorized-source acquisition</h1>
           <p className="hero-copy">
-            Intake one Spotify or SoundCloud playlist URL, then hand the
-            background job, matching, and artifact work off to later tasks.
+            Queue one Spotify or SoundCloud playlist and let the local
+            orchestrator ingest tracks, match authorized sources, package
+            artifacts, and open Beatport review when paid fallback is required.
           </p>
         </div>
         <div className="hero-sidecar">
@@ -183,8 +184,9 @@ export function HomeScreen({ initialRuns = [] }: HomeScreenProps) {
               : "No runs yet"}
           </StatusBadge>
           <p className="hero-note">
-            Queue authorized playlist runs into the local SQLite job store.
-            Acquisition, matching, and packaging workers land in later tasks.
+            Playwright fixture mode keeps end-to-end verification deterministic.
+            Live operator runs still need Spotify and SoundCloud credentials
+            configured before intake starts.
           </p>
         </div>
       </header>
@@ -193,7 +195,9 @@ export function HomeScreen({ initialRuns = [] }: HomeScreenProps) {
         <Panel
           eyebrow="Intake"
           title="Playlist Intake"
-          footer={<span className="panel-caption">Creates queued run records</span>}
+          footer={
+            <span className="panel-caption">Starts the live orchestration path</span>
+          }
         >
           <form className="panel-form" onSubmit={handleSubmit}>
             <label className="field" htmlFor="playlist-url">
@@ -218,8 +222,8 @@ export function HomeScreen({ initialRuns = [] }: HomeScreenProps) {
                 {isSubmitting ? "Queueing..." : "Queue Playlist"}
               </button>
               <p className="field-hint">
-                Creates a queued local run record and exposes status polling for
-                later background work.
+                Submits the playlist into intake, matching, acquisition,
+                packaging, and Beatport review queueing.
               </p>
             </div>
 

--- a/src/features/ingestion/playlist-intake.ts
+++ b/src/features/ingestion/playlist-intake.ts
@@ -1,3 +1,4 @@
+import { resolveE2eFixturePlaylistSnapshot } from "@/features/e2e/e2e-fixtures";
 import { getRunStore, type RunDetail, type RunStore } from "@/features/runs/run-store";
 
 import { PlaylistIntakeError } from "./playlist-intake-error";
@@ -42,8 +43,10 @@ export async function createRunFromPlaylistUrl(
   }
 
   const runStore = dependencies.runStore ?? getRunStore();
+  const fixtureSnapshot = resolveE2eFixturePlaylistSnapshot(playlistUrl);
   const snapshot =
-    sourceType === "spotify"
+    fixtureSnapshot ??
+    (sourceType === "spotify"
       ? await (
           dependencies.fetchSpotifyPlaylistSnapshot ??
           fetchSpotifyPlaylistSnapshot
@@ -51,7 +54,7 @@ export async function createRunFromPlaylistUrl(
       : await (
           dependencies.fetchSoundCloudPlaylistSnapshot ??
           fetchSoundCloudPlaylistSnapshot
-        )(playlistUrl);
+        )(playlistUrl));
   const run = runStore.createRun({
     playlistTitle: snapshot.playlistTitle,
     playlistUrl: snapshot.playlistUrl,

--- a/src/features/providers/live-provider-registry.ts
+++ b/src/features/providers/live-provider-registry.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import { BrowserSessionService } from "@/features/browser/browser-session-service";
+import { createE2eFixtureProviderRegistry } from "@/features/e2e/e2e-fixtures";
 
 import { createBandcampProvider } from "./bandcamp";
 import { createBeatportProvider } from "./beatport";
@@ -14,6 +15,14 @@ type CreateLiveProviderRegistryOptions = {
 export function createLiveProviderRegistry(
   options: CreateLiveProviderRegistryOptions = {}
 ) {
+  const fixtureRegistry = createE2eFixtureProviderRegistry({
+    workspaceRoot: options.workspaceRoot
+  });
+
+  if (fixtureRegistry) {
+    return fixtureRegistry;
+  }
+
   const browserSessionService = new BrowserSessionService({
     workspaceRoot: resolveWorkspaceRoot(options.workspaceRoot)
   });

--- a/src/features/runs/live-run-orchestrator.test.ts
+++ b/src/features/runs/live-run-orchestrator.test.ts
@@ -556,6 +556,90 @@ describe("submitLiveRunFromPlaylistUrl", () => {
     }
   });
 
+  it("resolves the Spotify happy-path fixture through the live orchestration path when e2e fixture mode is enabled", async () => {
+    const tempWorkspace = createTempWorkspace();
+    const runStore = createRunStore({ databasePath: tempWorkspace.databasePath });
+    const originalFixtureMode = process.env.MUSIC_DOWNLOADER_E2E_FIXTURES;
+
+    process.env.MUSIC_DOWNLOADER_E2E_FIXTURES = "1";
+
+    try {
+      const run = await submitLiveRunFromPlaylistUrl(
+        "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+        {
+          runStore,
+          workspaceRoot: tempWorkspace.workspaceRoot
+        }
+      );
+
+      expect(run.playlistTitle).toBe("Warehouse Starters");
+      expect(run.status).toBe("completed");
+      expect(run.tracks.map((track) => [track.sourcePosition, track.status])).toEqual([
+        [1, "acquired"],
+        [2, "acquired"]
+      ]);
+      expect([...run.artifacts.map((artifact) => artifact.kind)].sort()).toEqual([
+        "downloads-zip",
+        "manifest-json",
+        "misses-txt"
+      ]);
+    } finally {
+      if (originalFixtureMode === undefined) {
+        delete process.env.MUSIC_DOWNLOADER_E2E_FIXTURES;
+      } else {
+        process.env.MUSIC_DOWNLOADER_E2E_FIXTURES = originalFixtureMode;
+      }
+
+      runStore.close();
+      tempWorkspace.cleanup();
+    }
+  });
+
+  it("resolves the SoundCloud review-lane fixture through the live orchestration path when e2e fixture mode is enabled", async () => {
+    const tempWorkspace = createTempWorkspace();
+    const runStore = createRunStore({ databasePath: tempWorkspace.databasePath });
+    const originalFixtureMode = process.env.MUSIC_DOWNLOADER_E2E_FIXTURES;
+
+    process.env.MUSIC_DOWNLOADER_E2E_FIXTURES = "1";
+
+    try {
+      const run = await submitLiveRunFromPlaylistUrl(
+        "https://soundcloud.com/dj-nova/sets/warehouse-finds",
+        {
+          runStore,
+          workspaceRoot: tempWorkspace.workspaceRoot
+        }
+      );
+
+      expect(run.playlistTitle).toBe("Warehouse Finds");
+      expect(run.status).toBe("awaiting-approval");
+      expect(run.artifacts).toEqual([]);
+      expect(run.tracks.map((track) => [track.sourcePosition, track.status])).toEqual([
+        [1, "awaiting-approval"],
+        [2, "awaiting-approval"]
+      ]);
+      expect(
+        run.reviewQueue.map((review) => [
+          review.candidateId,
+          review.queueName,
+          review.status
+        ])
+      ).toEqual([
+        ["beatport-warehouse tool", "beatport-review", "queued"],
+        ["beatport-loft shaker", "beatport-review", "queued"]
+      ]);
+    } finally {
+      if (originalFixtureMode === undefined) {
+        delete process.env.MUSIC_DOWNLOADER_E2E_FIXTURES;
+      } else {
+        process.env.MUSIC_DOWNLOADER_E2E_FIXTURES = originalFixtureMode;
+      }
+
+      runStore.close();
+      tempWorkspace.cleanup();
+    }
+  });
+
   it("marks the run failed when automatic providers end with a retryable provider rejection", async () => {
     const tempWorkspace = createTempWorkspace();
     const runStore = createRunStore({ databasePath: tempWorkspace.databasePath });

--- a/tests/e2e/integrated-flow.spec.ts
+++ b/tests/e2e/integrated-flow.spec.ts
@@ -33,7 +33,7 @@ test.beforeEach(async ({ request }) => {
   await resetHarness(request);
 });
 
-test("submits a deterministic fixture playlist and exposes completed artifacts in the run report", async ({
+test("submits a deterministic fixture-mode playlist through the live orchestration path and exposes completed artifacts", async ({
   page
 }) => {
   await page.goto("/");
@@ -73,7 +73,7 @@ test("submits a deterministic fixture playlist and exposes completed artifacts i
   });
 });
 
-test("covers a miss-heavy report with Beatport review visibility via deterministic fixtures", async ({
+test("covers a Beatport review-lane run via deterministic fixture mode through the live orchestration path", async ({
   page
 }) => {
   await page.goto("/");
@@ -98,7 +98,7 @@ test("covers a miss-heavy report with Beatport review visibility via determinist
       name: /approve beatport candidate for dj sealer - warehouse tool/i
     })
   ).toBeVisible();
-  await expect(page.getByText(/paid-review-rejected/i)).toBeVisible();
+  await expect(page.getByText(/awaiting operator review/i).first()).toBeVisible();
 });
 
 test("shows persisted resume metadata after the run store is restarted", async ({


### PR DESCRIPTION
**@worker-01**

## Summary
- remove the /api/runs fixture submission short-circuit and keep fixture mode inside the shared intake/provider seams
- drive deterministic Spotify and Beatport review-lane coverage through the live orchestrator path
- refresh home-screen and README copy so shipped behavior and live-vs-fixture requirements are described accurately

## Verification
- npm run test
- npm run lint
- npm run test:e2e
- npm run build

Closes #72
