### PR TITLE
fix: prevent operator setup from reusing active automated sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ Local web app for authorized-source playlist acquisition, optimized for DJ and e
 npm install
 ```
 
-## Live Credentials
+## Live Credentials And Browser Sessions
 
 The normal local operator runtime (`npm run dev`) uses live playlist intake and
-therefore expects authorized Spotify and SoundCloud API credentials.
+therefore expects authorized Spotify and SoundCloud API credentials plus
+persisted authenticated browser sessions for:
+
+- SoundCloud Direct Downloads
+- Bandcamp
+- Beatport
 
 To enable authorized Spotify playlist ingestion through the Spotify Web API
 client-credentials flow, set these Spotify env vars before starting the app:
@@ -49,6 +54,15 @@ set these env vars before starting the app:
 export SOUNDCLOUD_CLIENT_ID=your-soundcloud-client-id
 export SOUNDCLOUD_CLIENT_SECRET=your-soundcloud-client-secret
 ```
+
+After the app is running, open `http://127.0.0.1:3000` and use the `Live
+Prerequisites` panel to launch a headed setup session for each required
+provider browser profile. Complete the provider login manually in the opened
+Playwright window, then return to the shell and click `Mark ready` to persist
+the authenticated session metadata.
+
+Those browser profiles are stored inside the local workspace and can be
+refreshed later from the same panel if a provider session expires.
 
 ## Run
 
@@ -83,7 +97,8 @@ exercises:
 No live Spotify or SoundCloud credentials are required for that verification
 path, and the fixtures stay within authorized-source-only scenarios. Use
 `npm run dev` with the env vars above when you want to test live playlist
-intake locally.
+intake locally; live provider acquisition also requires the browser-session
+setup flow described above.
 
 ## Notes
 

