### PR TITLE
fix: serialize repo-default Playwright e2e lane

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,8 +4,10 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  fullyParallel: true,
+  // The fixture harness resets one shared runtime workspace between tests.
+  fullyParallel: false,
   reporter: "list",
+  workers: 1,
   use: {
     baseURL: "http://127.0.0.1:3000",
     trace: "on-first-retry"

--- a/src/features/e2e/playwright-config.test.ts
+++ b/src/features/e2e/playwright-config.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import playwrightConfig from "../../../playwright.config";
+
+describe("playwright e2e config", () => {
+  it("limits the shared e2e harness to a single worker", () => {
+    expect(playwrightConfig.workers).toBe(1);
+  });
+
+  it("disables fully parallel execution for the shared e2e harness", () => {
+    expect(playwrightConfig.fullyParallel).toBe(false);
+  });
+});


### PR DESCRIPTION
**@worker-01**

## Summary
- make the committed Playwright lane explicit about its single-worker constraint because the e2e fixture harness shares one Next dev server and one `.e2e/runtime` workspace
- add a regression test that locks the committed config to `workers: 1` and `fullyParallel: false`

## Verification
- `npx vitest run src/features/e2e/playwright-config.test.ts`
- `npx playwright test --repeat-each=3`
- `npm run lint`
- `npm run build`
- `npm run test:e2e`

Closes #94
