### PR TITLE
test: isolate browser-backed vitest lane

### DIFF
--- a/src/test/vitest-project-scheduling.test.ts
+++ b/src/test/vitest-project-scheduling.test.ts
@@ -1,0 +1,46 @@
+/* @vitest-environment node */
+
+import vitestConfig from "../../vitest.config";
+
+import { describe, expect, it } from "vitest";
+
+const browserBackedTestFiles = [
+  "src/features/providers/beatport.test.ts",
+  "src/features/providers/bandcamp.test.ts",
+  "src/features/providers/soundcloud-direct-downloads.test.ts",
+  "src/features/browser/browser-session-service.test.ts",
+  "src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts"
+];
+
+describe("vitest project scheduling", () => {
+  it("runs browser-backed suites in a dedicated project group", () => {
+    const projects = vitestConfig.test?.projects;
+
+    expect(projects).toBeDefined();
+    expect(projects).toHaveLength(2);
+
+    const defaultProject = projects?.find((project) => project.test?.name === "default");
+    const browserBackedProject = projects?.find(
+      (project) => project.test?.name === "browser-backed"
+    );
+
+    expect(defaultProject).toMatchObject({
+      extends: true,
+      test: {
+        exclude: expect.arrayContaining(browserBackedTestFiles),
+        include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+        name: "default"
+      }
+    });
+    expect(browserBackedProject).toMatchObject({
+      extends: true,
+      test: {
+        include: browserBackedTestFiles,
+        name: "browser-backed",
+        sequence: {
+          groupOrder: 1
+        }
+      }
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,14 @@ import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
+const browserBackedTestFiles = [
+  "src/features/providers/beatport.test.ts",
+  "src/features/providers/bandcamp.test.ts",
+  "src/features/providers/soundcloud-direct-downloads.test.ts",
+  "src/features/browser/browser-session-service.test.ts",
+  "src/app/api/runs/[runId]/review-queue/[reviewId]/route.test.ts"
+];
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -14,7 +22,26 @@ export default defineConfig({
     css: true,
     environment: "jsdom",
     globals: true,
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    projects: [
+      {
+        extends: true,
+        test: {
+          exclude: browserBackedTestFiles,
+          include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+          name: "default"
+        }
+      },
+      {
+        extends: true,
+        test: {
+          include: browserBackedTestFiles,
+          name: "browser-backed",
+          sequence: {
+            groupOrder: 1
+          }
+        }
+      }
+    ],
     setupFiles: "./vitest.setup.ts"
   }
 });


### PR DESCRIPTION
**@worker-02**

## Summary
- isolate the browser-backed Vitest suites into a dedicated project lane that runs after the default unit project
- preserve the existing root Vitest config in both lanes via `extends: true`
- add a regression test that locks the project split into place

## Verification
- `npm test` (3 consecutive passes)
- `npm run lint`
- `npm run build`
