### PR TITLE
fix: queue live runs through local background worker

### DIFF
--- a/src/app/api/runs/route.test.ts
+++ b/src/app/api/runs/route.test.ts
@@ -26,37 +26,45 @@ async function withTempDatabase(
 afterEach(() => {
   vi.doUnmock("@/features/e2e/e2e-fixtures");
   vi.doUnmock("@/features/runs/live-run-orchestrator");
+  vi.doUnmock("@/features/runs/run-worker");
   vi.resetModules();
 });
 
 describe("/api/runs", () => {
-  it("submits runs through the shared live orchestrator without route-level fixture bypasses", async () => {
+  it("persists queued runs and schedules shared background execution without awaiting it", async () => {
     await withTempDatabase(async (databasePath) => {
       vi.resetModules();
 
       const playlistUrl = "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9";
-      const createdRun = {
-        artifactCount: 3,
-        artifacts: [],
-        createdAt: "2026-03-31T21:00:00.000Z",
-        id: "run-live-pipeline",
-        playlistTitle: "Warehouse Starters",
-        playlistUrl,
-        resumeAfterStatus: null,
-        reviewQueue: [],
-        sourceType: "spotify",
-        status: "completed",
-        trackCount: 2,
-        tracks: [],
-        updatedAt: "2026-03-31T21:05:00.000Z"
-      };
-      const submitLiveRunFromPlaylistUrl = vi.fn().mockResolvedValue(createdRun);
+      const scheduleRun = vi.fn().mockImplementation(
+        () => new Promise<void>(() => undefined)
+      );
+      let createdRunId: string | null = null;
 
       vi.doMock("@/features/e2e/e2e-fixtures", () => {
         throw new Error("route should not import e2e fixture submission bypasses");
       });
-      vi.doMock("@/features/runs/live-run-orchestrator", () => ({
-        submitLiveRunFromPlaylistUrl
+      vi.doMock("@/features/runs/live-run-orchestrator", async () => {
+        const runStoreModule = await import("@/features/runs/run-store");
+
+        return {
+          queueLiveRunFromPlaylistUrl: vi.fn(async (requestedPlaylistUrl: string) => {
+            const createdRun = runStoreModule.getRunStore().createRun({
+              playlistTitle: "Warehouse Starters",
+              playlistUrl: requestedPlaylistUrl,
+              sourceType: "spotify"
+            });
+
+            createdRunId = createdRun.id;
+
+            return createdRun;
+          })
+        };
+      });
+      vi.doMock("@/features/runs/run-worker", () => ({
+        getSharedRunWorker: () => ({
+          scheduleRun
+        })
       }));
 
       const { POST } = await import("./route");
@@ -72,9 +80,28 @@ describe("/api/runs", () => {
       );
 
       expect(createResponse.status).toBe(201);
-      expect(existsSync(databasePath)).toBe(false);
-      expect(submitLiveRunFromPlaylistUrl).toHaveBeenCalledWith(playlistUrl);
-      await expect(createResponse.json()).resolves.toEqual(createdRun);
+      expect(existsSync(databasePath)).toBe(true);
+      expect(createdRunId).not.toBeNull();
+      expect(scheduleRun).toHaveBeenCalledWith(createdRunId);
+
+      await expect(createResponse.json()).resolves.toEqual(
+        expect.objectContaining({
+          id: createdRunId,
+          playlistTitle: "Warehouse Starters",
+          playlistUrl,
+          sourceType: "spotify",
+          status: "queued"
+        })
+      );
+
+      const { getRunStore } = await import("@/features/runs/run-store");
+
+      expect(getRunStore().getRun(createdRunId ?? "")).toEqual(
+        expect.objectContaining({
+          id: createdRunId,
+          status: "queued"
+        })
+      );
     });
   });
 
@@ -230,30 +257,36 @@ describe("/api/runs", () => {
     });
   });
 
-  it("delegates non-fixture submissions to the shared live-run orchestrator", async () => {
+  it("delegates non-fixture submissions to queued intake and the shared worker", async () => {
     await withTempDatabase(async () => {
       vi.resetModules();
 
       const playlistUrl = "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9";
       const createdRun = {
-        artifactCount: 3,
+        artifactCount: 0,
         artifacts: [],
         createdAt: "2026-03-31T21:00:00.000Z",
-        id: "run-live-pipeline",
+        id: "run-live-queue",
         playlistTitle: "Warehouse Starters",
         playlistUrl,
         resumeAfterStatus: null,
         reviewQueue: [],
         sourceType: "spotify",
-        status: "completed",
+        status: "queued",
         trackCount: 2,
         tracks: [],
-        updatedAt: "2026-03-31T21:05:00.000Z"
+        updatedAt: "2026-03-31T21:00:00.000Z"
       };
-      const submitLiveRunFromPlaylistUrl = vi.fn().mockResolvedValue(createdRun);
+      const queueLiveRunFromPlaylistUrl = vi.fn().mockResolvedValue(createdRun);
+      const scheduleRun = vi.fn().mockResolvedValue(undefined);
 
       vi.doMock("@/features/runs/live-run-orchestrator", () => ({
-        submitLiveRunFromPlaylistUrl
+        queueLiveRunFromPlaylistUrl
+      }));
+      vi.doMock("@/features/runs/run-worker", () => ({
+        getSharedRunWorker: () => ({
+          scheduleRun
+        })
       }));
 
       const { POST } = await import("./route");
@@ -269,7 +302,8 @@ describe("/api/runs", () => {
       );
 
       expect(response.status).toBe(201);
-      expect(submitLiveRunFromPlaylistUrl).toHaveBeenCalledWith(playlistUrl);
+      expect(queueLiveRunFromPlaylistUrl).toHaveBeenCalledWith(playlistUrl);
+      expect(scheduleRun).toHaveBeenCalledWith(createdRun.id);
       await expect(response.json()).resolves.toEqual(createdRun);
     });
   });

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 
 import { PlaylistIntakeError } from "@/features/ingestion/playlist-intake-error";
 import { getRunStore } from "@/features/runs/run-store";
-import { submitLiveRunFromPlaylistUrl } from "@/features/runs/live-run-orchestrator";
+import { queueLiveRunFromPlaylistUrl } from "@/features/runs/live-run-orchestrator";
+import { getSharedRunWorker } from "@/features/runs/run-worker";
 
 export async function GET() {
   return NextResponse.json(getRunStore().listRuns());
@@ -22,9 +23,11 @@ export async function POST(request: Request) {
   }
 
   try {
-    return NextResponse.json(await submitLiveRunFromPlaylistUrl(playlistUrl), {
-      status: 201
-    });
+    const run = await queueLiveRunFromPlaylistUrl(playlistUrl);
+
+    void getSharedRunWorker().scheduleRun(run.id);
+
+    return NextResponse.json(run, { status: 201 });
   } catch (error) {
     if (error instanceof PlaylistIntakeError) {
       return NextResponse.json(

--- a/src/features/runs/live-run-orchestrator.ts
+++ b/src/features/runs/live-run-orchestrator.ts
@@ -31,23 +31,44 @@ type SubmitLiveRunDependencies = {
   workspaceRoot?: string;
 };
 
-export async function submitLiveRunFromPlaylistUrl(
+type QueueLiveRunDependencies = Pick<
+  SubmitLiveRunDependencies,
+  "createRunFromPlaylistUrl" | "runStore"
+>;
+
+type ExecuteQueuedRunDependencies = Pick<
+  SubmitLiveRunDependencies,
+  "providerRegistry" | "runStore" | "workspaceRoot"
+>;
+
+export async function queueLiveRunFromPlaylistUrl(
   playlistUrl: string,
-  dependencies: SubmitLiveRunDependencies = {}
+  dependencies: QueueLiveRunDependencies = {}
 ): Promise<RunDetail> {
   const runStore = dependencies.runStore ?? getRunStore();
+
+  return (dependencies.createRunFromPlaylistUrl ?? createRunFromPlaylistUrl)(
+    playlistUrl,
+    { runStore }
+  );
+}
+
+export async function executeQueuedRun(
+  runId: string,
+  dependencies: ExecuteQueuedRunDependencies = {}
+): Promise<RunDetail> {
+  const runStore = dependencies.runStore ?? getRunStore();
+  const queuedRun = requireRun(runStore, runId);
+
+  if (queuedRun.status !== "queued" || queuedRun.resumeAfterStatus) {
+    return queuedRun;
+  }
+
   const providerRegistry =
     dependencies.providerRegistry ??
     createLiveProviderRegistry({ workspaceRoot: dependencies.workspaceRoot });
-  let runId: string | null = null;
 
   try {
-    const createdRun = await (
-      dependencies.createRunFromPlaylistUrl ?? createRunFromPlaylistUrl
-    )(playlistUrl, { runStore });
-
-    runId = createdRun.id;
-
     runStore.transitionRunStatus(runId, "ingesting");
     runStore.transitionRunStatus(runId, "matching");
 
@@ -73,12 +94,18 @@ export async function submitLiveRunFromPlaylistUrl(
       workspaceRoot: dependencies.workspaceRoot
     });
   } catch (error) {
-    if (runId) {
-      failRunIfPossible(runStore, runId);
-    }
-
+    failRunIfPossible(runStore, runId);
     throw error;
   }
+}
+
+export async function submitLiveRunFromPlaylistUrl(
+  playlistUrl: string,
+  dependencies: SubmitLiveRunDependencies = {}
+): Promise<RunDetail> {
+  const createdRun = await queueLiveRunFromPlaylistUrl(playlistUrl, dependencies);
+
+  return executeQueuedRun(createdRun.id, dependencies);
 }
 
 async function resolveTrackWithAutomaticProviders(input: {

--- a/src/features/runs/run-worker.test.ts
+++ b/src/features/runs/run-worker.test.ts
@@ -1,0 +1,221 @@
+/* @vitest-environment node */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  defineAutomaticProvider,
+  type AutomaticProviderDefinition,
+  type ProviderCandidate,
+  type ProviderRegistry
+} from "@/features/providers/provider-registry";
+
+import { executeQueuedRun } from "./live-run-orchestrator";
+import { createRunStore, type RunStore, type RunTrack } from "./run-store";
+import { createRunWorker } from "./run-worker";
+
+function createTempWorkspace() {
+  const workspaceRoot = mkdtempSync(path.join(tmpdir(), "music-downloader-run-worker-"));
+  const databasePath = path.join(workspaceRoot, "data", "music-downloader.sqlite");
+
+  return {
+    cleanup() {
+      rmSync(workspaceRoot, { force: true, recursive: true });
+    },
+    databasePath,
+    workspaceRoot
+  };
+}
+
+function createStubRegistry(automaticProviders: AutomaticProviderDefinition[]) {
+  return {
+    listAutomatic: () => automaticProviders,
+    listReviewQueue: () => []
+  } satisfies Pick<ProviderRegistry, "listAutomatic" | "listReviewQueue">;
+}
+
+function createQueuedRun(
+  runStore: RunStore,
+  playlistUrl: string,
+  tracks: Array<{
+    artist: string;
+    sourcePosition: number;
+    title: string;
+    version?: string | null;
+  }>
+) {
+  const run = runStore.createRun({
+    playlistTitle: "Queued Worker Fixture",
+    playlistUrl,
+    sourceType: "spotify"
+  });
+
+  runStore.replaceRunTracks(run.id, tracks);
+
+  return run;
+}
+
+function buildMatchingCandidate(
+  provider: AutomaticProviderDefinition,
+  track: RunTrack
+): ProviderCandidate {
+  return {
+    artistName: track.artist,
+    authorizationBasis: provider.authorizationBasis,
+    availableFormats: ["mp3"],
+    candidateId: `${provider.id}-${track.sourcePosition}`,
+    durationSeconds: track.version ? 392 : 301,
+    mixConfidence: "high",
+    mixLabel: track.version ?? null,
+    priceTier: provider.priceTier,
+    providerId: provider.id,
+    providerName: provider.displayName,
+    provenance: {
+      discoveredVia: "search",
+      providerTrackId: `${provider.id}-${track.sourcePosition}`,
+      providerUrl: `https://example.test/${provider.id}/${track.sourcePosition}`,
+      searchQuery: `${track.artist} ${track.title}`
+    },
+    title: track.title
+  };
+}
+
+describe("createRunWorker", () => {
+  it("drains queued runs through the existing orchestration lifecycle", async () => {
+    const tempWorkspace = createTempWorkspace();
+    const runStore = createRunStore({ databasePath: tempWorkspace.databasePath });
+
+    const bandcampProvider = defineAutomaticProvider({
+      id: "bandcamp",
+      displayName: "Bandcamp",
+      authorizationBasis: "rights-holder-storefront",
+      priceTier: "free-or-owned",
+      priorityRank: 20,
+      supportedFormats: ["mp3", "wav"],
+      search: async ({ track }) => ({
+        outcome: "candidates" as const,
+        candidates: [
+          buildMatchingCandidate(bandcampProvider, {
+            artist: track.primaryArtist ?? "Unknown Artist",
+            createdAt: "",
+            id: `track-${track.title}`,
+            runId: "run",
+            sourcePosition: 1,
+            sourceTrackId: null,
+            status: "queued",
+            title: track.title,
+            updatedAt: "",
+            version: track.mix.displayLabel
+          })
+        ]
+      }),
+      acquire: async ({ candidate, track }) => {
+        const downloadDirectory = path.join(tempWorkspace.workspaceRoot, "downloads");
+        const artifactFileName = `${track.title.toLowerCase().replace(/\s+/g, "-")}.mp3`;
+        const localFilePath = path.join(downloadDirectory, artifactFileName);
+
+        mkdirSync(downloadDirectory, { recursive: true });
+        writeFileSync(localFilePath, `${candidate.providerName}:${track.title}\n`, "utf8");
+
+        return {
+          outcome: "acquired" as const,
+          artifact: {
+            contentType: "audio/mpeg",
+            fileExtension: "mp3",
+            fileName: artifactFileName,
+            format: "mp3",
+            localFilePath,
+            sha256: null,
+            sizeBytes: readFileSync(localFilePath).byteLength
+          },
+          candidate
+        };
+      }
+    });
+
+    try {
+      const queuedRun = createQueuedRun(
+        runStore,
+        "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+        [
+          {
+            artist: "Anyma",
+            sourcePosition: 1,
+            title: "Consciousness",
+            version: "Extended Mix"
+          }
+        ]
+      );
+      const worker = createRunWorker({
+        providerRegistry: createStubRegistry([bandcampProvider]),
+        runStore,
+        workspaceRoot: tempWorkspace.workspaceRoot
+      });
+
+      await worker.scheduleRun(queuedRun.id);
+
+      expect(runStore.getRun(queuedRun.id)).toEqual(
+        expect.objectContaining({
+          artifactCount: 3,
+          status: "completed"
+        })
+      );
+    } finally {
+      runStore.close();
+      tempWorkspace.cleanup();
+    }
+  });
+
+  it("does not double-process the same queued run when scheduling starts more than once", async () => {
+    const tempWorkspace = createTempWorkspace();
+    const runStore = createRunStore({ databasePath: tempWorkspace.databasePath });
+
+    try {
+      const queuedRun = createQueuedRun(
+        runStore,
+        "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+        [
+          {
+            artist: "DJ Sealer",
+            sourcePosition: 1,
+            title: "Warehouse Tool"
+          }
+        ]
+      );
+      let releaseExecution: (() => void) | null = null;
+      const processQueuedRun = vi.fn(async (runId: string) => {
+        runStore.transitionRunStatus(runId, "ingesting");
+
+        await new Promise<void>((resolve) => {
+          releaseExecution = resolve;
+        });
+
+        runStore.transitionRunStatus(runId, "matching");
+        runStore.transitionRunStatus(runId, "failed");
+
+        return runStore.getRun(runId) ?? null;
+      });
+      const worker = createRunWorker({
+        processQueuedRun: processQueuedRun as typeof executeQueuedRun,
+        runStore
+      });
+
+      const firstDrain = worker.scheduleRun(queuedRun.id);
+      const secondDrain = worker.scheduleRun(queuedRun.id);
+
+      await vi.waitFor(() => {
+        expect(processQueuedRun).toHaveBeenCalledTimes(1);
+      });
+
+      releaseExecution?.();
+      await Promise.all([firstDrain, secondDrain]);
+
+      expect(processQueuedRun).toHaveBeenCalledTimes(1);
+      expect(runStore.getRun(queuedRun.id)?.status).toBe("failed");
+    } finally {
+      runStore.close();
+      tempWorkspace.cleanup();
+    }
+  });
+});

--- a/src/features/runs/run-worker.ts
+++ b/src/features/runs/run-worker.ts
@@ -1,0 +1,101 @@
+import type { ProviderRegistry } from "@/features/providers/provider-registry";
+import type { RunStore } from "@/features/runs/run-store";
+
+import { executeQueuedRun } from "@/features/runs/live-run-orchestrator";
+
+type RunWorker = {
+  scheduleRun(runId: string): Promise<void>;
+  waitForIdle(): Promise<void>;
+};
+
+type CreateRunWorkerDependencies = {
+  processQueuedRun?: typeof executeQueuedRun;
+  providerRegistry?: Pick<ProviderRegistry, "listAutomatic" | "listReviewQueue">;
+  runStore?: RunStore;
+  workspaceRoot?: string;
+};
+
+const sharedRunWorkerKey = "__music_downloader_shared_run_worker__" as const;
+
+type GlobalWithRunWorker = typeof globalThis & {
+  [sharedRunWorkerKey]?: RunWorker;
+};
+
+export function createRunWorker(
+  dependencies: CreateRunWorkerDependencies = {}
+): RunWorker {
+  const pendingRunIds = new Set<string>();
+  const activeRunIds = new Set<string>();
+  const processQueuedRun = dependencies.processQueuedRun ?? executeQueuedRun;
+  let drainPromise: Promise<void> | null = null;
+
+  function drainQueue() {
+    if (!drainPromise) {
+      drainPromise = (async () => {
+        try {
+          while (pendingRunIds.size > 0) {
+            const iterator = pendingRunIds.values().next();
+
+            if (iterator.done) {
+              return;
+            }
+
+            const runId = iterator.value;
+
+            pendingRunIds.delete(runId);
+
+            if (activeRunIds.has(runId)) {
+              continue;
+            }
+
+            activeRunIds.add(runId);
+
+            try {
+              await processQueuedRun(runId, dependencies);
+            } catch {
+              continue;
+            } finally {
+              activeRunIds.delete(runId);
+            }
+          }
+        } finally {
+          drainPromise = null;
+        }
+      })();
+    }
+
+    return drainPromise;
+  }
+
+  return {
+    scheduleRun(runId: string) {
+      if (!activeRunIds.has(runId)) {
+        pendingRunIds.add(runId);
+      }
+
+      return drainQueue();
+    },
+
+    async waitForIdle() {
+      while (drainPromise) {
+        await drainPromise;
+      }
+    }
+  };
+}
+
+export function getSharedRunWorker() {
+  const globalWithRunWorker = globalThis as GlobalWithRunWorker;
+
+  if (!globalWithRunWorker[sharedRunWorkerKey]) {
+    globalWithRunWorker[sharedRunWorkerKey] = createRunWorker();
+  }
+
+  return globalWithRunWorker[sharedRunWorkerKey];
+}
+
+export function resetSharedRunWorkerForTests() {
+  const globalWithRunWorker = globalThis as GlobalWithRunWorker;
+
+  delete globalWithRunWorker[sharedRunWorkerKey];
+}


### PR DESCRIPTION
**@worker-01**

## Summary
- queue `POST /api/runs` submissions as persisted `queued` runs instead of awaiting the full orchestration pipeline inline
- add a shared local in-process run worker that drains scheduled queued runs without double-processing the same run in one app instance
- split live orchestration into queued intake plus queued execution, and cover the boundary with route and worker tests

## Verification
- `npm test`
- `npm run lint`
- `npm run build`

Closes #82