--- a/src/app/api/operator/browser-sessions/route.test.ts
+++ b/src/app/api/operator/browser-sessions/route.test.ts
@@ -1,0 +1,146 @@
+/* @vitest-environment node */
+
+afterEach(() => {
+  vi.doUnmock("@/features/browser/operator-browser-session-manager");
+  vi.resetModules();
+});
+
+describe("/api/operator/browser-sessions", () => {
+  it("returns the current operator browser-session readiness payload", async () => {
+    const listSessions = vi.fn().mockResolvedValue([
+      {
+        detail: "Authenticated session available for automatic acquisition.",
+        providerId: "bandcamp",
+        providerName: "Bandcamp",
+        sessionName: "bandcamp",
+        setupUrl: "https://bandcamp.com/login",
+        status: "ready",
+        subjectHint: "crate-digger@example.com"
+      }
+    ]);
+
+    vi.doMock("@/features/browser/operator-browser-session-manager", () => ({
+      getSharedOperatorBrowserSessionManager: () => ({
+        listSessions
+      })
+    }));
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(listSessions).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toEqual({
+      providers: [
+        expect.objectContaining({
+          providerId: "bandcamp",
+          status: "ready"
+        })
+      ]
+    });
+  });
+
+  it("dispatches provider session setup actions through the shared manager", async () => {
+    const launchSetup = vi.fn().mockResolvedValue({
+      detail: "Browser window open. Finish login, then mark the session ready.",
+      providerId: "beatport",
+      providerName: "Beatport",
+      sessionName: "beatport",
+      setupUrl: "https://www.beatport.com/login",
+      status: "setup-in-progress"
+    });
+    const markAuthenticated = vi.fn().mockResolvedValue({
+      detail: "Authenticated session available for owned-download refresh.",
+      providerId: "beatport",
+      providerName: "Beatport",
+      sessionName: "beatport",
+      setupUrl: "https://www.beatport.com/login",
+      status: "ready"
+    });
+
+    vi.doMock("@/features/browser/operator-browser-session-manager", () => ({
+      getSharedOperatorBrowserSessionManager: () => ({
+        launchSetup,
+        markAuthenticated
+      })
+    }));
+
+    const { POST } = await import("./route");
+
+    const launchResponse = await POST(
+      new Request("http://localhost/api/operator/browser-sessions", {
+        body: JSON.stringify({
+          action: "launch",
+          providerId: "beatport"
+        }),
+        headers: {
+          "content-type": "application/json"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(launchSetup).toHaveBeenCalledWith("beatport");
+    expect(launchResponse.status).toBe(200);
+    await expect(launchResponse.json()).resolves.toEqual({
+      provider: expect.objectContaining({
+        providerId: "beatport",
+        status: "setup-in-progress"
+      })
+    });
+
+    const completeResponse = await POST(
+      new Request("http://localhost/api/operator/browser-sessions", {
+        body: JSON.stringify({
+          action: "mark-authenticated",
+          providerId: "beatport",
+          subjectHint: "operator@example.com"
+        }),
+        headers: {
+          "content-type": "application/json"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(markAuthenticated).toHaveBeenCalledWith("beatport", {
+      subjectHint: "operator@example.com"
+    });
+    expect(completeResponse.status).toBe(200);
+    await expect(completeResponse.json()).resolves.toEqual({
+      provider: expect.objectContaining({
+        providerId: "beatport",
+        status: "ready"
+      })
+    });
+  });
+
+  it("rejects unsupported setup actions", async () => {
+    vi.doMock("@/features/browser/operator-browser-session-manager", () => ({
+      getSharedOperatorBrowserSessionManager: () => ({
+        launchSetup: vi.fn(),
+        markAuthenticated: vi.fn()
+      })
+    }));
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/operator/browser-sessions", {
+        body: JSON.stringify({
+          action: "unsupported-action",
+          providerId: "beatport"
+        }),
+        headers: {
+          "content-type": "application/json"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        "action must be one of: launch, mark-authenticated."
+    });
+  });
+});

--- a/src/app/api/operator/browser-sessions/route.test.ts
+++ b/src/app/api/operator/browser-sessions/route.test.ts
@@ -115,6 +115,45 @@ describe("/api/operator/browser-sessions", () => {
     });
   });
 
+  it("returns a conflict response when operator setup would reuse an active automated session", async () => {
+    class OperatorBrowserSessionConflictError extends Error {}
+
+    const launchSetup = vi.fn().mockRejectedValue(
+      new OperatorBrowserSessionConflictError(
+        "Beatport setup can't open while an automated session is already active. Wait for the current acquisition to finish, then try again."
+      )
+    );
+
+    vi.doMock("@/features/browser/operator-browser-session-manager", () => ({
+      getSharedOperatorBrowserSessionManager: () => ({
+        launchSetup,
+        markAuthenticated: vi.fn()
+      }),
+      OperatorBrowserSessionConflictError,
+      UnsupportedOperatorBrowserSessionProviderError: class UnsupportedOperatorBrowserSessionProviderError extends Error {}
+    }));
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/operator/browser-sessions", {
+        body: JSON.stringify({
+          action: "launch",
+          providerId: "beatport"
+        }),
+        headers: {
+          "content-type": "application/json"
+        },
+        method: "POST"
+      })
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        "Beatport setup can't open while an automated session is already active. Wait for the current acquisition to finish, then try again."
+    });
+  });
+
   it("rejects unsupported setup actions", async () => {
     vi.doMock("@/features/browser/operator-browser-session-manager", () => ({
       getSharedOperatorBrowserSessionManager: () => ({

--- a/src/app/api/operator/browser-sessions/route.ts
+++ b/src/app/api/operator/browser-sessions/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+
+import {
+  getSharedOperatorBrowserSessionManager,
+  UnsupportedOperatorBrowserSessionProviderError
+} from "@/features/browser/operator-browser-session-manager";
+
+export async function GET() {
+  const manager = getSharedOperatorBrowserSessionManager();
+
+  return NextResponse.json({
+    providers: await manager.listSessions()
+  });
+}
+
+export async function POST(request: Request) {
+  const payload = (await request.json().catch(() => null)) as
+    | {
+        action?: string;
+        providerId?: string;
+        subjectHint?: string;
+      }
+    | null;
+
+  if (!payload?.providerId?.trim()) {
+    return NextResponse.json(
+      { error: "providerId is required" },
+      { status: 400 }
+    );
+  }
+
+  const action = payload.action?.trim();
+  const providerId = payload.providerId.trim();
+  const manager = getSharedOperatorBrowserSessionManager();
+
+  try {
+    if (action === "launch") {
+      return NextResponse.json({
+        provider: await manager.launchSetup(providerId)
+      });
+    }
+
+    if (action === "mark-authenticated") {
+      return NextResponse.json({
+        provider: await manager.markAuthenticated(providerId, {
+          subjectHint: payload.subjectHint
+        })
+      });
+    }
+
+    return NextResponse.json(
+      { error: "action must be one of: launch, mark-authenticated." },
+      { status: 400 }
+    );
+  } catch (error) {
+    if (error instanceof UnsupportedOperatorBrowserSessionProviderError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 404 }
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/app/api/operator/browser-sessions/route.ts
+++ b/src/app/api/operator/browser-sessions/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import {
   getSharedOperatorBrowserSessionManager,
+  OperatorBrowserSessionConflictError,
   UnsupportedOperatorBrowserSessionProviderError
 } from "@/features/browser/operator-browser-session-manager";
 
@@ -53,6 +54,13 @@ export async function POST(request: Request) {
       { status: 400 }
     );
   } catch (error) {
+    if (error instanceof OperatorBrowserSessionConflictError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 409 }
+      );
+    }
+
     if (error instanceof UnsupportedOperatorBrowserSessionProviderError) {
       return NextResponse.json(
         { error: error.message },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -133,6 +133,10 @@ a {
   gap: 1rem;
 }
 
+.prerequisites-panel {
+  grid-column: 1 / -1;
+}
+
 .panel {
   display: grid;
   gap: 1.15rem;
@@ -178,6 +182,12 @@ a {
 .empty-state {
   display: grid;
   gap: 0.95rem;
+}
+
+.prerequisites-copy,
+.session-card-title-block {
+  display: grid;
+  gap: 0.35rem;
 }
 
 .field {
@@ -273,7 +283,9 @@ a {
 .field-hint,
 .empty-state p,
 .status-list dd,
-.run-card dd {
+.run-card dd,
+.session-card-detail,
+.session-card-link {
   color: var(--text-soft);
 }
 
@@ -364,9 +376,24 @@ a {
   gap: 0.8rem;
 }
 
+.session-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
 .run-card {
   display: grid;
   gap: 0.9rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid rgba(255, 243, 228, 0.1);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.session-card {
+  display: grid;
+  gap: 0.85rem;
   padding: 0.95rem 1rem;
   border: 1px solid rgba(255, 243, 228, 0.1);
   border-radius: var(--radius-lg);
@@ -380,16 +407,32 @@ a {
   justify-content: space-between;
 }
 
+.session-card-head,
+.session-card-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
 .run-card-source,
 .run-card-url {
   margin: 0;
 }
 
-.run-card-source {
+.run-card-source,
+.session-card-label {
   font-family: var(--font-mono);
   font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.session-card-label,
+.session-card-meta,
+.session-card-detail,
+.session-card-link {
+  margin: 0;
 }
 
 .run-card-title {
@@ -399,9 +442,21 @@ a {
   font-weight: 600;
 }
 
+.session-card-name {
+  margin: 0;
+  color: var(--text);
+  font-size: 1.05rem;
+}
+
 .run-card-url {
   margin-top: 0.35rem;
   color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.session-card-link {
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
   overflow-wrap: anywhere;
 }
 
@@ -555,6 +610,7 @@ a {
 @media (max-width: 900px) {
   .hero,
   .dashboard-grid,
+  .session-grid,
   .report-grid,
   .status-list,
   .run-card-stats,
@@ -567,6 +623,8 @@ a {
   }
 
   .panel-header,
+  .session-card-head,
+  .session-card-actions,
   .run-card-head,
   .report-review-card-head,
   .report-review-meta {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,22 @@
+import { getSharedOperatorBrowserSessionManager } from "@/features/browser/operator-browser-session-manager";
 import { HomeScreen } from "@/features/home/home-screen";
 import { getRunStore } from "@/features/runs/run-store";
 import { getSharedRunWorker } from "@/features/runs/run-worker";
 
 export const dynamic = "force-dynamic";
 
-export default function HomePage() {
+export default async function HomePage() {
   getSharedRunWorker();
 
-  return <HomeScreen initialRuns={getRunStore().listRuns()} />;
+  const [initialRuns, initialBrowserSessions] = await Promise.all([
+    Promise.resolve(getRunStore().listRuns()),
+    getSharedOperatorBrowserSessionManager().listSessions()
+  ]);
+
+  return (
+    <HomeScreen
+      initialBrowserSessions={initialBrowserSessions}
+      initialRuns={initialRuns}
+    />
+  );
 }

--- a/src/features/browser/browser-session-service.test.ts
+++ b/src/features/browser/browser-session-service.test.ts
@@ -5,6 +5,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import os from "node:os";
 import path from "node:path";
 
+import type { BrowserContext, BrowserType } from "playwright";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -160,6 +161,54 @@ describe("BrowserSessionService", () => {
     },
     15_000
   );
+
+  it("defaults browser sessions to headless and only uses headed mode when requested", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-browser-session-headless-")
+    );
+    const launchPersistentContext = vi
+      .fn<BrowserType["launchPersistentContext"]>()
+      .mockImplementation(async () => createStubBrowserContext());
+    const service = new BrowserSessionService({
+      workspaceRoot,
+      browserType: {
+        launchPersistentContext
+      } as unknown as BrowserType
+    });
+
+    try {
+      const backgroundSession = await service.openSession({
+        sessionName: "background-provider"
+      });
+      await backgroundSession.close();
+
+      const operatorSession = await service.openSession({
+        headless: false,
+        sessionName: "operator-setup"
+      });
+      await operatorSession.close();
+
+      expect(launchPersistentContext).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        expect.objectContaining({
+          acceptDownloads: true,
+          headless: true
+        })
+      );
+      expect(launchPersistentContext).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        expect.objectContaining({
+          acceptDownloads: true,
+          headless: false
+        })
+      );
+    } finally {
+      await service.shutdown();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
 });
 
 async function startFixtureServer() {
@@ -241,4 +290,15 @@ async function closeFixtureServer(server: Server) {
       resolve();
     });
   });
+}
+
+function createStubBrowserContext() {
+  return {
+    close: async () => undefined,
+    newPage: async () => ({
+      goto: async () => null,
+      url: () => "about:blank"
+    }),
+    pages: () => []
+  } as unknown as BrowserContext;
 }

--- a/src/features/browser/browser-session-service.ts
+++ b/src/features/browser/browser-session-service.ts
@@ -46,6 +46,7 @@ export interface BrowserSessionServiceOptions {
 }
 
 export interface OpenBrowserSessionOptions {
+  headless?: boolean;
   sessionName: string;
   authState?: BrowserSessionAuthState;
 }
@@ -174,7 +175,7 @@ export class BrowserSessionService {
 
     const context = await this.#browserType.launchPersistentContext(sessionPaths.userDataDir, {
       acceptDownloads: true,
-      headless: true
+      headless: options.headless ?? true
     });
 
     const now = new Date().toISOString();

--- a/src/features/browser/browser-session-service.ts
+++ b/src/features/browser/browser-session-service.ts
@@ -47,6 +47,7 @@ export interface BrowserSessionServiceOptions {
 
 export interface OpenBrowserSessionOptions {
   headless?: boolean;
+  reuseExisting?: boolean;
   sessionName: string;
   authState?: BrowserSessionAuthState;
 }
@@ -141,6 +142,17 @@ export class ExpiredBrowserSessionAuthStateError extends Error {
   }
 }
 
+export class ActiveBrowserSessionConflictError extends Error {
+  readonly code = "active-browser-session-conflict";
+  readonly sessionName: string;
+
+  constructor(sessionName: string) {
+    super(`Browser session "${sessionName}" is already active.`);
+    this.name = "ActiveBrowserSessionConflictError";
+    this.sessionName = sessionName;
+  }
+}
+
 /**
  * Manages named persistent Playwright profiles inside the local app workspace.
  */
@@ -161,6 +173,10 @@ export class BrowserSessionService {
     const activeSession = this.#activeSessions.get(options.sessionName);
 
     if (activeSession) {
+      if (options.reuseExisting === false) {
+        throw new ActiveBrowserSessionConflictError(options.sessionName);
+      }
+
       if (options.authState) {
         await activeSession.setAuthState(options.authState);
       }

--- a/src/features/browser/operator-browser-session-manager.test.ts
+++ b/src/features/browser/operator-browser-session-manager.test.ts
@@ -153,6 +153,51 @@ describe("OperatorBrowserSessionManager", () => {
       await rm(workspaceRoot, { force: true, recursive: true });
     }
   });
+
+  it("blocks operator setup when an automated provider session is already active", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-operator-session-conflict-")
+    );
+    const browserType = createStubBrowserType();
+    const browserSessionService = new BrowserSessionService({
+      workspaceRoot,
+      browserType: browserType.browserType
+    });
+    const manager = createOperatorBrowserSessionManager({
+      browserSessionService,
+      workspaceRoot
+    });
+
+    try {
+      const automatedSession = await browserSessionService.openSession({
+        sessionName: "soundcloud-direct-downloads"
+      });
+      await automatedSession.navigate({
+        url: "https://fixtures.example/provider-worker",
+        waitUntil: "load"
+      });
+
+      await expect(
+        manager.launchSetup("soundcloud-direct-downloads")
+      ).rejects.toMatchObject({
+        message: expect.stringContaining("already active")
+      });
+      expect(browserType.launchPersistentContext).toHaveBeenCalledTimes(1);
+      expect(browserType.page.goto).toHaveBeenCalledTimes(1);
+      expect(browserType.page.goto).toHaveBeenCalledWith(
+        "https://fixtures.example/provider-worker",
+        expect.objectContaining({
+          waitUntil: "load"
+        })
+      );
+      expect(browserType.page.url()).toBe("https://fixtures.example/provider-worker");
+
+      await automatedSession.close();
+    } finally {
+      await browserSessionService.shutdown();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
 });
 
 function createStubBrowserType() {

--- a/src/features/browser/operator-browser-session-manager.test.ts
+++ b/src/features/browser/operator-browser-session-manager.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment node
+
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { BrowserContext, BrowserType } from "playwright";
+import { describe, expect, it, vi } from "vitest";
+
+import { BrowserSessionService } from "./browser-session-service";
+import { createOperatorBrowserSessionManager } from "./operator-browser-session-manager";
+
+describe("OperatorBrowserSessionManager", () => {
+  it("lists required provider session readiness from persisted auth state", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-operator-session-readiness-")
+    );
+    const browserType = createStubBrowserType();
+    const browserSessionService = new BrowserSessionService({
+      workspaceRoot,
+      browserType: browserType.browserType
+    });
+    const manager = createOperatorBrowserSessionManager({
+      browserSessionService,
+      workspaceRoot
+    });
+
+    try {
+      const bandcampSession = await browserSessionService.openSession({
+        authState: {
+          authenticatedAt: "2026-04-01T07:00:00.000Z",
+          providerId: "bandcamp",
+          status: "authenticated",
+          subjectHint: "crate-digger@example.com"
+        },
+        sessionName: "bandcamp"
+      });
+      await bandcampSession.close();
+
+      const beatportSession = await browserSessionService.openSession({
+        authState: {
+          expiredAt: "2026-04-01T07:30:00.000Z",
+          providerId: "beatport",
+          reason: "fixture expiry",
+          status: "expired"
+        },
+        sessionName: "beatport"
+      });
+      await beatportSession.close();
+
+      const sessions = await manager.listSessions();
+
+      expect(
+        sessions.map(({ providerId, status }) => ({ providerId, status }))
+      ).toEqual([
+        {
+          providerId: "soundcloud-direct-downloads",
+          status: "missing"
+        },
+        {
+          providerId: "bandcamp",
+          status: "ready"
+        },
+        {
+          providerId: "beatport",
+          status: "expired"
+        }
+      ]);
+    } finally {
+      await browserSessionService.shutdown();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("launches headed provider setup and persists authenticated readiness after completion", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-operator-session-launch-")
+    );
+    const browserType = createStubBrowserType();
+    const browserSessionService = new BrowserSessionService({
+      workspaceRoot,
+      browserType: browserType.browserType
+    });
+    const manager = createOperatorBrowserSessionManager({
+      browserSessionService,
+      workspaceRoot
+    });
+
+    try {
+      const launchedSession = await manager.launchSetup(
+        "soundcloud-direct-downloads"
+      );
+
+      expect(launchedSession).toEqual(
+        expect.objectContaining({
+          providerId: "soundcloud-direct-downloads",
+          status: "setup-in-progress"
+        })
+      );
+      expect(browserType.launchPersistentContext).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          acceptDownloads: true,
+          headless: false
+        })
+      );
+      expect(browserType.page.goto).toHaveBeenCalledWith(
+        "https://soundcloud.com",
+        expect.objectContaining({
+          waitUntil: "load"
+        })
+      );
+
+      const completedSession = await manager.markAuthenticated(
+        "soundcloud-direct-downloads",
+        {
+          subjectHint: "warehouse-operator@example.com"
+        }
+      );
+
+      expect(completedSession).toEqual(
+        expect.objectContaining({
+          providerId: "soundcloud-direct-downloads",
+          status: "ready",
+          subjectHint: "warehouse-operator@example.com"
+        })
+      );
+
+      await browserSessionService.shutdown();
+
+      const restartedManager = createOperatorBrowserSessionManager({
+        browserSessionService: new BrowserSessionService({
+          workspaceRoot,
+          browserType: browserType.browserType
+        }),
+        workspaceRoot
+      });
+      const sessionsAfterRestart = await restartedManager.listSessions();
+
+      expect(
+        sessionsAfterRestart.find(
+          ({ providerId }) => providerId === "soundcloud-direct-downloads"
+        )
+      ).toEqual(
+        expect.objectContaining({
+          providerId: "soundcloud-direct-downloads",
+          status: "ready",
+          subjectHint: "warehouse-operator@example.com"
+        })
+      );
+    } finally {
+      await browserSessionService.shutdown();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
+});
+
+function createStubBrowserType() {
+  let currentUrl = "about:blank";
+  const page = {
+    bringToFront: vi.fn(async () => undefined),
+    goto: vi.fn(async (url: string) => {
+      currentUrl = url;
+
+      return {
+        status: () => 200
+      };
+    }),
+    url: () => currentUrl
+  };
+  const launchPersistentContext = vi
+    .fn<BrowserType["launchPersistentContext"]>()
+    .mockImplementation(async () => createStubBrowserContext(page));
+
+  return {
+    browserType: {
+      launchPersistentContext
+    } as unknown as BrowserType,
+    launchPersistentContext,
+    page
+  };
+}
+
+function createStubBrowserContext(page: {
+  bringToFront: () => Promise<void>;
+  goto: (url: string) => Promise<{ status: () => number }>;
+  url: () => string;
+}) {
+  return {
+    close: async () => undefined,
+    newPage: async () => page,
+    pages: () => []
+  } as unknown as BrowserContext;
+}

--- a/src/features/browser/operator-browser-session-manager.ts
+++ b/src/features/browser/operator-browser-session-manager.ts
@@ -1,0 +1,345 @@
+import path from "node:path";
+
+import {
+  type BrowserSessionRecord,
+  BrowserSessionService
+} from "@/features/browser/browser-session-service";
+import {
+  BANDCAMP_PROVIDER_ID,
+  BANDCAMP_PROVIDER_NAME,
+  BANDCAMP_SESSION_NAME
+} from "@/features/providers/bandcamp";
+import {
+  BEATPORT_PROVIDER_ID,
+  BEATPORT_PROVIDER_NAME,
+  BEATPORT_SESSION_NAME
+} from "@/features/providers/beatport";
+import {
+  SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+  SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+  SOUNDCLOUD_DIRECT_DOWNLOADS_SESSION_NAME
+} from "@/features/providers/soundcloud-direct-downloads";
+
+type OperatorBrowserSessionProviderDefinition = {
+  missingDetail: string;
+  providerId: string;
+  providerName: string;
+  readyDetail: string;
+  refreshDetail: string;
+  sessionName: string;
+  setupUrl: string;
+};
+
+export type OperatorBrowserSessionStatus =
+  | "expired"
+  | "missing"
+  | "ready"
+  | "setup-in-progress";
+
+export interface OperatorBrowserSessionReadiness {
+  authenticatedAt?: string;
+  detail: string;
+  expiredAt?: string;
+  providerId: string;
+  providerName: string;
+  sessionName: string;
+  setupUrl: string;
+  status: OperatorBrowserSessionStatus;
+  subjectHint?: string | null;
+}
+
+export interface OperatorBrowserSessionManagerDependencies {
+  getSessionRecord(sessionName: string): Promise<BrowserSessionRecord | null>;
+  openSession(options: {
+    authState?: BrowserSessionRecord["authState"];
+    headless?: boolean;
+    sessionName: string;
+  }): Promise<{
+    close(): Promise<void>;
+    getRecord(): Promise<BrowserSessionRecord>;
+    navigate(options: { url: string; waitUntil?: "load" }): Promise<unknown>;
+    setAuthState(
+      authState: BrowserSessionRecord["authState"]
+    ): Promise<BrowserSessionRecord>;
+    withPage<T>(
+      task: (page: { bringToFront?: () => Promise<void> }) => Promise<T>
+    ): Promise<T>;
+  }>;
+  shutdown?(): Promise<void>;
+}
+
+export class UnsupportedOperatorBrowserSessionProviderError extends Error {
+  readonly providerId: string;
+
+  constructor(providerId: string) {
+    super(`Unsupported operator browser-session provider "${providerId}".`);
+    this.name = "UnsupportedOperatorBrowserSessionProviderError";
+    this.providerId = providerId;
+  }
+}
+
+const REQUIRED_OPERATOR_BROWSER_SESSIONS: OperatorBrowserSessionProviderDefinition[] = [
+  {
+    missingDetail:
+      "Launch setup to create the persisted SoundCloud browser session used during live automatic acquisition.",
+    providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+    providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+    readyDetail: "Authenticated session available for automatic downloads.",
+    refreshDetail:
+      "The SoundCloud session expired. Refresh it before automatic downloads can run.",
+    sessionName: SOUNDCLOUD_DIRECT_DOWNLOADS_SESSION_NAME,
+    setupUrl: "https://soundcloud.com"
+  },
+  {
+    missingDetail:
+      "Launch setup to create the persisted Bandcamp browser session used during live automatic acquisition.",
+    providerId: BANDCAMP_PROVIDER_ID,
+    providerName: BANDCAMP_PROVIDER_NAME,
+    readyDetail: "Authenticated session available for automatic downloads.",
+    refreshDetail:
+      "The Bandcamp session expired. Refresh it before automatic downloads can run.",
+    sessionName: BANDCAMP_SESSION_NAME,
+    setupUrl: "https://bandcamp.com"
+  },
+  {
+    missingDetail:
+      "Launch setup to create the persisted Beatport browser session used for owned-download refresh after review approval.",
+    providerId: BEATPORT_PROVIDER_ID,
+    providerName: BEATPORT_PROVIDER_NAME,
+    readyDetail:
+      "Authenticated session available for owned-download refresh after review approval.",
+    refreshDetail:
+      "The Beatport session expired. Refresh it before owned downloads can run.",
+    sessionName: BEATPORT_SESSION_NAME,
+    setupUrl: "https://www.beatport.com"
+  }
+];
+
+const sharedOperatorBrowserSessionManagers = new Map<
+  string,
+  OperatorBrowserSessionManager
+>();
+
+export function createOperatorBrowserSessionManager(options: {
+  browserSessionService?: OperatorBrowserSessionManagerDependencies;
+  workspaceRoot?: string;
+} = {}) {
+  return new OperatorBrowserSessionManager({
+    browserSessionService:
+      options.browserSessionService ??
+      new BrowserSessionService({
+        workspaceRoot: resolveWorkspaceRoot(options.workspaceRoot)
+      }),
+    workspaceRoot: resolveWorkspaceRoot(options.workspaceRoot)
+  });
+}
+
+export function getSharedOperatorBrowserSessionManager(options: {
+  workspaceRoot?: string;
+} = {}) {
+  const workspaceRoot = resolveWorkspaceRoot(options.workspaceRoot);
+  const existingManager = sharedOperatorBrowserSessionManagers.get(workspaceRoot);
+
+  if (existingManager) {
+    return existingManager;
+  }
+
+  const manager = createOperatorBrowserSessionManager({ workspaceRoot });
+  sharedOperatorBrowserSessionManagers.set(workspaceRoot, manager);
+  return manager;
+}
+
+export async function resetSharedOperatorBrowserSessionManagerForTests() {
+  const managers = [...sharedOperatorBrowserSessionManagers.values()];
+  sharedOperatorBrowserSessionManagers.clear();
+
+  await Promise.all(managers.map((manager) => manager.shutdown()));
+}
+
+class OperatorBrowserSessionManager {
+  readonly #browserSessionService: OperatorBrowserSessionManagerDependencies;
+  readonly #providersById: Map<string, OperatorBrowserSessionProviderDefinition>;
+  readonly #setupInProgressProviderIds = new Set<string>();
+  readonly #workspaceRoot: string;
+
+  constructor(options: {
+    browserSessionService: OperatorBrowserSessionManagerDependencies;
+    workspaceRoot: string;
+  }) {
+    this.#browserSessionService = options.browserSessionService;
+    this.#providersById = new Map(
+      REQUIRED_OPERATOR_BROWSER_SESSIONS.map((provider) => [
+        provider.providerId,
+        provider
+      ])
+    );
+    this.#workspaceRoot = options.workspaceRoot;
+  }
+
+  async listSessions() {
+    return Promise.all(
+      REQUIRED_OPERATOR_BROWSER_SESSIONS.map((provider) =>
+        this.#readinessForProvider(provider)
+      )
+    );
+  }
+
+  async launchSetup(providerId: string) {
+    const provider = this.#getProvider(providerId);
+    const session = await this.#browserSessionService.openSession({
+      headless: false,
+      sessionName: provider.sessionName
+    });
+
+    await session.navigate({
+      url: provider.setupUrl,
+      waitUntil: "load"
+    });
+    await session.withPage(async (page) => {
+      await page.bringToFront?.();
+    });
+
+    this.#setupInProgressProviderIds.add(providerId);
+
+    return this.#buildReadiness({
+      detail: "Browser window open. Finish login, then mark the session ready.",
+      provider,
+      record: await session.getRecord(),
+      status: "setup-in-progress"
+    });
+  }
+
+  async markAuthenticated(
+    providerId: string,
+    input: { subjectHint?: string } = {}
+  ) {
+    const provider = this.#getProvider(providerId);
+    const session = await this.#browserSessionService.openSession({
+      headless: false,
+      sessionName: provider.sessionName
+    });
+
+    try {
+      const record = await session.setAuthState({
+        authenticatedAt: new Date().toISOString(),
+        providerId,
+        status: "authenticated",
+        subjectHint: input.subjectHint?.trim() || null
+      });
+
+      this.#setupInProgressProviderIds.delete(providerId);
+
+      return this.#buildReadiness({
+        provider,
+        record,
+        status: "ready"
+      });
+    } finally {
+      await session.close();
+    }
+  }
+
+  async shutdown() {
+    await this.#browserSessionService.shutdown?.();
+  }
+
+  async #readinessForProvider(
+    provider: OperatorBrowserSessionProviderDefinition
+  ): Promise<OperatorBrowserSessionReadiness> {
+    if (this.#setupInProgressProviderIds.has(provider.providerId)) {
+      const activeRecord = await this.#browserSessionService.getSessionRecord(
+        provider.sessionName
+      );
+
+      return this.#buildReadiness({
+        detail: "Browser window open. Finish login, then mark the session ready.",
+        provider,
+        record: activeRecord,
+        status: "setup-in-progress"
+      });
+    }
+
+    const record = await this.#browserSessionService.getSessionRecord(
+      provider.sessionName
+    );
+
+    if (record === null || record.authState.status === "unknown") {
+      return this.#buildReadiness({
+        detail: provider.missingDetail,
+        provider,
+        record,
+        status: "missing"
+      });
+    }
+
+    if (
+      record.authState.status === "expired" ||
+      (record.authState.status === "authenticated" &&
+        record.authState.expiresAt &&
+        Date.parse(record.authState.expiresAt) <= Date.now())
+    ) {
+      return this.#buildReadiness({
+        detail: provider.refreshDetail,
+        provider,
+        record,
+        status: "expired"
+      });
+    }
+
+    return this.#buildReadiness({
+      provider,
+      record,
+      status: "ready"
+    });
+  }
+
+  #buildReadiness(input: {
+    detail?: string;
+    provider: OperatorBrowserSessionProviderDefinition;
+    record: BrowserSessionRecord | null;
+    status: OperatorBrowserSessionStatus;
+  }): OperatorBrowserSessionReadiness {
+    const authState = input.record?.authState;
+
+    return {
+      authenticatedAt:
+        authState?.status === "authenticated" ? authState.authenticatedAt : undefined,
+      detail:
+        input.detail ??
+        (input.status === "ready"
+          ? input.provider.readyDetail
+          : input.provider.missingDetail),
+      expiredAt:
+        authState?.status === "expired"
+          ? authState.expiredAt
+          : authState?.status === "authenticated"
+            ? authState.expiresAt ?? undefined
+            : undefined,
+      providerId: input.provider.providerId,
+      providerName: input.provider.providerName,
+      sessionName: input.provider.sessionName,
+      setupUrl: input.provider.setupUrl,
+      status: input.status,
+      subjectHint:
+        authState?.status === "authenticated" ? authState.subjectHint ?? null : undefined
+    };
+  }
+
+  #getProvider(providerId: string) {
+    const provider = this.#providersById.get(providerId);
+
+    if (!provider) {
+      throw new UnsupportedOperatorBrowserSessionProviderError(providerId);
+    }
+
+    return provider;
+  }
+}
+
+function resolveWorkspaceRoot(workspaceRoot?: string) {
+  return (
+    workspaceRoot ??
+    process.env.MUSIC_DOWNLOADER_WORKSPACE_ROOT ??
+    path.join(process.cwd())
+  );
+}

