### PR TITLE
fix: preserve authoritative beatport review targets

### DIFF
--- a/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
+++ b/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
@@ -1,6 +1,12 @@
 /* @vitest-environment node */
 
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 
@@ -28,13 +34,51 @@ async function withTempWorkspace(
 }
 
 describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
-  it("persists approve reject and purchased review actions", async () => {
-    await withTempWorkspace(async () => {
+  it("acquires a purchased Beatport review and completes the run through existing artifacts", async () => {
+    await withTempWorkspace(async (workspaceRoot) => {
       vi.resetModules();
+      vi.doMock("@/features/providers/live-provider-registry", () => ({
+        createLiveProviderRegistry: () => ({
+          get(providerId: string) {
+            if (providerId !== "beatport") {
+              return null;
+            }
 
-      const [{ POST }, runStoreModule] = await Promise.all([
+            return {
+              acquirePurchased: async ({ candidate }: { candidate: { candidateId: string } }) => {
+                const artifactDirectory = path.join(workspaceRoot, "downloads");
+                const artifactBody = Buffer.from(
+                  `owned artifact for ${candidate.candidateId}\n`,
+                  "utf8"
+                );
+                const artifactPath = path.join(artifactDirectory, "track-one.mp3");
+
+                mkdirSync(artifactDirectory, { recursive: true });
+                writeFileSync(artifactPath, artifactBody);
+
+                return {
+                  outcome: "acquired" as const,
+                  artifact: {
+                    contentType: "audio/mpeg",
+                    fileExtension: "mp3",
+                    fileName: "track-one.mp3",
+                    format: "mp3" as const,
+                    localFilePath: artifactPath,
+                    sha256: "abc123",
+                    sizeBytes: artifactBody.byteLength
+                  },
+                  candidate
+                };
+              }
+            };
+          }
+        })
+      }));
+
+      const [{ POST }, runStoreModule, artifactsModule] = await Promise.all([
         import("./route"),
-        import("@/features/runs/run-store")
+        import("@/features/runs/run-store"),
+        import("@/features/artifacts/run-artifacts")
       ]);
       const store = runStoreModule.getRunStore();
       const run = store.createRun({
@@ -156,7 +200,7 @@ describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
       expect(store.getRun(run.id)).toEqual(
         expect.objectContaining({
           id: run.id,
-          status: "awaiting-approval"
+          status: "completed"
         })
       );
       expect(
@@ -172,15 +216,153 @@ describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
           .getRun(run.id)
           ?.tracks.map((track) => [track.sourcePosition, track.status])
       ).toEqual([
-        [1, "awaiting-approval"],
+        [1, "acquired"],
         [2, "missed"]
       ]);
+      expect([...((store.getRun(run.id)?.artifacts ?? []).map((artifact) => artifact.kind))].sort()).toEqual([
+        "downloads-zip",
+        "manifest-json",
+        "misses-txt"
+      ]);
+      expect(
+        artifactsModule
+          .listRunArtifactDownloads({
+            runId: run.id,
+            runStore: store
+          })
+          .map((artifact) => artifact.kind)
+      ).toEqual(["downloads-zip", "misses-txt", "manifest-json"]);
+
+      const manifestArtifact = store
+        .getRun(run.id)
+        ?.artifacts.find((artifact) => artifact.kind === "manifest-json");
+
+      expect(manifestArtifact).toBeDefined();
+
+      const manifest = JSON.parse(
+        readFileSync(
+          path.join(workspaceRoot, manifestArtifact?.relativePath ?? ""),
+          "utf8"
+        )
+      ) as {
+        summary: {
+          acquiredCount: number;
+          missCount: number;
+          trackCount: number;
+        };
+      };
+
+      expect(manifest.summary).toEqual({
+        acquiredCount: 1,
+        missCount: 1,
+        trackCount: 2
+      });
+    });
+  });
+
+  it("returns 409 when purchased acquisition fails and leaves the review queued", async () => {
+    await withTempWorkspace(async () => {
+      vi.resetModules();
+      vi.doMock("@/features/providers/live-provider-registry", () => ({
+        createLiveProviderRegistry: () => ({
+          get(providerId: string) {
+            if (providerId !== "beatport") {
+              return null;
+            }
+
+            return {
+              acquirePurchased: async ({ candidate }: { candidate: { candidateId: string } }) => ({
+                outcome: "rejected" as const,
+                candidate,
+                rejection: {
+                  detail:
+                    "The Beatport browser session expired and must be refreshed before owned downloads can be acquired.",
+                  providerId: "beatport",
+                  providerName: "Beatport",
+                  reason: "provider-session-expired" as const,
+                  retryable: true
+                }
+              })
+            };
+          }
+        })
+      }));
+
+      const [{ POST }, runStoreModule] = await Promise.all([
+        import("./route"),
+        import("@/features/runs/run-store")
+      ]);
+      const store = runStoreModule.getRunStore();
+      const run = store.createRun({
+        playlistTitle: "Beatport Purchased Failure",
+        playlistUrl: "https://soundcloud.com/sets/beatport-purchased-failure",
+        sourceType: "soundcloud"
+      });
+      const [track] = store.replaceRunTracks(run.id, [
+        {
+          artist: "Artist One",
+          sourcePosition: 1,
+          title: "Track One"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+
+      const review = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3"],
+        candidateId: "beatport-purchased-failure-1",
+        mixLabel: null,
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/track-one/failure-1",
+        queueName: "beatport-review",
+        runTrackId: track.id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+
+      const purchasedResponse = await POST(
+        new Request(`http://localhost/api/runs/${run.id}/review-queue/${review.id}`, {
+          body: JSON.stringify({ action: "purchased" }),
+          headers: {
+            "content-type": "application/json"
+          },
+          method: "POST"
+        }),
+        {
+          params: Promise.resolve({
+            reviewId: review.id,
+            runId: run.id
+          })
+        }
+      );
+
+      expect(purchasedResponse.status).toBe(409);
+      await expect(purchasedResponse.json()).resolves.toEqual({
+        error:
+          "The Beatport browser session expired and must be refreshed before owned downloads can be acquired."
+      });
+      expect(store.getRun(run.id)).toEqual(
+        expect.objectContaining({
+          id: run.id,
+          status: "awaiting-approval"
+        })
+      );
+      expect(
+        store.getRun(run.id)?.reviewQueue.map((candidate) => [candidate.candidateId, candidate.status])
+      ).toEqual([["beatport-purchased-failure-1", "queued"]]);
+      expect(
+        store.getRun(run.id)?.tracks.map((candidate) => [candidate.sourcePosition, candidate.status])
+      ).toEqual([[1, "awaiting-approval"]]);
     });
   });
 
   it("finalizes the run when the last remaining review candidate is rejected", async () => {
     await withTempWorkspace(async (workspaceRoot) => {
       vi.resetModules();
+      vi.doUnmock("@/features/providers/live-provider-registry");
 
       const [{ POST }, runStoreModule, artifactsModule] = await Promise.all([
         import("./route"),

--- a/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
+++ b/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
@@ -10,6 +10,9 @@ import {
 import path from "node:path";
 import { tmpdir } from "node:os";
 
+import { BrowserSessionService } from "@/features/browser/browser-session-service";
+import { createBeatportProvider } from "@/features/providers/beatport";
+
 async function withTempWorkspace(
   callback: (workspaceRoot: string) => Promise<void> | void
 ) {
@@ -36,6 +39,23 @@ async function withTempWorkspace(
 describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
   it("acquires a purchased Beatport review and completes the run through existing artifacts", async () => {
     await withTempWorkspace(async (workspaceRoot) => {
+      const beatportProvider = createBeatportProvider({
+        baseUrl: "https://catalog.beatport.test",
+        browserSessionService: new BrowserSessionService({ workspaceRoot })
+      });
+      const reviewTarget =
+        "https://catalog.beatport.test/search/tracks?q=Artist%20One%20Track%20One%20Original%20Mix";
+      const searchResult = await beatportProvider.search({
+        track: buildCanonicalTrack({
+          artistName: "Artist One",
+          title: "Track One"
+        })
+      });
+
+      if (searchResult.outcome !== "candidates") {
+        throw new Error("Expected Beatport search to return a candidate.");
+      }
+
       vi.resetModules();
       vi.doMock("@/features/providers/live-provider-registry", () => ({
         createLiveProviderRegistry: () => ({
@@ -45,7 +65,35 @@ describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
             }
 
             return {
-              acquirePurchased: async ({ candidate }: { candidate: { candidateId: string } }) => {
+              acquirePurchased: async ({
+                candidate
+              }: {
+                candidate: {
+                  candidateId: string;
+                  provenance: {
+                    providerTrackId?: string;
+                    providerUrl?: string;
+                  };
+                };
+              }) => {
+                if (
+                  candidate.provenance.providerTrackId !== undefined ||
+                  candidate.provenance.providerUrl !== reviewTarget
+                ) {
+                  return {
+                    outcome: "rejected" as const,
+                    candidate,
+                    rejection: {
+                      detail:
+                        "Purchased acquisition must reuse the authoritative Beatport review target.",
+                      providerId: "beatport",
+                      providerName: "Beatport",
+                      reason: "download-artifact-missing" as const,
+                      retryable: true
+                    }
+                  };
+                }
+
                 const artifactDirectory = path.join(workspaceRoot, "downloads");
                 const artifactBody = Buffer.from(
                   `owned artifact for ${candidate.candidateId}\n`,
@@ -105,12 +153,12 @@ describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
       const reviewOne = store.queueRunTrackReview({
         authorizationBasis: "purchase-entitlement",
         availableFormats: ["mp3", "wav"],
-        candidateId: "beatport-route-1",
-        mixLabel: "Original Mix",
+        candidateId: searchResult.candidates[0].candidateId,
+        mixLabel: searchResult.candidates[0].mixLabel,
         priceTier: "paid",
         providerKey: "beatport",
         providerName: "Beatport",
-        providerUrl: "https://www.beatport.com/track/track-one/route-1",
+        providerUrl: searchResult.candidates[0].provenance.providerUrl,
         queueName: "beatport-review",
         runTrackId: tracks[0].id,
         summary: "Queued after all automatic free-source providers missed."
@@ -208,7 +256,7 @@ describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
           .getRun(run.id)
           ?.reviewQueue.map((review) => [review.candidateId, review.status])
       ).toEqual([
-        ["beatport-route-1", "purchased"],
+        ["beatport-artist-one-track-one", "purchased"],
         ["beatport-route-2", "rejected"]
       ]);
       expect(
@@ -479,3 +527,37 @@ describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
     });
   });
 });
+
+function buildCanonicalTrack(input: { artistName: string; title: string }) {
+  return {
+    artistCredits: [
+      {
+        display: input.artistName,
+        normalized: input.artistName.toLowerCase().replace(/\s+/g, "-"),
+        role: "primary" as const
+      }
+    ],
+    availableFormats: [],
+    durationSeconds: 392,
+    mix: {
+      cleanTitle: input.title,
+      confidence: "high" as const,
+      displayLabel: "Original Mix",
+      kind: "original" as const,
+      normalizedLabel: "original mix",
+      selectionClass: "preferred" as const
+    },
+    normalizedArtistKey: input.artistName.toLowerCase().replace(/\s+/g, "-"),
+    normalizedTitle: input.title.toLowerCase().replace(/\s+/g, "-"),
+    preferredFormats: ["mp3", "wav"] as const,
+    primaryArtist: input.artistName,
+    provenance: {
+      rawArtists: [input.artistName],
+      rawDuration: null,
+      rawTitle: `${input.title} (Original Mix)`,
+      source: "playlist-run-track",
+      sourceTrackId: "track-1"
+    },
+    title: input.title
+  };
+}

--- a/src/app/api/runs/[runId]/review-queue/[reviewId]/route.ts
+++ b/src/app/api/runs/[runId]/review-queue/[reviewId]/route.ts
@@ -140,7 +140,6 @@ function buildReviewCandidate(review: RunTrackReview, track: RunTrack) {
     providerName: review.providerName,
     provenance: {
       discoveredVia: "search" as const,
-      providerTrackId: review.candidateId,
       providerUrl: review.providerUrl ?? undefined,
       searchQuery: [track.artist, track.title, review.mixLabel]
         .filter((value): value is string => Boolean(value))

--- a/src/app/api/runs/[runId]/review-queue/[reviewId]/route.ts
+++ b/src/app/api/runs/[runId]/review-queue/[reviewId]/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from "next/server";
 
+import { createLiveProviderRegistry } from "@/features/providers/live-provider-registry";
 import {
   getRunStore,
+  type RunTrack,
+  type RunTrackReview,
   type RunTrackReviewStatus
 } from "@/features/runs/run-store";
 import { finalizeTerminalRun } from "@/features/runs/run-finalization";
+import { canonicalizeTrack } from "@/features/tracks/canonical-track";
 
 type RouteContext = {
   params: Promise<{
@@ -13,9 +17,8 @@ type RouteContext = {
   }>;
 };
 
-const reviewActionToStatus: Record<string, RunTrackReviewStatus> = {
+const reviewActionToStatus: Record<string, Exclude<RunTrackReviewStatus, "purchased">> = {
   approve: "approved",
-  purchased: "purchased",
   reject: "rejected"
 };
 
@@ -25,7 +28,8 @@ export async function POST(request: Request, context: RouteContext) {
         action?: string;
       }
     | null;
-  const nextStatus = payload?.action ? reviewActionToStatus[payload.action] : null;
+  const action = payload?.action?.trim();
+  const nextStatus = action ? reviewActionToStatus[action] : null;
   const { reviewId, runId } = await context.params;
   const runStore = getRunStore();
   const run = runStore.getRun(runId);
@@ -40,7 +44,7 @@ export async function POST(request: Request, context: RouteContext) {
     return NextResponse.json({ error: "Review candidate not found" }, { status: 404 });
   }
 
-  if (!nextStatus) {
+  if (!action || (action !== "purchased" && !nextStatus)) {
     return NextResponse.json(
       { error: "action must be one of approve, reject, or purchased" },
       { status: 400 }
@@ -48,6 +52,60 @@ export async function POST(request: Request, context: RouteContext) {
   }
 
   try {
+    if (action === "purchased") {
+      const track = run.tracks.find((candidate) => candidate.id === review.runTrackId);
+
+      if (!track) {
+        return NextResponse.json({ error: "Run track not found" }, { status: 404 });
+      }
+
+      const providerRegistry = createLiveProviderRegistry();
+      const provider = providerRegistry.get(review.providerKey);
+
+      if (!provider || !("acquirePurchased" in provider)) {
+        return NextResponse.json(
+          { error: `Review provider not available: ${review.providerKey}` },
+          { status: 409 }
+        );
+      }
+
+      const acquisitionResult = await provider.acquirePurchased({
+        candidate: buildReviewCandidate(review, track),
+        track: canonicalizeTrack({
+          artistName: track.artist,
+          availableFormats: review.availableFormats,
+          source: "playlist-run-track",
+          sourceTrackId: track.sourceTrackId ?? track.id,
+          title: buildRequestedTrackTitle(track)
+        })
+      });
+
+      if (acquisitionResult.outcome !== "acquired") {
+        return NextResponse.json(
+          {
+            error:
+              acquisitionResult.outcome === "rejected"
+                ? acquisitionResult.rejection.detail
+                : acquisitionResult.miss.detail
+          },
+          { status: 409 }
+        );
+      }
+
+      const updatedReview = runStore.completePurchasedRunTrackReview({
+        artifact: acquisitionResult.artifact,
+        reviewId
+      });
+
+      await finalizeTerminalRun(runId, { runStore });
+
+      return NextResponse.json(updatedReview);
+    }
+
+    if (!nextStatus) {
+      throw new Error(`Unsupported review action: ${action}`);
+    }
+
     const updatedReview = runStore.transitionRunTrackReviewStatus(reviewId, nextStatus);
 
     await finalizeTerminalRun(runId, { runStore });
@@ -62,4 +120,32 @@ export async function POST(request: Request, context: RouteContext) {
       { status: 409 }
     );
   }
+}
+
+function buildRequestedTrackTitle(track: RunTrack) {
+  return track.version ? `${track.title} (${track.version})` : track.title;
+}
+
+function buildReviewCandidate(review: RunTrackReview, track: RunTrack) {
+  return {
+    artistName: track.artist,
+    authorizationBasis: review.authorizationBasis,
+    availableFormats: review.availableFormats,
+    candidateId: review.candidateId,
+    durationSeconds: null,
+    mixConfidence: "high" as const,
+    mixLabel: review.mixLabel,
+    priceTier: review.priceTier,
+    providerId: review.providerKey,
+    providerName: review.providerName,
+    provenance: {
+      discoveredVia: "search" as const,
+      providerTrackId: review.candidateId,
+      providerUrl: review.providerUrl ?? undefined,
+      searchQuery: [track.artist, track.title, review.mixLabel]
+        .filter((value): value is string => Boolean(value))
+        .join(" ")
+    },
+    title: track.title
+  };
 }

--- a/src/app/api/runs/[runId]/route.ts
+++ b/src/app/api/runs/[runId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { getRunStore } from "@/features/runs/run-store";
+import { getSharedRunWorker } from "@/features/runs/run-worker";
 
 type RouteContext = {
   params: Promise<{
@@ -9,6 +10,8 @@ type RouteContext = {
 };
 
 export async function GET(_request: Request, context: RouteContext) {
+  getSharedRunWorker();
+
   const { runId } = await context.params;
   const run = getRunStore().getRun(runId);
 

--- a/src/app/api/runs/route.ts
+++ b/src/app/api/runs/route.ts
@@ -6,6 +6,8 @@ import { queueLiveRunFromPlaylistUrl } from "@/features/runs/live-run-orchestrat
 import { getSharedRunWorker } from "@/features/runs/run-worker";
 
 export async function GET() {
+  getSharedRunWorker();
+
   return NextResponse.json(getRunStore().listRuns());
 }
 

--- a/src/app/api/test/e2e/restart/route.ts
+++ b/src/app/api/test/e2e/restart/route.ts
@@ -4,6 +4,7 @@ import {
   isE2eFixtureModeEnabled,
   restartE2eRunStore
 } from "@/features/e2e/e2e-fixtures";
+import { getSharedRunWorker } from "@/features/runs/run-worker";
 
 export async function POST() {
   if (!isE2eFixtureModeEnabled()) {
@@ -11,6 +12,7 @@ export async function POST() {
   }
 
   const result = restartE2eRunStore();
+  getSharedRunWorker();
 
   return NextResponse.json({
     ok: true,

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -3,6 +3,7 @@ import path from "node:path";
 import { tmpdir } from "node:os";
 
 import { render, screen } from "@testing-library/react";
+import { resetSharedRunWorkerForTests } from "@/features/runs/run-worker";
 
 async function withTempDatabase(callback: (databasePath: string) => Promise<void>) {
   const tempDirectory = mkdtempSync(path.join(tmpdir(), "music-downloader-page-"));
@@ -22,6 +23,14 @@ async function withTempDatabase(callback: (databasePath: string) => Promise<void
 }
 
 describe("HomePage", () => {
+  beforeEach(() => {
+    resetSharedRunWorkerForTests();
+  });
+
+  afterEach(() => {
+    resetSharedRunWorkerForTests();
+  });
+
   it("forces live home-page rendering against the SQLite run store", async () => {
     vi.resetModules();
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,11 @@
 import { HomeScreen } from "@/features/home/home-screen";
 import { getRunStore } from "@/features/runs/run-store";
+import { getSharedRunWorker } from "@/features/runs/run-worker";
 
 export const dynamic = "force-dynamic";
 
 export default function HomePage() {
+  getSharedRunWorker();
+
   return <HomeScreen initialRuns={getRunStore().listRuns()} />;
 }

--- a/src/app/runs/[runId]/page.test.tsx
+++ b/src/app/runs/[runId]/page.test.tsx
@@ -8,6 +8,7 @@ import {
   buildAcquiredArtifactSourceNote,
   buildMissedArtifactSourceNote
 } from "@/features/artifacts/run-artifacts";
+import { resetSharedRunWorkerForTests } from "@/features/runs/run-worker";
 
 vi.mock("next/navigation", async () => {
   const actual = await vi.importActual<typeof import("next/navigation")>(
@@ -40,6 +41,14 @@ async function withTempDatabase(callback: (databasePath: string) => Promise<void
 }
 
 describe("RunReportPage", () => {
+  beforeEach(() => {
+    resetSharedRunWorkerForTests();
+  });
+
+  afterEach(() => {
+    resetSharedRunWorkerForTests();
+  });
+
   it("renders persisted run details, source selections, misses, and artifact links", async () => {
     await withTempDatabase(async () => {
       vi.resetModules();
@@ -213,7 +222,18 @@ describe("RunReportPage", () => {
 
       store.transitionRunTrackReviewStatus(queuedReview.id, "approved");
       store.transitionRunTrackReviewStatus(purchasedReview.id, "approved");
-      store.transitionRunTrackReviewStatus(purchasedReview.id, "purchased");
+      store.completePurchasedRunTrackReview({
+        artifact: {
+          contentType: "audio/mpeg",
+          fileExtension: "mp3",
+          fileName: "drugs-from-amsterdam.mp3",
+          format: "mp3",
+          localFilePath: "/tmp/drugs-from-amsterdam.mp3",
+          sha256: "abc123",
+          sizeBytes: 1234
+        },
+        reviewId: purchasedReview.id
+      });
 
       const pageModule = await import("./page");
 
@@ -232,7 +252,7 @@ describe("RunReportPage", () => {
         0
       );
       expect(
-        screen.getAllByText(/purchased, awaiting import before packaging/i).length
+        screen.getAllByText(/purchased download acquired for packaging/i).length
       ).toBeGreaterThan(0);
       expect(
         screen.getByRole("button", {

--- a/src/app/runs/[runId]/page.tsx
+++ b/src/app/runs/[runId]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { getRunReport } from "@/features/reports/run-report";
 import { RunReportScreen } from "@/features/reports/run-report-screen";
+import { getSharedRunWorker } from "@/features/runs/run-worker";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +13,8 @@ type RunReportPageProps = {
 };
 
 export default async function RunReportPage({ params }: RunReportPageProps) {
+  getSharedRunWorker();
+
   const { runId } = await params;
   const report = getRunReport({ runId });
 

--- a/src/features/artifacts/run-artifacts.test.ts
+++ b/src/features/artifacts/run-artifacts.test.ts
@@ -16,8 +16,7 @@ import { createRunStore } from "@/features/runs/run-store";
 import {
   buildAcquiredArtifactSourceNote,
   buildMissedArtifactSourceNote,
-  generateRunArtifacts,
-  RunArtifactsNotReadyError
+  generateRunArtifacts
 } from "./run-artifacts";
 
 function createTempWorkspace() {
@@ -153,7 +152,7 @@ describe("generateRunArtifacts", () => {
     }
   });
 
-  it("keeps purchased Beatport reviews out of packaging until an owned file is imported", async () => {
+  it("packages purchased Beatport reviews after the owned artifact is acquired", async () => {
     const tempWorkspace = createTempWorkspace();
     const store = createRunStore({ databasePath: tempWorkspace.databasePath });
 
@@ -190,32 +189,78 @@ describe("generateRunArtifacts", () => {
       });
 
       store.transitionRunTrackReviewStatus(review.id, "approved");
-      store.transitionRunTrackReviewStatus(review.id, "purchased");
+      const downloadDirectory = path.join(tempWorkspace.workspaceRoot, "downloads");
+      const acquiredFilePath = path.join(downloadDirectory, "drugs-from-amsterdam.mp3");
+      const acquiredFileBody = Buffer.from("owned beatport payload\n", "utf8");
+
+      mkdirSync(downloadDirectory, { recursive: true });
+      writeFileSync(acquiredFilePath, acquiredFileBody);
+
+      store.completePurchasedRunTrackReview({
+        artifact: {
+          contentType: "audio/mpeg",
+          fileExtension: "mp3",
+          fileName: "drugs-from-amsterdam.mp3",
+          format: "mp3",
+          localFilePath: acquiredFilePath,
+          sha256: createSha256(acquiredFileBody),
+          sizeBytes: acquiredFileBody.byteLength
+        },
+        reviewId: review.id
+      });
 
       expect(store.getRun(run.id)).toEqual(
         expect.objectContaining({
           id: run.id,
-          status: "awaiting-approval"
+          status: "packaging"
         })
       );
-      expect(
-        store
-          .getRun(run.id)
-          ?.tracks.map((candidate) => [candidate.sourcePosition, candidate.status])
-      ).toEqual([[1, "awaiting-approval"]]);
+      expect(store.getRun(run.id)?.tracks.map((candidate) => [candidate.sourcePosition, candidate.status])).toEqual(
+        [[1, "acquired"]]
+      );
 
-      await expect(
-        generateRunArtifacts({
-          runId: run.id,
-          runStore: store,
-          workspaceRoot: tempWorkspace.workspaceRoot
-        })
-      ).rejects.toThrowError(
-        new RunArtifactsNotReadyError(
-          run.id,
-          `Run track "${track.id}" is still "awaiting-approval" and cannot be packaged yet.`
-        )
+      const generated = await generateRunArtifacts({
+        runId: run.id,
+        runStore: store,
+        workspaceRoot: tempWorkspace.workspaceRoot
+      });
+
+      expect(generated.manifest.summary).toEqual({
+        acquiredCount: 1,
+        missCount: 0,
+        trackCount: 1
+      });
+      expect(generated.manifest.tracks).toMatchObject([
+        {
+          artist: "Mau P",
+          miss: null,
+          outcome: "acquired",
+          selection: {
+            artifactFormat: "mp3",
+            providerId: "beatport",
+            providerName: "Beatport",
+            providerUrl:
+              "https://www.beatport.com/track/drugs-from-amsterdam/purchased-1",
+            selectedFormat: "mp3",
+            selectedReason: "accepted-base-version-fallback",
+            zipEntryName: "001 - Mau P - Drugs From Amsterdam.mp3"
+          },
+          sourcePosition: 1,
+          title: "Drugs From Amsterdam",
+          version: null
+        }
+      ]);
+
+      const zipArtifact = generated.artifacts.find(
+        (artifact) => artifact.kind === "downloads-zip"
       );
+
+      expect(zipArtifact).toBeDefined();
+      expect(
+        readStoredZipEntries(zipArtifact?.absolutePath ?? "").get(
+          "001 - Mau P - Drugs From Amsterdam.mp3"
+        )
+      ).toEqual(acquiredFileBody);
     } finally {
       store.close();
       tempWorkspace.cleanup();

--- a/src/features/e2e/e2e-fixtures.ts
+++ b/src/features/e2e/e2e-fixtures.ts
@@ -11,6 +11,7 @@ import {
 import {
   ProviderRegistry,
   buildProviderMissResult,
+  buildProviderRejectedResult,
   defineAutomaticProvider,
   defineReviewQueueProvider,
   type ProviderArtifactFormat,
@@ -26,6 +27,10 @@ import {
   type RunDetail,
   type RunStore
 } from "@/features/runs/run-store";
+import {
+  getSharedRunWorker,
+  resetSharedRunWorkerForTests
+} from "@/features/runs/run-worker";
 import type { CanonicalTrack } from "@/features/tracks/canonical-track";
 
 export const e2eFixtureScenarios = [
@@ -237,6 +242,14 @@ export function createE2eFixtureProviderRegistry(
         providerName: "Beatport"
       });
     },
+    acquirePurchased: async ({ candidate }) =>
+      buildProviderRejectedResult({
+        candidate,
+        detail: "Fixture Beatport provider does not expose purchased-download acquisition.",
+        providerId: "beatport",
+        providerName: "Beatport",
+        reason: "provider-error"
+      }),
     queueForReview: async ({ candidate }) => ({
       outcome: "queued-for-review" as const,
       candidate,
@@ -298,6 +311,7 @@ export function resetE2eFixtureState() {
   });
 
   resetRunStoreForTests();
+  resetSharedRunWorkerForTests();
   getRunStore();
 }
 
@@ -307,11 +321,13 @@ export function restartE2eRunStore() {
 
   ensureFixtureEnvironment(workspaceRoot);
   resetRunStoreForTests();
+  resetSharedRunWorkerForTests();
 
   const bootStore = createRunStore({ databasePath });
   const runCount = bootStore.listRuns().length;
 
   bootStore.close();
+  getSharedRunWorker();
 
   return { runCount };
 }

--- a/src/features/providers/bandcamp.test.ts
+++ b/src/features/providers/bandcamp.test.ts
@@ -44,6 +44,14 @@ describe("createBandcampProvider", () => {
             reason: "no-search-results",
             trackMissReason: "no-authorized-source-match"
           }),
+        acquirePurchased: async ({ candidate }) =>
+          buildProviderRejectedResult({
+            candidate,
+            detail: "Fixture provider does not acquire owned downloads in this test.",
+            providerId: "beatport",
+            providerName: "Beatport",
+            reason: "provider-error"
+          }),
         queueForReview: async ({ candidate }) => ({
           outcome: "queued-for-review",
           candidate,

--- a/src/features/providers/beatport.test.ts
+++ b/src/features/providers/beatport.test.ts
@@ -29,6 +29,16 @@ describe("createBeatportProvider", () => {
         track: buildCanonicalTrack()
       });
 
+      if (searchResult.outcome !== "candidates") {
+        throw new Error("Expected Beatport search to return a candidate.");
+      }
+
+      expect(searchResult.candidates[0].provenance.providerUrl).toBe(
+        "https://www.beatport.com/search/tracks?q=Anyma%20Consciousness%20Extended%20Mix"
+      );
+      expect(searchResult.candidates[0].provenance).not.toHaveProperty(
+        "providerTrackId"
+      );
       expect(searchResult).toEqual({
         candidates: [
           expect.objectContaining({
@@ -40,17 +50,14 @@ describe("createBeatportProvider", () => {
             providerId: "beatport",
             providerName: "Beatport",
             provenance: expect.objectContaining({
-              providerUrl: expect.stringMatching(/\/track\//)
+              providerUrl:
+                "https://www.beatport.com/search/tracks?q=Anyma%20Consciousness%20Extended%20Mix"
             }),
             title: "Consciousness"
           })
         ],
         outcome: "candidates"
       });
-
-      if (searchResult.outcome !== "candidates") {
-        throw new Error("Expected Beatport search to return a candidate.");
-      }
 
       await expect(
         provider.queueForReview({
@@ -262,7 +269,7 @@ async function startFixtureServer() {
 }
 
 function handleFixtureRequest(request: IncomingMessage, response: ServerResponse) {
-  if (request.url === "/track/anyma-consciousness/anyma-consciousness") {
+  if (request.url === "/search/tracks?q=Anyma%20Consciousness%20Extended%20Mix") {
     response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
     response.end(`<!doctype html>
 <html lang="en">

--- a/src/features/providers/beatport.test.ts
+++ b/src/features/providers/beatport.test.ts
@@ -1,102 +1,185 @@
-import { createBeatportProvider } from "./beatport";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse
+} from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+import { BrowserSessionService } from "@/features/browser/browser-session-service";
+
+import {
+  BEATPORT_SESSION_NAME,
+  createBeatportProvider
+} from "./beatport";
 import { createLiveProviderRegistry } from "./live-provider-registry";
 
 describe("createBeatportProvider", () => {
   it("builds review queue candidates and queue metadata for paid fallback review", async () => {
-    const provider = createBeatportProvider();
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-beatport-provider-search-")
+    );
+    const browserSessionService = new BrowserSessionService({ workspaceRoot });
+    const provider = createBeatportProvider({ browserSessionService });
 
-    const searchResult = await provider.search({
-      track: {
-        artistCredits: [
-          {
-            display: "Anyma",
-            normalized: "anyma",
-            role: "primary"
-          }
+    try {
+      const searchResult = await provider.search({
+        track: buildCanonicalTrack()
+      });
+
+      expect(searchResult).toEqual({
+        candidates: [
+          expect.objectContaining({
+            artistName: "Anyma",
+            availableFormats: ["mp3", "wav"],
+            candidateId: "beatport-anyma-consciousness",
+            mixLabel: "Extended Mix",
+            priceTier: "paid",
+            providerId: "beatport",
+            providerName: "Beatport",
+            provenance: expect.objectContaining({
+              providerUrl: expect.stringMatching(/\/track\//)
+            }),
+            title: "Consciousness"
+          })
         ],
-        availableFormats: [],
+        outcome: "candidates"
+      });
+
+      if (searchResult.outcome !== "candidates") {
+        throw new Error("Expected Beatport search to return a candidate.");
+      }
+
+      await expect(
+        provider.queueForReview({
+          candidate: searchResult.candidates[0],
+          track: buildCanonicalTrack()
+        })
+      ).resolves.toEqual({
+        candidate: expect.objectContaining({
+          candidateId: "beatport-anyma-consciousness"
+        }),
+        outcome: "queued-for-review",
+        review: {
+          queueName: "beatport-review",
+          summary: "Queued after all automatic free-source providers missed."
+        }
+      });
+    } finally {
+      await browserSessionService.shutdown();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("acquires an owned Beatport download and prefers MP3 over WAV", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-beatport-provider-owned-")
+    );
+    const fixtureServer = await startFixtureServer();
+    const browserSessionService = new BrowserSessionService({ workspaceRoot });
+
+    try {
+      await seedAuthenticatedSession(browserSessionService);
+
+      const provider = createBeatportProvider({
+        baseUrl: fixtureServer.baseUrl,
+        browserSessionService
+      });
+      const searchResult = await provider.search({
+        track: buildCanonicalTrack()
+      });
+
+      if (searchResult.outcome !== "candidates") {
+        throw new Error("Expected Beatport search to return a candidate.");
+      }
+
+      const acquisitionResult = await provider.acquirePurchased({
+        candidate: searchResult.candidates[0],
+        track: buildCanonicalTrack()
+      });
+
+      expect(acquisitionResult).toEqual(
+        expect.objectContaining({
+          artifact: expect.objectContaining({
+            contentType: "audio/mpeg",
+            fileExtension: "mp3",
+            fileName: "consciousness.mp3",
+            format: "mp3",
+            localFilePath: expect.stringMatching(/consciousness\.mp3$/),
+            sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+            sizeBytes: expect.any(Number)
+          }),
+          candidate: searchResult.candidates[0],
+          outcome: "acquired"
+        })
+      );
+
+      if (acquisitionResult.outcome !== "acquired") {
+        throw new Error("Expected Beatport acquisition to return an owned download.");
+      }
+
+      expect(await readFile(acquisitionResult.artifact.localFilePath, "utf8")).toBe(
+        "beatport owned mp3\n"
+      );
+      await access(acquisitionResult.artifact.localFilePath);
+    } finally {
+      await browserSessionService.shutdown();
+      await fixtureServer.close();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects owned downloads when no authenticated Beatport session is available", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-beatport-provider-auth-")
+    );
+    const browserSessionService = new BrowserSessionService({ workspaceRoot });
+
+    try {
+      const provider = createBeatportProvider({ browserSessionService });
+      const candidate = {
+        artistName: "Anyma",
+        authorizationBasis: "purchase-entitlement" as const,
+        availableFormats: ["mp3", "wav"] as const,
+        candidateId: "beatport-anyma-consciousness",
         durationSeconds: 392,
-        mix: {
-          cleanTitle: "Consciousness",
-          confidence: "high",
-          displayLabel: "Extended Mix",
-          kind: "extended",
-          normalizedLabel: "extended mix",
-          selectionClass: "preferred"
-        },
-        normalizedArtistKey: "anyma",
-        normalizedTitle: "consciousness",
-        preferredFormats: ["mp3", "wav"],
-        primaryArtist: "Anyma",
+        mixConfidence: "high" as const,
+        mixLabel: "Extended Mix",
+        priceTier: "paid" as const,
+        providerId: "beatport",
+        providerName: "Beatport",
         provenance: {
-          rawArtists: ["Anyma"],
-          rawDuration: null,
-          rawTitle: "Consciousness (Extended Mix)",
-          source: "playlist-run-track",
-          sourceTrackId: "track-1"
+          discoveredVia: "search" as const,
+          providerTrackId: "beatport-anyma-consciousness",
+          providerUrl: "https://www.beatport.com/track/anyma-consciousness/anyma-consciousness",
+          searchQuery: "Anyma Consciousness Extended Mix"
         },
         title: "Consciousness"
-      }
-    });
+      };
 
-    expect(searchResult).toEqual({
-      candidates: [
-        expect.objectContaining({
-          artistName: "Anyma",
-          availableFormats: ["mp3", "wav"],
-          candidateId: "beatport-anyma-consciousness",
-          mixLabel: "Extended Mix",
-          priceTier: "paid",
+      await expect(
+        provider.acquirePurchased({
+          candidate,
+          track: buildCanonicalTrack()
+        })
+      ).resolves.toEqual({
+        candidate,
+        outcome: "rejected",
+        rejection: expect.objectContaining({
+          detail:
+            "An authenticated Beatport browser session is required before owned downloads can be acquired.",
           providerId: "beatport",
           providerName: "Beatport",
-          title: "Consciousness"
+          reason: "auth-required",
+          retryable: true
         })
-      ],
-      outcome: "candidates"
-    });
-
-    if (searchResult.outcome !== "candidates") {
-      throw new Error("Expected Beatport search to return a candidate.");
+      });
+    } finally {
+      await browserSessionService.shutdown();
+      await rm(workspaceRoot, { force: true, recursive: true });
     }
-
-    await expect(
-      provider.queueForReview({
-        candidate: searchResult.candidates[0],
-        track: {
-          ...searchResult.candidates[0],
-          artistCredits: [],
-          availableFormats: [],
-          mix: {
-            cleanTitle: "Consciousness",
-            confidence: "high",
-            displayLabel: "Extended Mix",
-            kind: "extended",
-            normalizedLabel: "extended mix",
-            selectionClass: "preferred"
-          },
-          normalizedArtistKey: "anyma",
-          normalizedTitle: "consciousness",
-          preferredFormats: ["mp3", "wav"],
-          primaryArtist: "Anyma",
-          provenance: {
-            rawArtists: ["Anyma"],
-            rawDuration: null,
-            rawTitle: "Consciousness (Extended Mix)",
-            source: "playlist-run-track",
-            sourceTrackId: "track-1"
-          }
-        }
-      })
-    ).resolves.toEqual({
-      candidate: expect.objectContaining({
-        candidateId: "beatport-anyma-consciousness"
-      }),
-      outcome: "queued-for-review",
-      review: {
-        queueName: "beatport-review",
-        summary: "Queued after all automatic free-source providers missed."
-      }
-    });
   });
 
   it("registers Beatport as the live paid review provider", () => {
@@ -107,3 +190,143 @@ describe("createBeatportProvider", () => {
     ]);
   });
 });
+
+function buildCanonicalTrack() {
+  return {
+    artistCredits: [
+      {
+        display: "Anyma",
+        normalized: "anyma",
+        role: "primary" as const
+      }
+    ],
+    availableFormats: [],
+    durationSeconds: 392,
+    mix: {
+      cleanTitle: "Consciousness",
+      confidence: "high" as const,
+      displayLabel: "Extended Mix",
+      kind: "extended" as const,
+      normalizedLabel: "extended mix",
+      selectionClass: "preferred" as const
+    },
+    normalizedArtistKey: "anyma",
+    normalizedTitle: "consciousness",
+    preferredFormats: ["mp3", "wav"] as const,
+    primaryArtist: "Anyma",
+    provenance: {
+      rawArtists: ["Anyma"],
+      rawDuration: null,
+      rawTitle: "Consciousness (Extended Mix)",
+      source: "playlist-run-track",
+      sourceTrackId: "track-1"
+    },
+    title: "Consciousness"
+  };
+}
+
+async function seedAuthenticatedSession(browserSessionService: BrowserSessionService) {
+  const session = await browserSessionService.openSession({
+    authState: {
+      authenticatedAt: "2026-03-31T05:00:00.000Z",
+      providerId: "beatport",
+      status: "authenticated"
+    },
+    sessionName: BEATPORT_SESSION_NAME
+  });
+
+  await session.close();
+}
+
+async function startFixtureServer() {
+  const server = createServer(handleFixtureRequest);
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+
+  if (address === null || typeof address === "string") {
+    throw new Error("Fixture server did not expose a TCP address.");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () => closeFixtureServer(server)
+  };
+}
+
+function handleFixtureRequest(request: IncomingMessage, response: ServerResponse) {
+  if (request.url === "/track/anyma-consciousness/anyma-consciousness") {
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    response.end(`<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      <h1>Anyma - Consciousness</h1>
+      <a
+        data-testid="beatport-owned-download"
+        data-format-key="mp3"
+        href="/downloads/consciousness.mp3"
+        download="consciousness.mp3"
+        type="audio/mpeg"
+      >
+        Download MP3
+      </a>
+      <a
+        data-testid="beatport-owned-download"
+        data-format-key="wav"
+        href="/downloads/consciousness.wav"
+        download="consciousness.wav"
+        type="audio/wav"
+      >
+        Download WAV
+      </a>
+    </main>
+  </body>
+</html>`);
+
+    return;
+  }
+
+  if (request.url === "/downloads/consciousness.mp3") {
+    response.writeHead(200, {
+      "content-disposition": 'attachment; filename="consciousness.mp3"',
+      "content-type": "audio/mpeg"
+    });
+    response.end("beatport owned mp3\n");
+
+    return;
+  }
+
+  if (request.url === "/downloads/consciousness.wav") {
+    response.writeHead(200, {
+      "content-disposition": 'attachment; filename="consciousness.wav"',
+      "content-type": "audio/wav"
+    });
+    response.end("beatport owned wav\n");
+
+    return;
+  }
+
+  response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+  response.end("Not found");
+}
+
+async function closeFixtureServer(server: Server) {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}

--- a/src/features/providers/beatport.ts
+++ b/src/features/providers/beatport.ts
@@ -99,13 +99,13 @@ function buildBeatportCandidate(track: CanonicalTrack, baseUrl: string) {
     )
     .join("-")
     .replace(/-+/g, "-");
-  const providerTrackId = `${BEATPORT_PROVIDER_ID}-${slug}`;
+  const candidateId = `${BEATPORT_PROVIDER_ID}-${slug}`;
 
   return {
     artistName,
     authorizationBasis: "purchase-entitlement" as const,
     availableFormats: ["mp3", "wav"] as const,
-    candidateId: providerTrackId,
+    candidateId,
     durationSeconds:
       track.durationSeconds ?? (track.mix.displayLabel ? 392 : 301),
     mixConfidence: track.mix.confidence,
@@ -115,8 +115,10 @@ function buildBeatportCandidate(track: CanonicalTrack, baseUrl: string) {
     providerName: BEATPORT_PROVIDER_NAME,
     provenance: {
       discoveredVia: "search" as const,
-      providerTrackId,
-      providerUrl: new URL(`/track/${slug}/${slug}`, baseUrl).toString(),
+      providerUrl: new URL(
+        `/search/tracks?q=${encodeURIComponent(searchQuery)}`,
+        baseUrl
+      ).toString(),
       searchQuery
     },
     title: track.title

--- a/src/features/providers/beatport.ts
+++ b/src/features/providers/beatport.ts
@@ -1,14 +1,63 @@
+import { createHash } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+import type { Page } from "playwright";
+
+import {
+  BrowserSessionService,
+  ExpiredBrowserSessionAuthStateError,
+  MissingBrowserSessionAuthStateError,
+  MissingBrowserSessionStateError
+} from "@/features/browser/browser-session-service";
 import { type CanonicalTrack } from "@/features/tracks/canonical-track";
 
-import { defineReviewQueueProvider } from "./provider-registry";
+import {
+  buildProviderRejectedResult,
+  defineReviewQueueProvider,
+  type ProviderAcquireInput,
+  type ProviderArtifactFormat,
+  type ProviderCandidate
+} from "./provider-registry";
 
 export const BEATPORT_PROVIDER_ID = "beatport";
 export const BEATPORT_PROVIDER_NAME = "Beatport";
 export const BEATPORT_REVIEW_QUEUE_NAME = "beatport-review";
 export const BEATPORT_REVIEW_SUMMARY =
   "Queued after all automatic free-source providers missed.";
+export const BEATPORT_SESSION_NAME = BEATPORT_PROVIDER_ID;
 
-export function createBeatportProvider() {
+const DEFAULT_BEATPORT_BASE_URL = "https://www.beatport.com";
+const OWNED_DOWNLOAD_SELECTOR = [
+  '[data-testid="beatport-owned-download"]',
+  'a[data-format-key][href]',
+  'a[data-format][href]',
+  'a[href*="/download"][download]',
+  'a[href*="/download"]'
+].join(", ");
+
+interface BeatportProviderDependencies {
+  baseUrl?: string;
+  browserSessionService: Pick<
+    BrowserSessionService,
+    "openSession" | "requireAuthenticatedSession"
+  >;
+  sessionName?: string;
+}
+
+type ParsedOwnedDownload = {
+  contentType: string | null;
+  format: ProviderArtifactFormat;
+  href: string;
+  label: string | null;
+};
+
+export function createBeatportProvider(
+  dependencies: BeatportProviderDependencies
+) {
+  const baseUrl = dependencies.baseUrl ?? DEFAULT_BEATPORT_BASE_URL;
+  const sessionName = dependencies.sessionName ?? BEATPORT_SESSION_NAME;
+
   return defineReviewQueueProvider({
     id: BEATPORT_PROVIDER_ID,
     displayName: BEATPORT_PROVIDER_NAME,
@@ -17,8 +66,14 @@ export function createBeatportProvider() {
     supportedFormats: ["mp3", "wav", "aiff"],
     search: async ({ track }) => ({
       outcome: "candidates" as const,
-      candidates: [buildBeatportCandidate(track)]
+      candidates: [buildBeatportCandidate(track, baseUrl)]
     }),
+    acquirePurchased: async (input) =>
+      acquirePurchasedBeatportDownload({
+        browserSessionService: dependencies.browserSessionService,
+        input,
+        sessionName
+      }),
     queueForReview: async ({ candidate }) => ({
       outcome: "queued-for-review" as const,
       candidate,
@@ -30,10 +85,10 @@ export function createBeatportProvider() {
   });
 }
 
-function buildBeatportCandidate(track: CanonicalTrack) {
+function buildBeatportCandidate(track: CanonicalTrack, baseUrl: string) {
   const artistName = track.primaryArtist ?? "Unknown Artist";
   const searchQuery = [artistName, track.title, track.mix.displayLabel]
-    .filter(Boolean)
+    .filter((value): value is string => Boolean(value))
     .join(" ");
   const slug = [artistName, track.title]
     .map((segment) =>
@@ -44,12 +99,13 @@ function buildBeatportCandidate(track: CanonicalTrack) {
     )
     .join("-")
     .replace(/-+/g, "-");
+  const providerTrackId = `${BEATPORT_PROVIDER_ID}-${slug}`;
 
   return {
     artistName,
     authorizationBasis: "purchase-entitlement" as const,
     availableFormats: ["mp3", "wav"] as const,
-    candidateId: `${BEATPORT_PROVIDER_ID}-${slug}`,
+    candidateId: providerTrackId,
     durationSeconds:
       track.durationSeconds ?? (track.mix.displayLabel ? 392 : 301),
     mixConfidence: track.mix.confidence,
@@ -59,12 +115,351 @@ function buildBeatportCandidate(track: CanonicalTrack) {
     providerName: BEATPORT_PROVIDER_NAME,
     provenance: {
       discoveredVia: "search" as const,
-      providerTrackId: `${BEATPORT_PROVIDER_ID}-${slug}`,
-      providerUrl: `https://www.beatport.com/search/tracks?q=${encodeURIComponent(
-        searchQuery
-      )}`,
+      providerTrackId,
+      providerUrl: new URL(`/track/${slug}/${slug}`, baseUrl).toString(),
       searchQuery
     },
     title: track.title
   };
+}
+
+async function acquirePurchasedBeatportDownload(input: {
+  browserSessionService: BeatportProviderDependencies["browserSessionService"];
+  input: ProviderAcquireInput;
+  sessionName: string;
+}) {
+  const sessionResult = await openAuthenticatedSession({
+    browserSessionService: input.browserSessionService,
+    candidate: input.input.candidate,
+    sessionName: input.sessionName
+  });
+
+  if ("outcome" in sessionResult) {
+    return sessionResult;
+  }
+
+  const trackUrl =
+    input.input.candidate.provenance.providerUrl ??
+    input.input.candidate.provenance.sourcePageUrl;
+
+  if (!trackUrl) {
+    return buildProviderRejectedResult({
+      candidate: input.input.candidate,
+      detail: "Beatport candidate was missing the track page URL required for download.",
+      providerId: BEATPORT_PROVIDER_ID,
+      providerName: BEATPORT_PROVIDER_NAME,
+      reason: "download-artifact-missing"
+    });
+  }
+
+  try {
+    const ownedDownloads = await sessionResult.withPage(async (page) => {
+      await page.goto(trackUrl, { waitUntil: "load" });
+      return parseOwnedDownloadOptions(page);
+    });
+
+    if (ownedDownloads.length === 0) {
+      return buildProviderRejectedResult({
+        candidate: input.input.candidate,
+        detail:
+          "Beatport track is not currently owned or does not expose owned-download links.",
+        providerId: BEATPORT_PROVIDER_ID,
+        providerName: BEATPORT_PROVIDER_NAME,
+        reason: "no-download-entitlement"
+      });
+    }
+
+    const preferredDownload = selectPreferredOwnedDownload(ownedDownloads);
+
+    if (!preferredDownload) {
+      return buildProviderRejectedResult({
+        candidate: input.input.candidate,
+        detail:
+          "Beatport owned download is available, but none of the exposed formats match the MP3/WAV fallback policy.",
+        providerId: BEATPORT_PROVIDER_ID,
+        providerName: BEATPORT_PROVIDER_NAME,
+        reason: "candidate-format-unavailable"
+      });
+    }
+
+    const download = await sessionResult.captureDownload({
+      trigger: async (page) => {
+        await clickOwnedDownload(page, preferredDownload);
+      }
+    });
+    const artifact = await buildArtifactMetadata(
+      download.path,
+      download.suggestedFilename,
+      preferredDownload.contentType
+    );
+
+    if (artifact.format !== "mp3" && artifact.format !== "wav") {
+      return buildProviderRejectedResult({
+        candidate: input.input.candidate,
+        detail:
+          "Beatport download completed, but the artifact format fell outside the MP3/WAV fallback policy.",
+        providerId: BEATPORT_PROVIDER_ID,
+        providerName: BEATPORT_PROVIDER_NAME,
+        reason: "candidate-format-unavailable"
+      });
+    }
+
+    return {
+      outcome: "acquired" as const,
+      artifact,
+      candidate: input.input.candidate
+    };
+  } catch (error) {
+    return buildProviderRejectedResult({
+      candidate: input.input.candidate,
+      detail: buildProviderErrorDetail(
+        "Beatport acquisition failed while capturing an owned download.",
+        error
+      ),
+      providerId: BEATPORT_PROVIDER_ID,
+      providerName: BEATPORT_PROVIDER_NAME,
+      reason: "provider-error"
+    });
+  } finally {
+    await sessionResult.close();
+  }
+}
+
+async function openAuthenticatedSession(input: {
+  browserSessionService: BeatportProviderDependencies["browserSessionService"];
+  candidate: ProviderCandidate;
+  sessionName: string;
+}) {
+  try {
+    await input.browserSessionService.requireAuthenticatedSession(input.sessionName);
+  } catch (error) {
+    if (
+      error instanceof MissingBrowserSessionStateError ||
+      error instanceof MissingBrowserSessionAuthStateError
+    ) {
+      return buildProviderRejectedResult({
+        candidate: input.candidate,
+        detail:
+          "An authenticated Beatport browser session is required before owned downloads can be acquired.",
+        providerId: BEATPORT_PROVIDER_ID,
+        providerName: BEATPORT_PROVIDER_NAME,
+        reason: "auth-required"
+      });
+    }
+
+    if (error instanceof ExpiredBrowserSessionAuthStateError) {
+      return buildProviderRejectedResult({
+        candidate: input.candidate,
+        detail:
+          "The Beatport browser session expired and must be refreshed before owned downloads can be acquired.",
+        providerId: BEATPORT_PROVIDER_ID,
+        providerName: BEATPORT_PROVIDER_NAME,
+        reason: "provider-session-expired"
+      });
+    }
+
+    throw error;
+  }
+
+  return input.browserSessionService.openSession({
+    sessionName: input.sessionName
+  });
+}
+
+async function parseOwnedDownloadOptions(page: Page): Promise<ParsedOwnedDownload[]> {
+  return page.evaluate((selector) => {
+    const downloads: ParsedOwnedDownload[] = [];
+
+    for (const element of document.querySelectorAll(selector)) {
+      if (!(element instanceof HTMLAnchorElement)) {
+        continue;
+      }
+
+      const href = element.getAttribute("href");
+
+      if (!href) {
+        continue;
+      }
+
+      const formatLabel =
+        element.getAttribute("data-format-key") ??
+        element.getAttribute("data-format") ??
+        element.textContent ??
+        "";
+
+      downloads.push({
+        contentType: element.getAttribute("type"),
+        format: classifyOwnedDownloadFormat(formatLabel),
+        href: new URL(href, window.location.href).toString(),
+        label: element.textContent?.trim() ?? null
+      });
+    }
+
+    return downloads;
+
+    function classifyOwnedDownloadFormat(value: string): ProviderArtifactFormat {
+      const normalizedValue = value.trim().toLowerCase();
+
+      if (normalizedValue.includes("mp3")) {
+        return "mp3";
+      }
+
+      if (normalizedValue.includes("wav")) {
+        return "wav";
+      }
+
+      if (normalizedValue.includes("aiff") || normalizedValue.includes("aif")) {
+        return "aiff";
+      }
+
+      return "unknown";
+    }
+  }, OWNED_DOWNLOAD_SELECTOR);
+}
+
+function selectPreferredOwnedDownload(downloads: ParsedOwnedDownload[]) {
+  return (
+    downloads.find((download) => download.format === "mp3") ??
+    downloads.find((download) => download.format === "wav") ??
+    null
+  );
+}
+
+async function clickOwnedDownload(page: Page, selectedDownload: ParsedOwnedDownload) {
+  const clicked = await page.evaluate(
+    ({ format, href }) => {
+      const links = [...document.querySelectorAll("a[href]")].filter(
+        (element): element is HTMLAnchorElement =>
+          element instanceof HTMLAnchorElement
+      );
+
+      const hrefMatch = links.find(
+        (element) =>
+          new URL(element.getAttribute("href") ?? "", window.location.href).toString() ===
+          href
+      );
+
+      if (hrefMatch) {
+        hrefMatch.click();
+        return true;
+      }
+
+      const formatMatch = links.find((element) => {
+        const formatLabel =
+          element.getAttribute("data-format-key") ??
+          element.getAttribute("data-format") ??
+          element.textContent ??
+          "";
+
+        return formatLabel.trim().toLowerCase().includes(format);
+      });
+
+      if (formatMatch) {
+        formatMatch.click();
+        return true;
+      }
+
+      return false;
+    },
+    {
+      format: selectedDownload.format,
+      href: selectedDownload.href
+    }
+  );
+
+  if (!clicked) {
+    throw new Error(
+      `Beatport owned download link not found for format "${selectedDownload.format}".`
+    );
+  }
+}
+
+async function buildArtifactMetadata(
+  downloadPath: string,
+  suggestedFilename: string,
+  contentType: string | null
+) {
+  const normalizedContentType =
+    normalizeContentType(contentType) ?? inferContentType(suggestedFilename);
+  const fileBuffer = await readFile(downloadPath);
+  const fileStats = await stat(downloadPath);
+  const fileExtension = normalizeFileExtension(suggestedFilename);
+
+  return {
+    contentType: normalizedContentType,
+    fileExtension,
+    fileName: suggestedFilename,
+    format: inferArtifactFormat(fileExtension, normalizedContentType),
+    localFilePath: downloadPath,
+    sha256: createHash("sha256").update(fileBuffer).digest("hex"),
+    sizeBytes: fileStats.size
+  };
+}
+
+function normalizeFileExtension(fileName: string) {
+  const extension = path.extname(fileName).replace(/^\./, "").trim().toLowerCase();
+  return extension || null;
+}
+
+function inferArtifactFormat(
+  fileExtension: string | null,
+  contentType: string | null
+): ProviderArtifactFormat {
+  switch (fileExtension) {
+    case "mp3":
+      return "mp3";
+    case "wav":
+      return "wav";
+    case "aif":
+    case "aiff":
+      return "aiff";
+    default:
+      return inferArtifactFormatFromContentType(contentType);
+  }
+}
+
+function inferArtifactFormatFromContentType(
+  contentType: string | null
+): ProviderArtifactFormat {
+  switch (normalizeContentType(contentType)) {
+    case "audio/mpeg":
+    case "audio/mp3":
+      return "mp3";
+    case "audio/wav":
+    case "audio/wave":
+    case "audio/x-wav":
+      return "wav";
+    case "audio/aiff":
+    case "audio/x-aiff":
+      return "aiff";
+    default:
+      return "unknown";
+  }
+}
+
+function normalizeContentType(contentType: string | null) {
+  const normalizedContentType = contentType?.trim().toLowerCase();
+  return normalizedContentType || null;
+}
+
+function inferContentType(fileName: string) {
+  switch (normalizeFileExtension(fileName)) {
+    case "mp3":
+      return "audio/mpeg";
+    case "wav":
+      return "audio/wav";
+    case "aif":
+    case "aiff":
+      return "audio/aiff";
+    default:
+      return null;
+  }
+}
+
+function buildProviderErrorDetail(message: string, error: unknown) {
+  if (error instanceof Error && error.message) {
+    return `${message} ${error.message}`;
+  }
+
+  return message;
 }

--- a/src/features/providers/live-provider-registry.ts
+++ b/src/features/providers/live-provider-registry.ts
@@ -30,7 +30,7 @@ export function createLiveProviderRegistry(
   return new ProviderRegistry([
     createSoundCloudDirectDownloadsProvider({ browserSessionService }),
     createBandcampProvider({ browserSessionService }),
-    createBeatportProvider()
+    createBeatportProvider({ browserSessionService })
   ]);
 }
 

--- a/src/features/providers/provider-registry.test.ts
+++ b/src/features/providers/provider-registry.test.ts
@@ -26,6 +26,14 @@ describe("ProviderRegistry", () => {
             reason: "no-search-results",
             trackMissReason: "no-authorized-source-match"
           }),
+        acquirePurchased: async ({ candidate }) =>
+          buildProviderRejectedResult({
+            candidate,
+            detail: "Fixture provider is not wired to acquire owned downloads in tests.",
+            providerId: "beatport",
+            providerName: "Beatport",
+            reason: "provider-error"
+          }),
         queueForReview: async ({ candidate }) => ({
           outcome: "queued-for-review",
           candidate,

--- a/src/features/providers/provider-registry.ts
+++ b/src/features/providers/provider-registry.ts
@@ -205,6 +205,9 @@ export interface AutomaticProviderDefinition
 
 export interface ReviewQueueProviderDefinition
   extends BaseProviderDefinition<"review", "paid", "paid-review-queue"> {
+  acquirePurchased(
+    input: ProviderAcquireInput
+  ): Promise<ProviderAcquisitionResult>;
   queueForReview(
     input: ProviderReviewQueueInput
   ): Promise<ProviderReviewQueueResult>;

--- a/src/features/providers/soundcloud-direct-downloads.test.ts
+++ b/src/features/providers/soundcloud-direct-downloads.test.ts
@@ -43,6 +43,14 @@ describe("createSoundCloudDirectDownloadsProvider", () => {
             reason: "no-search-results",
             trackMissReason: "no-authorized-source-match"
           }),
+        acquirePurchased: async ({ candidate }) =>
+          buildProviderRejectedResult({
+            candidate,
+            detail: "Fixture provider does not acquire owned downloads in this test.",
+            providerId: "beatport",
+            providerName: "Beatport",
+            reason: "provider-error"
+          }),
         queueForReview: async ({ candidate }) => ({
           outcome: "queued-for-review",
           candidate,

--- a/src/features/reports/beatport-review-lane.tsx
+++ b/src/features/reports/beatport-review-lane.tsx
@@ -169,7 +169,7 @@ function formatReviewPrimaryCopy(review: RunReportReviewQueueEntry) {
     case "approved":
       return "Approved for manual purchase";
     case "purchased":
-      return "Purchased, awaiting import before packaging";
+      return "Purchased download acquired for packaging";
     case "rejected":
       return "Rejected during paid review";
     default:

--- a/src/features/reports/run-report-screen.beatport-review.test.tsx
+++ b/src/features/reports/run-report-screen.beatport-review.test.tsx
@@ -27,7 +27,7 @@ describe("RunReportScreen Beatport review lane", () => {
       0
     );
     expect(
-      screen.getAllByText(/purchased, awaiting import before packaging/i).length
+      screen.getAllByText(/purchased download acquired for packaging/i).length
     ).toBeGreaterThan(0);
     expect(
       screen.getByRole("button", {
@@ -184,7 +184,7 @@ function buildBeatportReviewReport() {
         },
         sourcePosition: 2,
         sourceTrackId: "sp-102",
-        status: "awaiting-approval",
+        status: "acquired",
         title: "Drugs From Amsterdam",
         version: null
       }

--- a/src/features/reports/run-report-screen.tsx
+++ b/src/features/reports/run-report-screen.tsx
@@ -309,7 +309,7 @@ function formatReviewDecision(
     case "approved":
       return "Approved for manual purchase";
     case "purchased":
-      return "Purchased, awaiting import before packaging";
+      return "Purchased download acquired for packaging";
     case "rejected":
       return "Rejected during paid review";
     default:

--- a/src/features/runs/live-run-orchestrator.test.ts
+++ b/src/features/runs/live-run-orchestrator.test.ts
@@ -19,7 +19,10 @@ import {
 } from "@/features/providers/provider-registry";
 import { createRunStore, type RunStore, type RunTrack } from "@/features/runs/run-store";
 
-import { submitLiveRunFromPlaylistUrl } from "./live-run-orchestrator";
+import {
+  executeQueuedRun,
+  submitLiveRunFromPlaylistUrl
+} from "./live-run-orchestrator";
 
 function createTempWorkspace() {
   const workspaceRoot = mkdtempSync(
@@ -100,6 +103,120 @@ function buildMatchingCandidate(
 }
 
 describe("submitLiveRunFromPlaylistUrl", () => {
+  it("resumes interrupted matching runs from persisted queued state", async () => {
+    const tempWorkspace = createTempWorkspace();
+    let initialRunStore: RunStore | undefined;
+    let resumedRunStore: RunStore | undefined;
+
+    const bandcampProvider = defineAutomaticProvider({
+      id: "bandcamp",
+      displayName: "Bandcamp",
+      authorizationBasis: "rights-holder-storefront",
+      priceTier: "free-or-owned",
+      priorityRank: 20,
+      supportedFormats: ["mp3", "wav"],
+      search: async ({ track }) => ({
+        outcome: "candidates" as const,
+        candidates: [
+          buildMatchingCandidate(bandcampProvider, {
+            artist: track.primaryArtist ?? "Unknown Artist",
+            createdAt: "",
+            id: `track-${track.title}`,
+            runId: "run",
+            sourcePosition: 1,
+            sourceTrackId: null,
+            status: "queued",
+            title: track.title,
+            updatedAt: "",
+            version: track.mix.displayLabel
+          })
+        ]
+      }),
+      acquire: async ({ candidate, track }) => {
+        const downloadDirectory = path.join(tempWorkspace.workspaceRoot, "downloads");
+        const artifactFileName = `${track.title.toLowerCase().replace(/\s+/g, "-")}.mp3`;
+        const localFilePath = path.join(downloadDirectory, artifactFileName);
+
+        mkdirSync(downloadDirectory, { recursive: true });
+        writeFileSync(localFilePath, `${candidate.providerName}:${track.title}\n`, "utf8");
+
+        return {
+          outcome: "acquired" as const,
+          artifact: {
+            contentType: "audio/mpeg",
+            fileExtension: "mp3",
+            fileName: artifactFileName,
+            format: "mp3",
+            localFilePath,
+            sha256: null,
+            sizeBytes: readFileSync(localFilePath).byteLength
+          },
+          candidate
+        };
+      }
+    });
+
+    try {
+      initialRunStore = createRunStore({ databasePath: tempWorkspace.databasePath });
+
+      const interruptedRun = createStubRun(
+        initialRunStore,
+        "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+        [
+          {
+            artist: "Anyma",
+            sourcePosition: 1,
+            title: "Consciousness",
+            version: "Extended Mix"
+          },
+          {
+            artist: "Kx5",
+            sourcePosition: 2,
+            title: "Escape"
+          }
+        ]
+      );
+
+      initialRunStore.transitionRunStatus(interruptedRun.id, "ingesting");
+      initialRunStore.transitionRunStatus(interruptedRun.id, "matching");
+      initialRunStore.close();
+      initialRunStore = undefined;
+
+      resumedRunStore = createRunStore({ databasePath: tempWorkspace.databasePath });
+
+      expect(resumedRunStore.getRunStatusSnapshot(interruptedRun.id)).toEqual(
+        expect.objectContaining({
+          resumeAfterStatus: "matching",
+          status: "queued"
+        })
+      );
+
+      const resumedRun = await executeQueuedRun(interruptedRun.id, {
+        providerRegistry: createStubRegistry([bandcampProvider]),
+        runStore: resumedRunStore,
+        workspaceRoot: tempWorkspace.workspaceRoot
+      });
+
+      expect(resumedRun.status).toBe("completed");
+      expect(resumedRun.resumeAfterStatus).toBe("matching");
+      expect(resumedRun.tracks.map((track) => [track.sourcePosition, track.status])).toEqual(
+        [
+          [1, "acquired"],
+          [2, "acquired"]
+        ]
+      );
+      expect([...resumedRun.artifacts.map((artifact) => artifact.kind)].sort()).toEqual([
+        "downloads-zip",
+        "manifest-json",
+        "misses-txt"
+      ]);
+    } finally {
+      initialRunStore?.close();
+      resumedRunStore?.close();
+      tempWorkspace.cleanup();
+    }
+  });
+
   it("executes automatic providers in priority order, persists selected outcomes, and packages fully auto-resolved runs", async () => {
     const tempWorkspace = createTempWorkspace();
     const runStore = createRunStore({ databasePath: tempWorkspace.databasePath });
@@ -515,6 +632,15 @@ describe("submitLiveRunFromPlaylistUrl", () => {
           }
         ]
       }),
+      acquirePurchased: async ({ candidate }) =>
+        buildProviderRejectedResult({
+          candidate,
+          detail:
+            "Stub Beatport provider does not acquire purchased downloads in this orchestration test.",
+          providerId: "beatport",
+          providerName: "Beatport",
+          reason: "provider-error"
+        }),
       queueForReview: async ({ candidate }) => ({
         outcome: "queued-for-review" as const,
         candidate,

--- a/src/features/runs/live-run-orchestrator.ts
+++ b/src/features/runs/live-run-orchestrator.ts
@@ -60,7 +60,7 @@ export async function executeQueuedRun(
   const runStore = dependencies.runStore ?? getRunStore();
   const queuedRun = requireRun(runStore, runId);
 
-  if (queuedRun.status !== "queued" || queuedRun.resumeAfterStatus) {
+  if (queuedRun.status !== "queued") {
     return queuedRun;
   }
 
@@ -69,12 +69,28 @@ export async function executeQueuedRun(
     createLiveProviderRegistry({ workspaceRoot: dependencies.workspaceRoot });
 
   try {
-    runStore.transitionRunStatus(runId, "ingesting");
-    runStore.transitionRunStatus(runId, "matching");
+    let activeRun = queuedRun.resumeAfterStatus
+      ? runStore.resumeRun(runId)
+      : runStore.transitionRunStatus(runId, "ingesting");
+
+    if (activeRun.status === "ingesting") {
+      activeRun = runStore.transitionRunStatus(runId, "matching");
+    }
+
+    if (activeRun.status === "packaging") {
+      return finalizeTerminalRun(runId, {
+        runStore,
+        workspaceRoot: dependencies.workspaceRoot
+      });
+    }
 
     const hydratedRun = requireRun(runStore, runId);
 
     for (const track of hydratedRun.tracks) {
+      if (isResolvedTrackStatus(track.status)) {
+        continue;
+      }
+
       await resolveTrackWithAutomaticProviders({
         providers: providerRegistry.listAutomatic(),
         reviewProviders: providerRegistry.listReviewQueue(),
@@ -385,6 +401,10 @@ function failRunIfPossible(runStore: RunStore, runId: string) {
   }
 
   runStore.transitionRunStatus(runId, "failed");
+}
+
+function isResolvedTrackStatus(status: RunTrack["status"]) {
+  return status === "acquired" || status === "awaiting-approval" || status === "missed";
 }
 
 function requireRun(runStore: RunStore, runId: string) {

--- a/src/features/runs/run-store.beatport-review.test.ts
+++ b/src/features/runs/run-store.beatport-review.test.ts
@@ -116,7 +116,7 @@ describe("createRunStore Beatport review queue", () => {
     }
   });
 
-  it("keeps purchased reviews awaiting import and persists rejected reviews as misses", () => {
+  it("completes purchased reviews by recording the acquired owned download and persists rejected reviews as misses", () => {
     const tempDatabase = createTempDatabasePath();
 
     try {
@@ -177,12 +177,22 @@ describe("createRunStore Beatport review queue", () => {
         rejectedReview.id,
         "rejected"
       );
-      const purchasedResult = store.transitionRunTrackReviewStatus(
-        approvedReview.id,
-        "purchased"
-      );
+      const purchasedResult = store.completePurchasedRunTrackReview({
+        artifact: {
+          contentType: "audio/mpeg",
+          fileExtension: "mp3",
+          fileName: "track-one.mp3",
+          format: "mp3",
+          localFilePath: "/tmp/track-one.mp3",
+          sha256: "abc123",
+          sizeBytes: 1234
+        },
+        reviewId: approvedReview.id
+      });
       const persistedRun = store.getRun(run.id);
       const attempts = store.listRunTrackAttempts(run.id);
+      const matchedAttempt = attempts.find((attempt) => attempt.outcome === "matched");
+      const missedAttempt = attempts.find((attempt) => attempt.outcome === "missed");
 
       expect(approvedResult.status).toBe("approved");
       expect(rejectedResult.status).toBe("rejected");
@@ -190,7 +200,7 @@ describe("createRunStore Beatport review queue", () => {
       expect(persistedRun).toEqual(
         expect.objectContaining({
           id: run.id,
-          status: "awaiting-approval"
+          status: "packaging"
         })
       );
       expect(
@@ -199,14 +209,46 @@ describe("createRunStore Beatport review queue", () => {
         ["beatport-2001", "purchased"],
         ["beatport-2002", "rejected"]
       ]);
-      expect(attempts).toEqual([
+      expect(matchedAttempt).toEqual(
+        expect.objectContaining({
+          outcome: "matched",
+          providerKey: "beatport",
+          runTrackId: tracks[0].id
+        })
+      );
+      expect(missedAttempt).toEqual(
         expect.objectContaining({
           outcome: "missed",
           providerKey: "beatport",
           runTrackId: tracks[1].id
         })
-      ]);
-      expect(parseRunTrackArtifactSourceNote(attempts[0]?.note ?? null)).toEqual(
+      );
+      expect(parseRunTrackArtifactSourceNote(matchedAttempt?.note ?? null)).toEqual(
+        expect.objectContaining({
+          artifact: expect.objectContaining({
+            fileName: "track-one.mp3",
+            format: "mp3",
+            localFilePath: "/tmp/track-one.mp3",
+            sha256: "abc123",
+            sizeBytes: 1234
+          }),
+          outcome: "acquired",
+          provider: expect.objectContaining({
+            authorizationBasis: "purchase-entitlement",
+            priceTier: "paid",
+            providerId: "beatport",
+            providerName: "Beatport",
+            providerUrl: "https://www.beatport.com/track/track-one/2001"
+          }),
+          selection: expect.objectContaining({
+            details:
+              "Beatport paid review confirmed the owned download and captured it for packaging.",
+            reason: "accepted-original-mix",
+            selectedFormat: "mp3"
+          })
+        })
+      );
+      expect(parseRunTrackArtifactSourceNote(missedAttempt?.note ?? null)).toEqual(
         expect.objectContaining({
           miss: expect.objectContaining({
             detail: "Rejected during Beatport paid review.",
@@ -223,7 +265,7 @@ describe("createRunStore Beatport review queue", () => {
             [track.sourcePosition, track.status] satisfies [number, RunTrackStatus]
         )
       ).toEqual([
-        [1, "awaiting-approval"],
+        [1, "acquired"],
         [2, "missed"]
       ]);
     } finally {

--- a/src/features/runs/run-store.test.ts
+++ b/src/features/runs/run-store.test.ts
@@ -255,7 +255,7 @@ describe("createRunStore", () => {
     }
   });
 
-  it("updates review queue while keeping purchased tracks out of packaging until import", () => {
+  it("updates review queue after a purchased review acquires the owned download", () => {
     const tempDatabase = createTempDatabasePath();
 
     try {
@@ -316,10 +316,18 @@ describe("createRunStore", () => {
         rejectedReview.id,
         "rejected"
       );
-      const purchasedResult = store.transitionRunTrackReviewStatus(
-        approvedReview.id,
-        "purchased"
-      );
+      const purchasedResult = store.completePurchasedRunTrackReview({
+        artifact: {
+          contentType: "audio/mpeg",
+          fileExtension: "mp3",
+          fileName: "track-one.mp3",
+          format: "mp3",
+          localFilePath: "/tmp/track-one.mp3",
+          sha256: "abc123",
+          sizeBytes: 1234
+        },
+        reviewId: approvedReview.id
+      });
       const persistedRun = store.getRun(run.id);
 
       expect(approvedResult.status).toBe("approved");
@@ -328,7 +336,7 @@ describe("createRunStore", () => {
       expect(persistedRun).toEqual(
         expect.objectContaining({
           id: run.id,
-          status: "awaiting-approval"
+          status: "packaging"
         })
       );
       expect(
@@ -343,9 +351,54 @@ describe("createRunStore", () => {
             [track.sourcePosition, track.status] satisfies [number, RunTrackStatus]
         )
       ).toEqual([
-        [1, "awaiting-approval"],
+        [1, "acquired"],
         [2, "missed"]
       ]);
+    } finally {
+      tempDatabase.cleanup();
+    }
+  });
+
+  it("requires completePurchasedRunTrackReview for purchased review transitions", () => {
+    const tempDatabase = createTempDatabasePath();
+
+    try {
+      const store = createRunStore({ databasePath: tempDatabase.databasePath });
+      const run = store.createRun({
+        playlistTitle: "Purchased Transition Guard",
+        playlistUrl: "https://soundcloud.com/sets/purchased-transition-guard",
+        sourceType: "soundcloud"
+      });
+      const [track] = store.replaceRunTracks(run.id, [
+        {
+          artist: "Artist One",
+          sourcePosition: 1,
+          title: "Track One"
+        }
+      ]);
+
+      store.transitionRunStatus(run.id, "ingesting");
+      store.transitionRunStatus(run.id, "matching");
+
+      const review = store.queueRunTrackReview({
+        authorizationBasis: "purchase-entitlement",
+        availableFormats: ["mp3"],
+        candidateId: "beatport-guard-1",
+        mixLabel: null,
+        priceTier: "paid",
+        providerKey: "beatport",
+        providerName: "Beatport",
+        providerUrl: "https://www.beatport.com/track/track-one/guard-1",
+        queueName: "beatport-review",
+        runTrackId: track.id,
+        summary: "Queued after all automatic free-source providers missed."
+      });
+
+      expect(() =>
+        store.transitionRunTrackReviewStatus(review.id, "purchased")
+      ).toThrowError(
+        "Use completePurchasedRunTrackReview to persist a purchased owned-download acquisition."
+      );
     } finally {
       tempDatabase.cleanup();
     }

--- a/src/features/runs/run-store.ts
+++ b/src/features/runs/run-store.ts
@@ -2,12 +2,20 @@ import { mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
-import { buildMissedArtifactSourceNote } from "@/features/artifacts/run-track-artifact-source-note";
+import {
+  buildAcquiredArtifactSourceNote,
+  buildMissedArtifactSourceNote
+} from "@/features/artifacts/run-track-artifact-source-note";
 import type {
+  ProviderArtifactMetadata,
   ProviderArtifactFormat,
   ProviderAuthorizationBasis,
   ProviderPriceTier
 } from "@/features/providers/provider-registry";
+import type {
+  TrackAcceptedDecision,
+  TrackAudioFormat
+} from "@/features/tracks/canonical-track";
 
 export const runStatuses = [
   "queued",
@@ -231,6 +239,11 @@ export type QueueRunTrackReviewInput = {
   summary: string;
 };
 
+export type CompletePurchasedRunTrackReviewInput = {
+  artifact: ProviderArtifactMetadata;
+  reviewId: string;
+};
+
 type RunAggregateRow = RunRow & {
   artifact_count: number;
   track_count: number;
@@ -257,9 +270,9 @@ const allowedRunTrackReviewStatusTransitions: Record<
   RunTrackReviewStatus,
   RunTrackReviewStatus[]
 > = {
-  approved: ["rejected", "purchased"],
+  approved: ["rejected"],
   purchased: [],
-  queued: ["approved", "rejected", "purchased"],
+  queued: ["approved", "rejected"],
   rejected: []
 };
 
@@ -570,6 +583,64 @@ export function createRunStore(options: RunStoreOptions = {}) {
     );
   }
 
+  function buildPurchasedReviewAcquisitionNote(
+    review: RunTrackReviewRow,
+    artifact: ProviderArtifactMetadata
+  ) {
+    return JSON.stringify(
+      buildAcquiredArtifactSourceNote({
+        artifact,
+        provider: {
+          authorizationBasis: review.authorization_basis,
+          priceTier: review.price_tier,
+          providerId: review.provider_key,
+          providerName: review.provider_name,
+          providerUrl: review.provider_url
+        },
+        selection: {
+          details:
+            "Beatport paid review confirmed the owned download and captured it for packaging.",
+          reason: resolvePurchasedReviewSelectionReason(review.mix_label),
+          selectedFormat: resolvePurchasedReviewSelectedFormat(
+            artifact.format,
+            review.available_formats
+          )
+        }
+      })
+    );
+  }
+
+  function resolvePurchasedReviewSelectionReason(
+    mixLabel: string | null
+  ): TrackAcceptedDecision["reason"] {
+    const normalizedMixLabel = mixLabel?.trim().toLowerCase();
+
+    if (normalizedMixLabel === "extended mix") {
+      return "accepted-extended-mix";
+    }
+
+    if (normalizedMixLabel === "original mix") {
+      return "accepted-original-mix";
+    }
+
+    return "accepted-base-version-fallback";
+  }
+
+  function resolvePurchasedReviewSelectedFormat(
+    artifactFormat: ProviderArtifactFormat,
+    availableFormats: string
+  ): TrackAudioFormat | null {
+    if (artifactFormat === "mp3" || artifactFormat === "wav") {
+      return artifactFormat;
+    }
+
+    const candidateFormat = (JSON.parse(availableFormats) as ProviderArtifactFormat[]).find(
+      (format): format is TrackAudioFormat => format === "mp3" || format === "wav"
+    );
+
+    return candidateFormat ?? null;
+  }
+
   function syncRunStatusForReviewQueue(runId: string, now: string) {
     const currentRun = getRunOrThrow(runId);
     const unresolvedReviews = database
@@ -580,7 +651,7 @@ export function createRunStore(options: RunStoreOptions = {}) {
           INNER JOIN run_tracks
             ON run_tracks.id = run_track_reviews.run_track_id
           WHERE run_tracks.run_id = ?
-            AND run_track_reviews.status IN ('queued', 'approved', 'purchased')
+            AND run_track_reviews.status IN ('queued', 'approved')
         `
       )
       .get(runId) as { count: number };
@@ -756,6 +827,21 @@ export function createRunStore(options: RunStoreOptions = {}) {
         trackCount: summary.trackCount,
         updatedAt: summary.updatedAt
       };
+    },
+
+    listQueuedRunIds(): string[] {
+      const rows = database
+        .prepare(
+          `
+            SELECT id
+            FROM runs
+            WHERE status = 'queued'
+            ORDER BY updated_at ASC, created_at ASC
+          `
+        )
+        .all() as Array<{ id: string }>;
+
+      return rows.map((row) => row.id);
     },
 
     listRuns(limit = 10): RunSummary[] {
@@ -1092,11 +1178,88 @@ export function createRunStore(options: RunStoreOptions = {}) {
       return attempts.map(mapRunTrackAcquisitionAttempt);
     },
 
+    completePurchasedRunTrackReview(input: CompletePurchasedRunTrackReviewInput) {
+      const review = readRunTrackReview(input.reviewId);
+
+      if (!review) {
+        throw new Error(`Run track review not found: ${input.reviewId}`);
+      }
+
+      if (review.status !== "queued" && review.status !== "approved") {
+        throw new Error(
+          `Purchased reviews can only be completed from queued or approved status: ${review.status}`
+        );
+      }
+
+      const track = readRunTrack(review.run_track_id);
+
+      if (!track) {
+        throw new Error(`Run track not found: ${review.run_track_id}`);
+      }
+
+      const now = getTimestamp();
+      const note = buildPurchasedReviewAcquisitionNote(review, input.artifact);
+
+      database.exec("BEGIN");
+
+      try {
+        database
+          .prepare(
+            `
+              UPDATE run_track_reviews
+              SET status = ?,
+                  updated_at = ?
+              WHERE id = ?
+            `
+          )
+          .run("purchased", now, input.reviewId);
+        database
+          .prepare(
+            `
+              UPDATE run_tracks
+              SET status = ?,
+                  updated_at = ?
+              WHERE id = ?
+            `
+          )
+          .run("acquired", now, track.id);
+        insertAcquisitionAttemptDirect({
+          note,
+          now,
+          outcome: "matched",
+          providerKey: review.provider_key,
+          runTrackId: track.id
+        });
+        database
+          .prepare("UPDATE runs SET updated_at = ? WHERE id = ?")
+          .run(now, track.run_id);
+        syncRunStatusForReviewQueue(track.run_id, now);
+        database.exec("COMMIT");
+      } catch (error) {
+        database.exec("ROLLBACK");
+        throw error;
+      }
+
+      const updatedReview = readRunTrackReview(input.reviewId);
+
+      if (!updatedReview) {
+        throw new Error(`Run track review not found after update: ${input.reviewId}`);
+      }
+
+      return mapRunTrackReview(updatedReview);
+    },
+
     transitionRunTrackReviewStatus(
       reviewId: string,
       nextStatus: RunTrackReviewStatus
     ) {
       assertValidRunTrackReviewStatus(nextStatus);
+
+      if (nextStatus === "purchased") {
+        throw new Error(
+          "Use completePurchasedRunTrackReview to persist a purchased owned-download acquisition."
+        );
+      }
 
       const review = readRunTrackReview(reviewId);
 
@@ -1179,7 +1342,7 @@ export function createRunStore(options: RunStoreOptions = {}) {
       const now = getTimestamp();
       const completedAt = nextStatus === "completed" ? now : null;
       const failedAt = nextStatus === "failed" ? now : null;
-      const resumeAfterStatus = nextStatus === "queued" ? currentRun.resume_after_status : null;
+      const resumeAfterStatus = currentRun.resume_after_status;
 
       database
         .prepare(
@@ -1209,6 +1372,49 @@ export function createRunStore(options: RunStoreOptions = {}) {
       }
 
       return run;
+    },
+
+    resumeRun(runId: string): RunDetail {
+      const currentRun = getRunOrThrow(runId);
+
+      if (currentRun.status !== "queued" || !currentRun.resume_after_status) {
+        const existingRun = this.getRun(runId);
+
+        if (!existingRun) {
+          throw new Error(`Run not found after resume lookup: ${runId}`);
+        }
+
+        return existingRun;
+      }
+
+      if (!resumableRunStatuses.includes(currentRun.resume_after_status)) {
+        throw new Error(
+          `Run cannot resume from persisted status: ${currentRun.resume_after_status}`
+        );
+      }
+
+      const now = getTimestamp();
+
+      database
+        .prepare(
+          `
+            UPDATE runs
+            SET status = ?,
+                updated_at = ?,
+                completed_at = NULL,
+                failed_at = NULL
+            WHERE id = ?
+          `
+        )
+        .run(currentRun.resume_after_status, now, runId);
+
+      const resumedRun = this.getRun(runId);
+
+      if (!resumedRun) {
+        throw new Error(`Run not found after resume: ${runId}`);
+      }
+
+      return resumedRun;
     },
 
     updateRunTrackStatus(trackId: string, nextStatus: RunTrackStatus): RunTrack {

--- a/src/features/runs/run-worker.test.ts
+++ b/src/features/runs/run-worker.test.ts
@@ -82,6 +82,73 @@ function buildMatchingCandidate(
 }
 
 describe("createRunWorker", () => {
+  it("automatically schedules persisted queued runs when the worker boots after a restart", async () => {
+    const tempWorkspace = createTempWorkspace();
+    let initialStore: RunStore | undefined;
+    let resumedStore: RunStore | undefined;
+
+    try {
+      initialStore = createRunStore({
+        databasePath: tempWorkspace.databasePath
+      });
+
+      const interruptedRun = createQueuedRun(
+        initialStore,
+        "https://open.spotify.com/playlist/37i9dQZF1DWVRSukIED0e9",
+        [
+          {
+            artist: "Anyma",
+            sourcePosition: 1,
+            title: "Consciousness",
+            version: "Extended Mix"
+          }
+        ]
+      );
+
+      initialStore.transitionRunStatus(interruptedRun.id, "ingesting");
+      initialStore.transitionRunStatus(interruptedRun.id, "matching");
+      initialStore.close();
+      initialStore = undefined;
+
+      resumedStore = createRunStore({
+        databasePath: tempWorkspace.databasePath
+      });
+
+      const processQueuedRun = vi.fn(async (runId: string) => {
+        expect(resumedStore?.getRunStatusSnapshot(runId)).toEqual(
+          expect.objectContaining({
+            resumeAfterStatus: "matching",
+            status: "queued"
+          })
+        );
+
+        resumedStore?.transitionRunStatus(runId, "ingesting");
+        resumedStore?.transitionRunStatus(runId, "matching");
+        resumedStore?.transitionRunStatus(runId, "failed");
+
+        return resumedStore?.getRun(runId) ?? null;
+      });
+
+      const worker = createRunWorker({
+        processQueuedRun: processQueuedRun as typeof executeQueuedRun,
+        runStore: resumedStore
+      });
+
+      await worker.waitForIdle();
+
+      expect(processQueuedRun).toHaveBeenCalledTimes(1);
+      expect(resumedStore.getRun(interruptedRun.id)).toEqual(
+        expect.objectContaining({
+          status: "failed"
+        })
+      );
+    } finally {
+      initialStore?.close();
+      resumedStore?.close();
+      tempWorkspace.cleanup();
+    }
+  });
+
   it("drains queued runs through the existing orchestration lifecycle", async () => {
     const tempWorkspace = createTempWorkspace();
     const runStore = createRunStore({ databasePath: tempWorkspace.databasePath });

--- a/src/features/runs/run-worker.ts
+++ b/src/features/runs/run-worker.ts
@@ -1,5 +1,5 @@
 import type { ProviderRegistry } from "@/features/providers/provider-registry";
-import type { RunStore } from "@/features/runs/run-store";
+import { getRunStore, type RunStore } from "@/features/runs/run-store";
 
 import { executeQueuedRun } from "@/features/runs/live-run-orchestrator";
 
@@ -24,6 +24,7 @@ type GlobalWithRunWorker = typeof globalThis & {
 export function createRunWorker(
   dependencies: CreateRunWorkerDependencies = {}
 ): RunWorker {
+  const runStore = dependencies.runStore ?? getRunStore();
   const pendingRunIds = new Set<string>();
   const activeRunIds = new Set<string>();
   const processQueuedRun = dependencies.processQueuedRun ?? executeQueuedRun;
@@ -51,7 +52,10 @@ export function createRunWorker(
             activeRunIds.add(runId);
 
             try {
-              await processQueuedRun(runId, dependencies);
+              await processQueuedRun(runId, {
+                ...dependencies,
+                runStore
+              });
             } catch {
               continue;
             } finally {
@@ -67,7 +71,7 @@ export function createRunWorker(
     return drainPromise;
   }
 
-  return {
+  const worker: RunWorker = {
     scheduleRun(runId: string) {
       if (!activeRunIds.has(runId)) {
         pendingRunIds.add(runId);
@@ -82,6 +86,12 @@ export function createRunWorker(
       }
     }
   };
+
+  for (const runId of runStore.listQueuedRunIds()) {
+    void worker.scheduleRun(runId);
+  }
+
+  return worker;
 }
 
 export function getSharedRunWorker() {

--- a/tests/e2e/integrated-flow.spec.ts
+++ b/tests/e2e/integrated-flow.spec.ts
@@ -101,7 +101,7 @@ test("covers a Beatport review-lane run via deterministic fixture mode through t
   await expect(page.getByText(/awaiting operator review/i).first()).toBeVisible();
 });
 
-test("shows persisted resume metadata after the run store is restarted", async ({
+test("resumes interrupted runs after the run store is restarted", async ({
   page,
   request
 }) => {
@@ -116,8 +116,11 @@ test("shows persisted resume metadata after the run store is restarted", async (
     .locator("article")
     .filter({ hasText: seedPayload.run.playlistTitle ?? seedPayload.run.playlistUrl });
 
-  await expect(runCard).toContainText(/queued/i);
   await expect(runCard).toContainText(/matching/i);
+  await expect(runCard).toContainText(/completed/i, {
+    timeout: 15_000
+  });
+  await expect(runCard).not.toContainText(/queued/i);
   await expect(
     runCard.getByRole("link", {
       name: new RegExp(


### PR DESCRIPTION
**@worker-02**

## Summary
- replace fabricated Beatport `/track/<slug>/<slug>` review targets with persisted search URLs
- stop reconstructing purchased candidates with a synthetic `providerTrackId`
- add regression coverage proving the purchased flow reuses authoritative review data

## Verification
- `npx vitest run src/features/providers/beatport.test.ts 'src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts'`
- `npm run lint`
- `npm run build`

Closes #89
