### PR TITLE
Fix PR #2 so terminal runs finalize artifacts after mixed misses and closed Beatport reviews

### DIFF
--- a/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
+++ b/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
@@ -1,33 +1,35 @@
 /* @vitest-environment node */
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 
-async function withTempDatabase(
-  callback: (databasePath: string) => Promise<void> | void
+async function withTempWorkspace(
+  callback: (workspaceRoot: string) => Promise<void> | void
 ) {
   const tempDirectory = mkdtempSync(
     path.join(tmpdir(), "music-downloader-review-route-")
   );
-  const databasePath = path.join(tempDirectory, "music-downloader.sqlite");
+  const databasePath = path.join(tempDirectory, "data", "music-downloader.sqlite");
 
   process.env.MUSIC_DOWNLOADER_DB_PATH = databasePath;
+  process.env.MUSIC_DOWNLOADER_WORKSPACE_ROOT = tempDirectory;
 
   try {
-    await callback(databasePath);
+    await callback(tempDirectory);
   } finally {
     const runStoreModule = await import("@/features/runs/run-store");
 
     runStoreModule.resetRunStoreForTests();
     delete process.env.MUSIC_DOWNLOADER_DB_PATH;
+    delete process.env.MUSIC_DOWNLOADER_WORKSPACE_ROOT;
     rmSync(tempDirectory, { force: true, recursive: true });
   }
 }
 
 describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
   it("persists approve reject and purchased review actions", async () => {
-    await withTempDatabase(async () => {
+    await withTempWorkspace(async () => {
       vi.resetModules();
 
       const [{ POST }, runStoreModule] = await Promise.all([
@@ -173,6 +175,125 @@ describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
         [1, "awaiting-approval"],
         [2, "missed"]
       ]);
+    });
+  });
+
+  it("finalizes the run when the last remaining review candidate is rejected", async () => {
+    await withTempWorkspace(async (workspaceRoot) => {
+      vi.resetModules();
+
+      const [{ POST }, runStoreModule, artifactsModule] = await Promise.all([
+        import("./route"),
+        import("@/features/runs/run-store"),
+        import("@/features/artifacts/run-artifacts")
+      ]);
+      const store = runStoreModule.getRunStore();
+      const run = store.createRun({
+        playlistTitle: "Beatport Final Reject",
+        playlistUrl: "https://soundcloud.com/sets/beatport-final-reject",
+        sourceType: "soundcloud"
+      });
+      const [track] = store.replaceRunTracks(run.id, [
+        {
+          artist: "Artist One",
+          sourcePosition: 1,
+          title: "Track One"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+
+      const review = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3", "wav"],
+        candidateId: "beatport-final-reject-1",
+        mixLabel: "Original Mix",
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/track-one/final-reject-1",
+        queueName: "beatport-review",
+        runTrackId: track.id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+
+      const rejectResponse = await POST(
+        new Request(`http://localhost/api/runs/${run.id}/review-queue/${review.id}`, {
+          body: JSON.stringify({ action: "reject" }),
+          headers: {
+            "content-type": "application/json"
+          },
+          method: "POST"
+        }),
+        {
+          params: Promise.resolve({
+            reviewId: review.id,
+            runId: run.id
+          })
+        }
+      );
+
+      expect(rejectResponse.status).toBe(200);
+      await expect(rejectResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          id: review.id,
+          status: "rejected"
+        })
+      );
+
+      const persistedRun = store.getRun(run.id);
+
+      expect(persistedRun).toEqual(
+        expect.objectContaining({
+          id: run.id,
+          status: "completed"
+        })
+      );
+      expect(
+        persistedRun?.reviewQueue.map((candidate) => [candidate.candidateId, candidate.status])
+      ).toEqual([["beatport-final-reject-1", "rejected"]]);
+      expect(
+        persistedRun?.tracks.map((candidate) => [candidate.sourcePosition, candidate.status])
+      ).toEqual([[1, "missed"]]);
+      expect([...((persistedRun?.artifacts ?? []).map((artifact) => artifact.kind))].sort()).toEqual([
+        "downloads-zip",
+        "manifest-json",
+        "misses-txt"
+      ]);
+      expect(
+        artifactsModule
+          .listRunArtifactDownloads({
+            runId: run.id,
+            runStore: store
+          })
+          .map((artifact) => artifact.kind)
+      ).toEqual(["downloads-zip", "misses-txt", "manifest-json"]);
+
+      const manifestArtifact = persistedRun?.artifacts.find(
+        (artifact) => artifact.kind === "manifest-json"
+      );
+
+      expect(manifestArtifact).toBeDefined();
+
+      const manifest = JSON.parse(
+        readFileSync(
+          path.join(workspaceRoot, manifestArtifact?.relativePath ?? ""),
+          "utf8"
+        )
+      ) as {
+        summary: {
+          acquiredCount: number;
+          missCount: number;
+          trackCount: number;
+        };
+      };
+
+      expect(manifest.summary).toEqual({
+        acquiredCount: 0,
+        missCount: 1,
+        trackCount: 1
+      });
     });
   });
 });

--- a/src/app/api/runs/[runId]/review-queue/[reviewId]/route.ts
+++ b/src/app/api/runs/[runId]/review-queue/[reviewId]/route.ts
@@ -4,6 +4,7 @@ import {
   getRunStore,
   type RunTrackReviewStatus
 } from "@/features/runs/run-store";
+import { finalizeTerminalRun } from "@/features/runs/run-finalization";
 
 type RouteContext = {
   params: Promise<{
@@ -47,9 +48,11 @@ export async function POST(request: Request, context: RouteContext) {
   }
 
   try {
-    return NextResponse.json(
-      runStore.transitionRunTrackReviewStatus(reviewId, nextStatus)
-    );
+    const updatedReview = runStore.transitionRunTrackReviewStatus(reviewId, nextStatus);
+
+    await finalizeTerminalRun(runId, { runStore });
+
+    return NextResponse.json(updatedReview);
   } catch (error) {
     return NextResponse.json(
       {

--- a/src/features/runs/live-run-orchestrator.test.ts
+++ b/src/features/runs/live-run-orchestrator.test.ts
@@ -273,7 +273,7 @@ describe("submitLiveRunFromPlaylistUrl", () => {
     }
   });
 
-  it("persists unresolved automatic misses without falsely completing or packaging the run", async () => {
+  it("packages mixed acquired and missed runs once every track reaches a terminal status", async () => {
     const tempWorkspace = createTempWorkspace();
     const runStore = createRunStore({ databasePath: tempWorkspace.databasePath });
 
@@ -380,13 +380,18 @@ describe("submitLiveRunFromPlaylistUrl", () => {
         }
       );
 
-      expect(run.status).toBe("matching");
-      expect(run.artifacts).toEqual([]);
+      expect(run.status).toBe("completed");
+      expect([...run.artifacts.map((artifact) => artifact.kind)].sort()).toEqual([
+        "downloads-zip",
+        "manifest-json",
+        "misses-txt"
+      ]);
       expect(run.tracks.map((track) => [track.sourcePosition, track.status])).toEqual([
         [1, "acquired"],
         [2, "missed"]
       ]);
 
+      const persistedRun = runStore.getRun(run.id);
       const attempts = runStore.listRunTrackAttempts(run.id);
       const latestMissAttempt = attempts.find(
         (attempt) => attempt.providerKey === "track-matcher"
@@ -405,6 +410,31 @@ describe("submitLiveRunFromPlaylistUrl", () => {
           })
         })
       );
+
+      const manifestArtifact = persistedRun?.artifacts.find(
+        (artifact) => artifact.kind === "manifest-json"
+      );
+
+      expect(manifestArtifact).toBeDefined();
+
+      const manifest = JSON.parse(
+        readFileSync(
+          path.join(tempWorkspace.workspaceRoot, manifestArtifact?.relativePath ?? ""),
+          "utf8"
+        )
+      ) as {
+        summary: {
+          acquiredCount: number;
+          missCount: number;
+          trackCount: number;
+        };
+      };
+
+      expect(manifest.summary).toEqual({
+        acquiredCount: 1,
+        missCount: 1,
+        trackCount: 2
+      });
     } finally {
       runStore.close();
       tempWorkspace.cleanup();

--- a/src/features/runs/live-run-orchestrator.ts
+++ b/src/features/runs/live-run-orchestrator.ts
@@ -1,7 +1,6 @@
 import {
   buildAcquiredArtifactSourceNote,
-  buildMissedArtifactSourceNote,
-  generateRunArtifacts
+  buildMissedArtifactSourceNote
 } from "@/features/artifacts/run-artifacts";
 import {
   matchTrackCandidates,
@@ -21,6 +20,7 @@ import {
   type RunTrack
 } from "@/features/runs/run-store";
 import { canonicalizeTrack } from "@/features/tracks/canonical-track";
+import { finalizeTerminalRun } from "./run-finalization";
 
 import { createRunFromPlaylistUrl } from "../ingestion/playlist-intake";
 
@@ -68,18 +68,10 @@ export async function submitLiveRunFromPlaylistUrl(
       return runStore.transitionRunStatus(runId, "failed");
     }
 
-    if (resolvedRun.tracks.every((track) => track.status === "acquired")) {
-      runStore.transitionRunStatus(runId, "packaging");
-      await generateRunArtifacts({
-        runId,
-        runStore,
-        workspaceRoot: dependencies.workspaceRoot
-      });
-
-      return runStore.transitionRunStatus(runId, "completed");
-    }
-
-    return resolvedRun;
+    return finalizeTerminalRun(runId, {
+      runStore,
+      workspaceRoot: dependencies.workspaceRoot
+    });
   } catch (error) {
     if (runId) {
       failRunIfPossible(runStore, runId);

--- a/src/features/runs/run-finalization.ts
+++ b/src/features/runs/run-finalization.ts
@@ -1,0 +1,63 @@
+import { generateRunArtifacts } from "@/features/artifacts/run-artifacts";
+
+import {
+  getRunStore,
+  type RunDetail,
+  type RunStatus,
+  type RunStore,
+  type RunTrackStatus
+} from "./run-store";
+
+type FinalizeTerminalRunDependencies = {
+  runStore?: RunStore;
+  workspaceRoot?: string;
+};
+
+const finalizableRunStatuses = new Set<RunStatus>([
+  "matching",
+  "awaiting-approval",
+  "packaging"
+]);
+const terminalTrackStatuses = new Set<RunTrackStatus>(["acquired", "missed"]);
+
+export async function finalizeTerminalRun(
+  runId: string,
+  dependencies: FinalizeTerminalRunDependencies = {}
+): Promise<RunDetail> {
+  const runStore = dependencies.runStore ?? getRunStore();
+  const run = requireRun(runStore, runId);
+
+  if (run.status === "completed" || run.status === "failed") {
+    return run;
+  }
+
+  if (!finalizableRunStatuses.has(run.status)) {
+    return run;
+  }
+
+  if (run.tracks.some((track) => !terminalTrackStatuses.has(track.status))) {
+    return run;
+  }
+
+  if (run.status !== "packaging") {
+    runStore.transitionRunStatus(runId, "packaging");
+  }
+
+  await generateRunArtifacts({
+    runId,
+    runStore,
+    workspaceRoot: dependencies.workspaceRoot
+  });
+
+  return runStore.transitionRunStatus(runId, "completed");
+}
+
+function requireRun(runStore: RunStore, runId: string) {
+  const run = runStore.getRun(runId);
+
+  if (!run) {
+    throw new Error(`Run not found: ${runId}`);
+  }
+
+  return run;
+}


### PR DESCRIPTION
**@worker-03**

## Summary
- add a shared terminal-run finalization helper under `src/features/runs/`
- reuse it in the live orchestrator so mixed `acquired`/`missed` runs package artifacts and transition to `completed`
- reuse it in the Beatport review action route so rejecting the last remaining review candidate packages artifacts and completes the run
- extend regression coverage for both paths and confirm artifact downloads stay available through the existing surfaces

## Verification
- `npm test`
- `npm run lint`
- `npm run build`

Refs #79