--- a/src/features/browser/operator-browser-session-manager.ts
+++ b/src/features/browser/operator-browser-session-manager.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import {
+  ActiveBrowserSessionConflictError,
   type BrowserSessionRecord,
   BrowserSessionService
 } from "@/features/browser/browser-session-service";
@@ -53,6 +54,7 @@ export interface OperatorBrowserSessionManagerDependencies {
   openSession(options: {
     authState?: BrowserSessionRecord["authState"];
     headless?: boolean;
+    reuseExisting?: boolean;
     sessionName: string;
   }): Promise<{
     close(): Promise<void>;
@@ -75,6 +77,25 @@ export class UnsupportedOperatorBrowserSessionProviderError extends Error {
     super(`Unsupported operator browser-session provider "${providerId}".`);
     this.name = "UnsupportedOperatorBrowserSessionProviderError";
     this.providerId = providerId;
+  }
+}
+
+export class OperatorBrowserSessionConflictError extends Error {
+  readonly code = "operator-browser-session-conflict";
+  readonly providerId: string;
+  readonly sessionName: string;
+
+  constructor(input: {
+    providerId: string;
+    providerName: string;
+    sessionName: string;
+  }) {
+    super(
+      `${input.providerName} setup can't open while an automated session is already active. Wait for the current acquisition to finish, then try again.`
+    );
+    this.name = "OperatorBrowserSessionConflictError";
+    this.providerId = input.providerId;
+    this.sessionName = input.sessionName;
   }
 }
 
@@ -186,10 +207,21 @@ class OperatorBrowserSessionManager {
 
   async launchSetup(providerId: string) {
     const provider = this.#getProvider(providerId);
-    const session = await this.#browserSessionService.openSession({
-      headless: false,
-      sessionName: provider.sessionName
-    });
+    let session;
+
+    try {
+      session = await this.#browserSessionService.openSession({
+        headless: false,
+        reuseExisting: false,
+        sessionName: provider.sessionName
+      });
+    } catch (error) {
+      if (error instanceof ActiveBrowserSessionConflictError) {
+        throw new OperatorBrowserSessionConflictError(provider);
+      }
+
+      throw error;
+    }
 
     await session.navigate({
       url: provider.setupUrl,

--- a/src/features/home/home-screen.test.tsx
+++ b/src/features/home/home-screen.test.tsx
@@ -4,7 +4,39 @@ import { HomeScreen } from "./home-screen";
 
 describe("HomeScreen", () => {
   it("renders the intake shell and empty run state", () => {
-    render(<HomeScreen />);
+    render(
+      <HomeScreen
+        initialBrowserSessions={[
+          {
+            detail:
+              "Launch setup to create the persisted SoundCloud browser session used during live automatic acquisition.",
+            providerId: "soundcloud-direct-downloads",
+            providerName: "SoundCloud Direct Downloads",
+            sessionName: "soundcloud-direct-downloads",
+            setupUrl: "https://soundcloud.com",
+            status: "missing"
+          },
+          {
+            detail: "Authenticated session available for automatic downloads.",
+            providerId: "bandcamp",
+            providerName: "Bandcamp",
+            sessionName: "bandcamp",
+            setupUrl: "https://bandcamp.com/login",
+            status: "ready",
+            subjectHint: "crate-digger@example.com"
+          },
+          {
+            detail:
+              "The Beatport session expired. Refresh it before owned downloads can run.",
+            providerId: "beatport",
+            providerName: "Beatport",
+            sessionName: "beatport",
+            setupUrl: "https://www.beatport.com/login",
+            status: "expired"
+          }
+        ]}
+      />
+    );
 
     expect(
       screen.getByRole("heading", { name: /authorized-source acquisition/i })
@@ -23,9 +55,23 @@ describe("HomeScreen", () => {
     ).toBeVisible();
     expect(
       screen.getByText(
-        /playwright fixture mode keeps end-to-end verification deterministic\. live operator runs still need spotify and soundcloud credentials configured before intake starts/i
+        /playwright fixture mode keeps end-to-end verification deterministic\. live operator runs need spotify and soundcloud api credentials plus refreshed provider browser sessions before queueing real acquisition/i
       )
     ).toBeVisible();
+    expect(
+      screen.getByRole("heading", { name: /live prerequisites/i })
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: /launch soundcloud direct downloads session setup/i
+      })
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: /refresh beatport session setup/i
+      })
+    ).toBeVisible();
+    expect(screen.getByText(/crate-digger@example\.com/i)).toBeVisible();
   });
 
   it("links recent runs into the run report detail flow", () => {

--- a/src/features/home/home-screen.tsx
+++ b/src/features/home/home-screen.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { startTransition, useEffect, useEffectEvent, useState } from "react";
 
+import type { OperatorBrowserSessionReadiness } from "@/features/browser/operator-browser-session-manager";
 import { FileBadge } from "@/components/ui/file-badge";
 import { Panel } from "@/components/ui/panel";
 import { StatusBadge } from "@/components/ui/status-badge";
@@ -12,6 +13,7 @@ const artifacts = ["downloads.zip", "manifest.json", "misses.txt"];
 const terminalStatuses: RunStatus[] = ["completed", "failed"];
 
 type HomeScreenProps = {
+  initialBrowserSessions?: OperatorBrowserSessionReadiness[];
   initialRuns?: RunSummary[];
 };
 
@@ -33,6 +35,60 @@ function formatSourceLabel(sourceType: RunSummary["sourceType"]) {
 
 function formatTrackCount(trackCount: number) {
   return `${trackCount} ${trackCount === 1 ? "track" : "tracks"}`;
+}
+
+function getBrowserSessionTone(
+  status: OperatorBrowserSessionReadiness["status"]
+) {
+  if (status === "ready") {
+    return "success" as const;
+  }
+
+  if (status === "setup-in-progress") {
+    return "muted" as const;
+  }
+
+  return "warning" as const;
+}
+
+function formatBrowserSessionStatus(
+  status: OperatorBrowserSessionReadiness["status"]
+) {
+  if (status === "ready") {
+    return "Ready";
+  }
+
+  if (status === "setup-in-progress") {
+    return "Setup Open";
+  }
+
+  if (status === "expired") {
+    return "Expired";
+  }
+
+  return "Missing";
+}
+
+function getBrowserSessionAction(
+  session: OperatorBrowserSessionReadiness
+): "launch" | "mark-authenticated" {
+  return session.status === "setup-in-progress"
+    ? "mark-authenticated"
+    : "launch";
+}
+
+function formatBrowserSessionActionLabel(
+  session: OperatorBrowserSessionReadiness
+) {
+  if (session.status === "setup-in-progress") {
+    return "Mark ready";
+  }
+
+  if (session.status === "ready" || session.status === "expired") {
+    return "Refresh";
+  }
+
+  return "Launch";
 }
 
 function getApiUrl(pathname: string) {
@@ -65,11 +121,34 @@ function upsertRun(runs: RunSummary[], incomingRun: RunSummary) {
   );
 }
 
-export function HomeScreen({ initialRuns = [] }: HomeScreenProps) {
+function updateBrowserSession(
+  sessions: OperatorBrowserSessionReadiness[],
+  incomingSession: OperatorBrowserSessionReadiness
+) {
+  return sessions.map((session) =>
+    session.providerId === incomingSession.providerId ? incomingSession : session
+  );
+}
+
+export function HomeScreen({
+  initialBrowserSessions = [],
+  initialRuns = []
+}: HomeScreenProps) {
+  const [browserSessions, setBrowserSessions] = useState(initialBrowserSessions);
   const [playlistUrl, setPlaylistUrl] = useState("");
   const [recentRuns, setRecentRuns] = useState(initialRuns);
+  const [sessionActionError, setSessionActionError] = useState<string | null>(
+    null
+  );
+  const [sessionActionProviderId, setSessionActionProviderId] = useState<
+    string | null
+  >(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const providerSessionsNeedingAttention = browserSessions.filter(
+    (session) => session.status !== "ready"
+  ).length;
 
   const pollRuns = useEffectEvent(async () => {
     const activeRuns = recentRuns.filter(
@@ -165,6 +244,52 @@ export function HomeScreen({ initialRuns = [] }: HomeScreenProps) {
     }
   }
 
+  async function handleBrowserSessionAction(
+    session: OperatorBrowserSessionReadiness
+  ) {
+    setSessionActionError(null);
+    setSessionActionProviderId(session.providerId);
+
+    try {
+      const response = await fetch(getApiUrl("/api/operator/browser-sessions"), {
+        body: JSON.stringify({
+          action: getBrowserSessionAction(session),
+          providerId: session.providerId
+        }),
+        headers: {
+          "content-type": "application/json"
+        },
+        method: "POST"
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json()) as { error?: string };
+
+        throw new Error(
+          payload.error ?? "Unable to update the browser-session setup state."
+        );
+      }
+
+      const payload = (await response.json()) as {
+        provider: OperatorBrowserSessionReadiness;
+      };
+
+      startTransition(() => {
+        setBrowserSessions((currentSessions) =>
+          updateBrowserSession(currentSessions, payload.provider)
+        );
+      });
+    } catch (error) {
+      setSessionActionError(
+        error instanceof Error
+          ? error.message
+          : "Unable to update the browser-session setup state."
+      );
+    } finally {
+      setSessionActionProviderId(null);
+    }
+  }
+
   return (
     <main className="app-shell">
       <header className="hero">
@@ -185,13 +310,91 @@ export function HomeScreen({ initialRuns = [] }: HomeScreenProps) {
           </StatusBadge>
           <p className="hero-note">
             Playwright fixture mode keeps end-to-end verification deterministic.
-            Live operator runs still need Spotify and SoundCloud credentials
-            configured before intake starts.
+            Live operator runs need Spotify and SoundCloud API credentials plus
+            refreshed provider browser sessions before queueing real
+            acquisition.
           </p>
         </div>
       </header>
 
       <div className="dashboard-grid">
+        <Panel
+          className="prerequisites-panel"
+          eyebrow="Live Setup"
+          title="Live Prerequisites"
+          footer={
+            <span className="panel-caption">
+              {providerSessionsNeedingAttention
+                ? `${providerSessionsNeedingAttention} provider ${providerSessionsNeedingAttention === 1 ? "session needs" : "sessions need"} attention`
+                : "All required provider sessions are ready"}
+            </span>
+          }
+        >
+          <div className="prerequisites-copy">
+            <p>
+              Live playlist queueing depends on Spotify and SoundCloud API
+              credentials plus persisted browser sessions for SoundCloud direct
+              downloads, Bandcamp, and Beatport refresh.
+            </p>
+            <p>
+              Launch setup to open a headed Playwright profile, finish the
+              provider login manually, then return here and mark the session
+              ready.
+            </p>
+          </div>
+
+          {sessionActionError ? (
+            <p className="form-status" role="alert">
+              {sessionActionError}
+            </p>
+          ) : null}
+
+          <div className="session-grid" aria-label="Live provider session readiness">
+            {browserSessions.map((session) => {
+              const actionLabel = formatBrowserSessionActionLabel(session);
+              const isPending = sessionActionProviderId === session.providerId;
+
+              return (
+                <article className="session-card" key={session.providerId}>
+                  <div className="session-card-head">
+                    <div className="session-card-title-block">
+                      <p className="session-card-label">Persistent session</p>
+                      <h3 className="session-card-name">{session.providerName}</h3>
+                      <p className="session-card-meta">{session.sessionName}</p>
+                    </div>
+                    <StatusBadge tone={getBrowserSessionTone(session.status)}>
+                      {formatBrowserSessionStatus(session.status)}
+                    </StatusBadge>
+                  </div>
+
+                  <p className="session-card-detail">{session.detail}</p>
+
+                  {session.subjectHint ? (
+                    <p className="session-card-meta">{session.subjectHint}</p>
+                  ) : null}
+
+                  <div className="session-card-actions">
+                    <button
+                      className="secondary-button"
+                      type="button"
+                      disabled={isPending}
+                      aria-label={`${actionLabel} ${session.providerName} session setup`}
+                      onClick={() => void handleBrowserSessionAction(session)}
+                    >
+                      {isPending
+                        ? session.status === "setup-in-progress"
+                          ? "Saving..."
+                          : "Launching..."
+                        : `${actionLabel} setup`}
+                    </button>
+                    <p className="session-card-link">{session.setupUrl}</p>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </Panel>
+
         <Panel
           eyebrow="Intake"
           title="Playlist Intake"


### PR DESCRIPTION
**@worker-01**

## Summary
- includes the operator browser-session setup flow from #100 on top of `epic/1-build-music-downloader-product`
- blocks `launchSetup()` from reusing an already-active provider session
- returns a `409` operator-facing conflict response instead of claiming a browser window opened
- adds regression coverage for the active automated-session collision path

## Testing
- `npm test`
- `npm run lint`
- `npm run build`

Closes #101
Supersedes #100
