### PR TITLE
test: stabilize browser-backed review flow tests

### DIFF
--- a/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
+++ b/src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts
@@ -43,283 +43,285 @@ async function withTempWorkspace(
 }
 
 describe("/api/runs/[runId]/review-queue/[reviewId]", () => {
-  it("acquires a purchased Beatport review and completes the run through existing artifacts", async () => {
-    await withTempWorkspace(async (workspaceRoot) => {
-      const fixtureServer = await startBeatportFixtureServer();
-      const browserSessionService = new BrowserSessionService({ workspaceRoot });
+  it(
+    "acquires a purchased Beatport review and completes the run through existing artifacts",
+    async () => {
+      await withTempWorkspace(async (workspaceRoot) => {
+        const fixtureServer = await startBeatportFixtureServer();
+        const browserSessionService = new BrowserSessionService({ workspaceRoot });
 
-      try {
-        const beatportProvider = createBeatportProvider({
-          baseUrl: fixtureServer.baseUrl,
-          browserSessionService
-        });
-        const reviewTarget = `${fixtureServer.baseUrl}/track/track-one/route-1`;
-        const searchResult = await beatportProvider.search({
-          track: buildCanonicalTrack({
-            artistName: "Artist One",
-            title: "Track One"
-          })
-        });
+        try {
+          const beatportProvider = createBeatportProvider({
+            baseUrl: fixtureServer.baseUrl,
+            browserSessionService
+          });
+          const reviewTarget = `${fixtureServer.baseUrl}/track/track-one/route-1`;
+          const searchResult = await beatportProvider.search({
+            track: buildCanonicalTrack({
+              artistName: "Artist One",
+              title: "Track One"
+            })
+          });
 
-        if (searchResult.outcome !== "candidates") {
-          throw new Error("Expected Beatport search to return a candidate.");
-        }
+          if (searchResult.outcome !== "candidates") {
+            throw new Error("Expected Beatport search to return a candidate.");
+          }
 
-        vi.resetModules();
-        vi.doMock("@/features/providers/live-provider-registry", () => ({
-          createLiveProviderRegistry: () => ({
-            get(providerId: string) {
-              if (providerId !== "beatport") {
-                return null;
-              }
+          vi.resetModules();
+          vi.doMock("@/features/providers/live-provider-registry", () => ({
+            createLiveProviderRegistry: () => ({
+              get(providerId: string) {
+                if (providerId !== "beatport") {
+                  return null;
+                }
 
-              return {
-                acquirePurchased: async ({
-                  candidate
-                }: {
-                  candidate: {
-                    candidateId: string;
-                    provenance: {
-                      providerTrackId?: string;
-                      providerUrl?: string;
+                return {
+                  acquirePurchased: async ({
+                    candidate
+                  }: {
+                    candidate: {
+                      candidateId: string;
+                      provenance: {
+                        providerTrackId?: string;
+                        providerUrl?: string;
+                      };
                     };
-                  };
-                }) => {
-                  if (
-                    candidate.provenance.providerTrackId !== undefined ||
-                    candidate.provenance.providerUrl !== reviewTarget
-                  ) {
+                  }) => {
+                    if (
+                      candidate.provenance.providerTrackId !== undefined ||
+                      candidate.provenance.providerUrl !== reviewTarget
+                    ) {
+                      return {
+                        outcome: "rejected" as const,
+                        candidate,
+                        rejection: {
+                          detail:
+                            "Purchased acquisition must reuse the authoritative Beatport review target.",
+                          providerId: "beatport",
+                          providerName: "Beatport",
+                          reason: "download-artifact-missing" as const,
+                          retryable: true
+                        }
+                      };
+                    }
+
+                    const artifactDirectory = path.join(workspaceRoot, "downloads");
+                    const artifactBody = Buffer.from(
+                      `owned artifact for ${candidate.candidateId}\n`,
+                      "utf8"
+                    );
+                    const artifactPath = path.join(artifactDirectory, "track-one.mp3");
+
+                    mkdirSync(artifactDirectory, { recursive: true });
+                    writeFileSync(artifactPath, artifactBody);
+
                     return {
-                      outcome: "rejected" as const,
-                      candidate,
-                      rejection: {
-                        detail:
-                          "Purchased acquisition must reuse the authoritative Beatport review target.",
-                        providerId: "beatport",
-                        providerName: "Beatport",
-                        reason: "download-artifact-missing" as const,
-                        retryable: true
-                      }
+                      outcome: "acquired" as const,
+                      artifact: {
+                        contentType: "audio/mpeg",
+                        fileExtension: "mp3",
+                        fileName: "track-one.mp3",
+                        format: "mp3" as const,
+                        localFilePath: artifactPath,
+                        sha256: "abc123",
+                        sizeBytes: artifactBody.byteLength
+                      },
+                      candidate
                     };
                   }
+                };
+              }
+            })
+          }));
 
-                  const artifactDirectory = path.join(workspaceRoot, "downloads");
-                  const artifactBody = Buffer.from(
-                    `owned artifact for ${candidate.candidateId}\n`,
-                    "utf8"
-                  );
-                  const artifactPath = path.join(artifactDirectory, "track-one.mp3");
-
-                  mkdirSync(artifactDirectory, { recursive: true });
-                  writeFileSync(artifactPath, artifactBody);
-
-                  return {
-                    outcome: "acquired" as const,
-                    artifact: {
-                      contentType: "audio/mpeg",
-                      fileExtension: "mp3",
-                      fileName: "track-one.mp3",
-                      format: "mp3" as const,
-                      localFilePath: artifactPath,
-                      sha256: "abc123",
-                      sizeBytes: artifactBody.byteLength
-                    },
-                    candidate
-                  };
-                }
-              };
+          const [{ POST }, runStoreModule, artifactsModule] = await Promise.all([
+            import("./route"),
+            import("@/features/runs/run-store"),
+            import("@/features/artifacts/run-artifacts")
+          ]);
+          const store = runStoreModule.getRunStore();
+          const run = store.createRun({
+            playlistTitle: "Beatport Route Flow",
+            playlistUrl: "https://soundcloud.com/sets/beatport-route-flow",
+            sourceType: "soundcloud"
+          });
+          const tracks = store.replaceRunTracks(run.id, [
+            {
+              artist: "Artist One",
+              sourcePosition: 1,
+              title: "Track One"
+            },
+            {
+              artist: "Artist Two",
+              sourcePosition: 2,
+              title: "Track Two"
             }
-          })
-        }));
+          ]);
 
-        const [{ POST }, runStoreModule, artifactsModule] = await Promise.all([
-          import("./route"),
-          import("@/features/runs/run-store"),
-          import("@/features/artifacts/run-artifacts")
-        ]);
-        const store = runStoreModule.getRunStore();
-        const run = store.createRun({
-          playlistTitle: "Beatport Route Flow",
-          playlistUrl: "https://soundcloud.com/sets/beatport-route-flow",
-          sourceType: "soundcloud"
-        });
-        const tracks = store.replaceRunTracks(run.id, [
-          {
-            artist: "Artist One",
-            sourcePosition: 1,
-            title: "Track One"
-          },
-          {
-            artist: "Artist Two",
-            sourcePosition: 2,
-            title: "Track Two"
-          }
-        ]);
+          store.transitionRunStatus(run.id, "ingesting");
+          store.transitionRunStatus(run.id, "matching");
 
-        store.transitionRunStatus(run.id, "ingesting");
-        store.transitionRunStatus(run.id, "matching");
+          const reviewOne = store.queueRunTrackReview({
+            authorizationBasis: "purchase-entitlement",
+            availableFormats: ["mp3", "wav"],
+            candidateId: searchResult.candidates[0].candidateId,
+            mixLabel: searchResult.candidates[0].mixLabel,
+            priceTier: "paid",
+            providerKey: "beatport",
+            providerName: "Beatport",
+            providerUrl: searchResult.candidates[0].provenance.providerUrl,
+            queueName: "beatport-review",
+            runTrackId: tracks[0].id,
+            summary: "Queued after all automatic free-source providers missed."
+          });
+          const reviewTwo = store.queueRunTrackReview({
+            authorizationBasis: "purchase-entitlement",
+            availableFormats: ["mp3"],
+            candidateId: "beatport-route-2",
+            mixLabel: null,
+            priceTier: "paid",
+            providerKey: "beatport",
+            providerName: "Beatport",
+            providerUrl: "https://www.beatport.com/track/track-two/route-2",
+            queueName: "beatport-review",
+            runTrackId: tracks[1].id,
+            summary: "Queued after all automatic free-source providers missed."
+          });
 
-        const reviewOne = store.queueRunTrackReview({
-          authorizationBasis: "purchase-entitlement",
-          availableFormats: ["mp3", "wav"],
-          candidateId: searchResult.candidates[0].candidateId,
-          mixLabel: searchResult.candidates[0].mixLabel,
-          priceTier: "paid",
-          providerKey: "beatport",
-          providerName: "Beatport",
-          providerUrl: searchResult.candidates[0].provenance.providerUrl,
-          queueName: "beatport-review",
-          runTrackId: tracks[0].id,
-          summary: "Queued after all automatic free-source providers missed."
-        });
-        const reviewTwo = store.queueRunTrackReview({
-          authorizationBasis: "purchase-entitlement",
-          availableFormats: ["mp3"],
-          candidateId: "beatport-route-2",
-          mixLabel: null,
-          priceTier: "paid",
-          providerKey: "beatport",
-          providerName: "Beatport",
-          providerUrl: "https://www.beatport.com/track/track-two/route-2",
-          queueName: "beatport-review",
-          runTrackId: tracks[1].id,
-          summary: "Queued after all automatic free-source providers missed."
-        });
+          const approveResponse = await POST(
+            new Request(`http://localhost/api/runs/${run.id}/review-queue/${reviewOne.id}`, {
+              body: JSON.stringify({ action: "approve" }),
+              headers: {
+                "content-type": "application/json"
+              },
+              method: "POST"
+            }),
+            {
+              params: Promise.resolve({
+                reviewId: reviewOne.id,
+                runId: run.id
+              })
+            }
+          );
+          const purchasedResponse = await POST(
+            new Request(`http://localhost/api/runs/${run.id}/review-queue/${reviewOne.id}`, {
+              body: JSON.stringify({ action: "purchased" }),
+              headers: {
+                "content-type": "application/json"
+              },
+              method: "POST"
+            }),
+            {
+              params: Promise.resolve({
+                reviewId: reviewOne.id,
+                runId: run.id
+              })
+            }
+          );
+          const rejectResponse = await POST(
+            new Request(`http://localhost/api/runs/${run.id}/review-queue/${reviewTwo.id}`, {
+              body: JSON.stringify({ action: "reject" }),
+              headers: {
+                "content-type": "application/json"
+              },
+              method: "POST"
+            }),
+            {
+              params: Promise.resolve({
+                reviewId: reviewTwo.id,
+                runId: run.id
+              })
+            }
+          );
 
-        const approveResponse = await POST(
-          new Request(`http://localhost/api/runs/${run.id}/review-queue/${reviewOne.id}`, {
-            body: JSON.stringify({ action: "approve" }),
-            headers: {
-              "content-type": "application/json"
-            },
-            method: "POST"
-          }),
-          {
-            params: Promise.resolve({
-              reviewId: reviewOne.id,
-              runId: run.id
+          expect(approveResponse.status).toBe(200);
+          await expect(approveResponse.json()).resolves.toEqual(
+            expect.objectContaining({
+              id: reviewOne.id,
+              status: "approved"
             })
-          }
-        );
-        const purchasedResponse = await POST(
-          new Request(`http://localhost/api/runs/${run.id}/review-queue/${reviewOne.id}`, {
-            body: JSON.stringify({ action: "purchased" }),
-            headers: {
-              "content-type": "application/json"
-            },
-            method: "POST"
-          }),
-          {
-            params: Promise.resolve({
-              reviewId: reviewOne.id,
-              runId: run.id
+          );
+          expect(purchasedResponse.status).toBe(200);
+          await expect(purchasedResponse.json()).resolves.toEqual(
+            expect.objectContaining({
+              id: reviewOne.id,
+              status: "purchased"
             })
-          }
-        );
-        const rejectResponse = await POST(
-          new Request(`http://localhost/api/runs/${run.id}/review-queue/${reviewTwo.id}`, {
-            body: JSON.stringify({ action: "reject" }),
-            headers: {
-              "content-type": "application/json"
-            },
-            method: "POST"
-          }),
-          {
-            params: Promise.resolve({
-              reviewId: reviewTwo.id,
-              runId: run.id
+          );
+          expect(rejectResponse.status).toBe(200);
+          await expect(rejectResponse.json()).resolves.toEqual(
+            expect.objectContaining({
+              id: reviewTwo.id,
+              status: "rejected"
             })
-          }
-        );
+          );
 
-        expect(approveResponse.status).toBe(200);
-        await expect(approveResponse.json()).resolves.toEqual(
-          expect.objectContaining({
-            id: reviewOne.id,
-            status: "approved"
-          })
-        );
-        expect(purchasedResponse.status).toBe(200);
-        await expect(purchasedResponse.json()).resolves.toEqual(
-          expect.objectContaining({
-            id: reviewOne.id,
-            status: "purchased"
-          })
-        );
-        expect(rejectResponse.status).toBe(200);
-        await expect(rejectResponse.json()).resolves.toEqual(
-          expect.objectContaining({
-            id: reviewTwo.id,
-            status: "rejected"
-          })
-        );
+          expect(store.getRun(run.id)).toEqual(
+            expect.objectContaining({
+              id: run.id,
+              status: "completed"
+            })
+          );
+          expect(
+            store
+              .getRun(run.id)
+              ?.reviewQueue.map((review) => [review.candidateId, review.status])
+          ).toEqual([
+            ["beatport-artist-one-track-one", "purchased"],
+            ["beatport-route-2", "rejected"]
+          ]);
+          expect(
+            store
+              .getRun(run.id)
+              ?.tracks.map((track) => [track.sourcePosition, track.status])
+          ).toEqual([
+            [1, "acquired"],
+            [2, "missed"]
+          ]);
+          expect(
+            [...((store.getRun(run.id)?.artifacts ?? []).map((artifact) => artifact.kind))].sort()
+          ).toEqual(["downloads-zip", "manifest-json", "misses-txt"]);
+          expect(
+            artifactsModule
+              .listRunArtifactDownloads({
+                runId: run.id,
+                runStore: store
+              })
+              .map((artifact) => artifact.kind)
+          ).toEqual(["downloads-zip", "misses-txt", "manifest-json"]);
 
-        expect(store.getRun(run.id)).toEqual(
-          expect.objectContaining({
-            id: run.id,
-            status: "completed"
-          })
-        );
-        expect(
-          store
+          const manifestArtifact = store
             .getRun(run.id)
-            ?.reviewQueue.map((review) => [review.candidateId, review.status])
-        ).toEqual([
-          ["beatport-artist-one-track-one", "purchased"],
-          ["beatport-route-2", "rejected"]
-        ]);
-        expect(
-          store
-            .getRun(run.id)
-            ?.tracks.map((track) => [track.sourcePosition, track.status])
-        ).toEqual([
-          [1, "acquired"],
-          [2, "missed"]
-        ]);
-        expect([...((store.getRun(run.id)?.artifacts ?? []).map((artifact) => artifact.kind))].sort()).toEqual([
-          "downloads-zip",
-          "manifest-json",
-          "misses-txt"
-        ]);
-        expect(
-          artifactsModule
-            .listRunArtifactDownloads({
-              runId: run.id,
-              runStore: store
-            })
-            .map((artifact) => artifact.kind)
-        ).toEqual(["downloads-zip", "misses-txt", "manifest-json"]);
+            ?.artifacts.find((artifact) => artifact.kind === "manifest-json");
 
-        const manifestArtifact = store
-          .getRun(run.id)
-          ?.artifacts.find((artifact) => artifact.kind === "manifest-json");
+          expect(manifestArtifact).toBeDefined();
 
-        expect(manifestArtifact).toBeDefined();
-
-        const manifest = JSON.parse(
-          readFileSync(
-            path.join(workspaceRoot, manifestArtifact?.relativePath ?? ""),
-            "utf8"
-          )
-        ) as {
-          summary: {
-            acquiredCount: number;
-            missCount: number;
-            trackCount: number;
+          const manifest = JSON.parse(
+            readFileSync(
+              path.join(workspaceRoot, manifestArtifact?.relativePath ?? ""),
+              "utf8"
+            )
+          ) as {
+            summary: {
+              acquiredCount: number;
+              missCount: number;
+              trackCount: number;
+            };
           };
-        };
 
-        expect(manifest.summary).toEqual({
-          acquiredCount: 1,
-          missCount: 1,
-          trackCount: 2
-        });
-      } finally {
-        await browserSessionService.shutdown();
-        await fixtureServer.close();
-      }
-    });
-  });
+          expect(manifest.summary).toEqual({
+            acquiredCount: 1,
+            missCount: 1,
+            trackCount: 2
+          });
+        } finally {
+          await browserSessionService.shutdown();
+          await fixtureServer.close();
+        }
+      });
+    },
+    15_000
+  );
 
   it("returns 409 when purchased acquisition fails and leaves the review queued", async () => {
     await withTempWorkspace(async () => {

--- a/src/features/browser/browser-session-service.test.ts
+++ b/src/features/browser/browser-session-service.test.ts
@@ -58,100 +58,108 @@ describe("BrowserSessionService", () => {
     15_000
   );
 
-  it("surfaces typed missing and expired auth state failures", async () => {
-    const workspaceRoot = await mkdtemp(
-      path.join(os.tmpdir(), "music-downloader-browser-session-auth-")
-    );
-    const service = new BrowserSessionService({ workspaceRoot });
-
-    try {
-      await expect(
-        service.requireAuthenticatedSession("missing-session")
-      ).rejects.toBeInstanceOf(MissingBrowserSessionStateError);
-
-      const unknownAuthSession = await service.openSession({
-        sessionName: "beatport-review"
-      });
-      await unknownAuthSession.close();
-
-      await expect(
-        service.requireAuthenticatedSession("beatport-review")
-      ).rejects.toBeInstanceOf(MissingBrowserSessionAuthStateError);
-
-      const expiredAt = "2026-03-31T05:00:00.000Z";
-      const expiredSession = await service.openSession({
-        sessionName: "expired-session",
-        authState: {
-          expiredAt,
-          providerId: "beatport",
-          reason: "fixture login expired",
-          status: "expired"
-        }
-      });
-      await expiredSession.close();
-
-      await expect(
-        service.requireAuthenticatedSession("expired-session")
-      ).rejects.toEqual(
-        expect.objectContaining({
-          code: "expired-session-auth-state",
-          expiredAt,
-          sessionName: "expired-session"
-        })
+  it(
+    "surfaces typed missing and expired auth state failures",
+    async () => {
+      const workspaceRoot = await mkdtemp(
+        path.join(os.tmpdir(), "music-downloader-browser-session-auth-")
       );
-    } finally {
-      await service.shutdown();
-      await rm(workspaceRoot, { force: true, recursive: true });
-    }
-  });
+      const service = new BrowserSessionService({ workspaceRoot });
 
-  it("wraps navigation, screenshots, and downloads behind provider helpers", async () => {
-    const workspaceRoot = await mkdtemp(
-      path.join(os.tmpdir(), "music-downloader-browser-session-helpers-")
-    );
-    const fixtureServer = await startFixtureServer();
-    const service = new BrowserSessionService({ workspaceRoot });
+      try {
+        await expect(
+          service.requireAuthenticatedSession("missing-session")
+        ).rejects.toBeInstanceOf(MissingBrowserSessionStateError);
 
-    try {
-      const session = await service.openSession({
-        sessionName: "helper-fixture",
-        authState: {
-          authenticatedAt: "2026-03-31T05:00:00.000Z",
-          providerId: "fixture-provider",
-          status: "authenticated"
-        }
-      });
+        const unknownAuthSession = await service.openSession({
+          sessionName: "beatport-review"
+        });
+        await unknownAuthSession.close();
 
-      const visit = await session.navigate({ url: fixtureServer.url("/download") });
-      expect(visit).toEqual({
-        status: 200,
-        url: fixtureServer.url("/download")
-      });
+        await expect(
+          service.requireAuthenticatedSession("beatport-review")
+        ).rejects.toBeInstanceOf(MissingBrowserSessionAuthStateError);
 
-      const screenshotPath = path.join(workspaceRoot, "artifacts", "fixture.png");
-      const screenshot = await session.takeScreenshot({ path: screenshotPath });
-      await access(screenshot.path);
+        const expiredAt = "2026-03-31T05:00:00.000Z";
+        const expiredSession = await service.openSession({
+          sessionName: "expired-session",
+          authState: {
+            expiredAt,
+            providerId: "beatport",
+            reason: "fixture login expired",
+            status: "expired"
+          }
+        });
+        await expiredSession.close();
 
-      const downloadPath = path.join(workspaceRoot, "artifacts", "fixture.txt");
-      const download = await session.captureDownload({
-        saveAs: downloadPath,
-        trigger: async (page) => {
-          await page.getByRole("link", { name: "Download fixture" }).click();
-        }
-      });
+        await expect(
+          service.requireAuthenticatedSession("expired-session")
+        ).rejects.toEqual(
+          expect.objectContaining({
+            code: "expired-session-auth-state",
+            expiredAt,
+            sessionName: "expired-session"
+          })
+        );
+      } finally {
+        await service.shutdown();
+        await rm(workspaceRoot, { force: true, recursive: true });
+      }
+    },
+    15_000
+  );
 
-      expect(download.suggestedFilename).toBe("fixture.txt");
-      expect(await readFile(download.path, "utf8")).toBe("fixture download contents\n");
-      await access(download.path);
-      expect(screenshot).toEqual({ path: screenshotPath });
+  it(
+    "wraps navigation, screenshots, and downloads behind provider helpers",
+    async () => {
+      const workspaceRoot = await mkdtemp(
+        path.join(os.tmpdir(), "music-downloader-browser-session-helpers-")
+      );
+      const fixtureServer = await startFixtureServer();
+      const service = new BrowserSessionService({ workspaceRoot });
 
-      await session.close();
-    } finally {
-      await service.shutdown();
-      await fixtureServer.close();
-      await rm(workspaceRoot, { force: true, recursive: true });
-    }
-  });
+      try {
+        const session = await service.openSession({
+          sessionName: "helper-fixture",
+          authState: {
+            authenticatedAt: "2026-03-31T05:00:00.000Z",
+            providerId: "fixture-provider",
+            status: "authenticated"
+          }
+        });
+
+        const visit = await session.navigate({ url: fixtureServer.url("/download") });
+        expect(visit).toEqual({
+          status: 200,
+          url: fixtureServer.url("/download")
+        });
+
+        const screenshotPath = path.join(workspaceRoot, "artifacts", "fixture.png");
+        const screenshot = await session.takeScreenshot({ path: screenshotPath });
+        await access(screenshot.path);
+
+        const downloadPath = path.join(workspaceRoot, "artifacts", "fixture.txt");
+        const download = await session.captureDownload({
+          saveAs: downloadPath,
+          trigger: async (page) => {
+            await page.getByRole("link", { name: "Download fixture" }).click();
+          }
+        });
+
+        expect(download.suggestedFilename).toBe("fixture.txt");
+        expect(await readFile(download.path, "utf8")).toBe("fixture download contents\n");
+        await access(download.path);
+        expect(screenshot).toEqual({ path: screenshotPath });
+
+        await session.close();
+      } finally {
+        await service.shutdown();
+        await fixtureServer.close();
+        await rm(workspaceRoot, { force: true, recursive: true });
+      }
+    },
+    15_000
+  );
 });
 
 async function startFixtureServer() {

--- a/src/features/providers/beatport.test.ts
+++ b/src/features/providers/beatport.test.ts
@@ -1,3 +1,5 @@
+/* @vitest-environment node */
+
 import { access, mkdtemp, readFile, rm } from "node:fs/promises";
 import {
   createServer,
@@ -17,7 +19,9 @@ import {
 import { createLiveProviderRegistry } from "./live-provider-registry";
 
 describe("createBeatportProvider", () => {
-  it("builds review queue candidates with an exact Beatport track target for paid fallback review", async () => {
+  it(
+    "builds review queue candidates with an exact Beatport track target for paid fallback review",
+    async () => {
     const workspaceRoot = await mkdtemp(
       path.join(os.tmpdir(), "music-downloader-beatport-provider-search-")
     );
@@ -82,9 +86,13 @@ describe("createBeatportProvider", () => {
       await fixtureServer.close();
       await rm(workspaceRoot, { force: true, recursive: true });
     }
-  });
+    },
+    15_000
+  );
 
-  it("acquires an owned Beatport download from the exact reviewed track page and prefers MP3 over WAV", async () => {
+  it(
+    "acquires an owned Beatport download from the exact reviewed track page and prefers MP3 over WAV",
+    async () => {
     const workspaceRoot = await mkdtemp(
       path.join(os.tmpdir(), "music-downloader-beatport-provider-owned-")
     );
@@ -144,7 +152,9 @@ describe("createBeatportProvider", () => {
       await fixtureServer.close();
       await rm(workspaceRoot, { force: true, recursive: true });
     }
-  });
+    },
+    15_000
+  );
 
   it("rejects owned downloads when no authenticated Beatport session is available", async () => {
     const workspaceRoot = await mkdtemp(


### PR DESCRIPTION
**@worker-03**

## Summary
- align the Beatport browser-backed provider tests with the existing provider-suite pattern by using the node test environment and explicit per-test timeouts
- add a targeted timeout to the purchased Beatport review route coverage so the end-to-end review completion path stays exercised under the full suite
- extend the same explicit timeout budget to browser-session service tests that launch persistent Playwright contexts under `npm test`

## Verification
- `npm test` (run twice)
- `npm run lint`
- `npm run build`
