### PR TITLE
fix: isolate operator-owned provider sessions

### DIFF
--- a/src/features/browser/browser-session-service.test.ts
+++ b/src/features/browser/browser-session-service.test.ts
@@ -9,6 +9,7 @@ import type { BrowserContext, BrowserType } from "playwright";
 import { describe, expect, it } from "vitest";
 
 import {
+  BrowserSessionOwnershipConflictError,
   BrowserSessionService,
   MissingBrowserSessionAuthStateError,
   MissingBrowserSessionStateError
@@ -204,6 +205,59 @@ describe("BrowserSessionService", () => {
           headless: false
         })
       );
+    } finally {
+      await service.shutdown();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects background reuse when a headed operator session is already active", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-browser-session-ownership-")
+    );
+    const launchPersistentContext = vi
+      .fn<BrowserType["launchPersistentContext"]>()
+      .mockImplementation(async () => createStubBrowserContext());
+    const service = new BrowserSessionService({
+      workspaceRoot,
+      browserType: {
+        launchPersistentContext
+      } as unknown as BrowserType
+    });
+
+    try {
+      const operatorSession = await service.openSession({
+        headless: false,
+        sessionName: "bandcamp"
+      });
+
+      await expect(
+        service.openSession({
+          sessionName: "bandcamp"
+        })
+      ).rejects.toBeInstanceOf(BrowserSessionOwnershipConflictError);
+      await expect(
+        service.openSession({
+          sessionName: "bandcamp"
+        })
+      ).rejects.toEqual(
+        expect.objectContaining({
+          activeOwner: "operator",
+          code: "browser-session-ownership-conflict",
+          requestedOwner: "background",
+          sessionName: "bandcamp"
+        })
+      );
+      await expect(
+        service.openSession({
+          headless: false,
+          sessionName: "bandcamp"
+        })
+      ).resolves.toBe(operatorSession);
+      expect(launchPersistentContext).toHaveBeenCalledTimes(1);
+
+      await operatorSession.close();
+      await service.shutdown();
     } finally {
       await service.shutdown();
       await rm(workspaceRoot, { force: true, recursive: true });

--- a/src/features/browser/browser-session-service.ts
+++ b/src/features/browser/browser-session-service.ts
@@ -40,6 +40,8 @@ export interface BrowserSessionRecord {
   authState: BrowserSessionAuthState;
 }
 
+export type BrowserSessionOwner = "background" | "operator";
+
 export interface BrowserSessionServiceOptions {
   workspaceRoot: string;
   browserType?: BrowserType;
@@ -47,6 +49,7 @@ export interface BrowserSessionServiceOptions {
 
 export interface OpenBrowserSessionOptions {
   headless?: boolean;
+  owner?: BrowserSessionOwner;
   reuseExisting?: boolean;
   sessionName: string;
   authState?: BrowserSessionAuthState;
@@ -153,6 +156,27 @@ export class ActiveBrowserSessionConflictError extends Error {
   }
 }
 
+export class BrowserSessionOwnershipConflictError extends Error {
+  readonly activeOwner: BrowserSessionOwner;
+  readonly code = "browser-session-ownership-conflict";
+  readonly requestedOwner: BrowserSessionOwner;
+  readonly sessionName: string;
+
+  constructor(input: {
+    activeOwner: BrowserSessionOwner;
+    requestedOwner: BrowserSessionOwner;
+    sessionName: string;
+  }) {
+    super(
+      `Browser session "${input.sessionName}" is already active for ${input.activeOwner} work.`
+    );
+    this.name = "BrowserSessionOwnershipConflictError";
+    this.activeOwner = input.activeOwner;
+    this.requestedOwner = input.requestedOwner;
+    this.sessionName = input.sessionName;
+  }
+}
+
 /**
  * Manages named persistent Playwright profiles inside the local app workspace.
  */
@@ -171,10 +195,19 @@ export class BrowserSessionService {
    */
   async openSession(options: OpenBrowserSessionOptions): Promise<ProviderBrowserSession> {
     const activeSession = this.#activeSessions.get(options.sessionName);
+    const owner = resolveBrowserSessionOwner(options);
 
     if (activeSession) {
       if (options.reuseExisting === false) {
         throw new ActiveBrowserSessionConflictError(options.sessionName);
+      }
+
+      if (activeSession.owner !== owner) {
+        throw new BrowserSessionOwnershipConflictError({
+          activeOwner: activeSession.owner,
+          requestedOwner: owner,
+          sessionName: options.sessionName
+        });
       }
 
       if (options.authState) {
@@ -211,6 +244,7 @@ export class BrowserSessionService {
       onClose: () => {
         this.#activeSessions.delete(options.sessionName);
       },
+      owner,
       record,
       sessionPaths
     });
@@ -276,6 +310,7 @@ export class BrowserSessionService {
 interface ManagedBrowserSessionOptions {
   context: BrowserContext;
   onClose: () => void;
+  owner: BrowserSessionOwner;
   record: BrowserSessionRecord;
   sessionPaths: {
     metadataPath: string;
@@ -303,6 +338,7 @@ class ManagedBrowserSession implements ProviderBrowserSession {
     this.#onClose = options.onClose;
     this.#record = options.record;
     this.#sessionRoot = options.sessionPaths.sessionRoot;
+    this.owner = options.owner;
     this.sessionName = options.record.sessionName;
     this.wasReused = options.record.createdAt !== options.record.lastOpenedAt;
   }
@@ -313,6 +349,7 @@ class ManagedBrowserSession implements ProviderBrowserSession {
 
   readonly sessionName: string;
   readonly wasReused: boolean;
+  readonly owner: BrowserSessionOwner;
 
   async navigate(
     options: BrowserSessionNavigationOptions
@@ -415,6 +452,16 @@ function sanitizeSessionName(sessionName: string) {
   }
 
   return safeSessionName;
+}
+
+function resolveBrowserSessionOwner(
+  options: OpenBrowserSessionOptions
+): BrowserSessionOwner {
+  if (options.owner) {
+    return options.owner;
+  }
+
+  return (options.headless ?? true) ? "background" : "operator";
 }
 
 async function readBrowserSessionRecord(metadataPath: string) {

--- a/src/features/providers/bandcamp.test.ts
+++ b/src/features/providers/bandcamp.test.ts
@@ -556,6 +556,83 @@ describe("createBandcampProvider", () => {
       await rm(expiredWorkspaceRoot, { force: true, recursive: true });
     }
   });
+
+  it("rejects background search while an operator-owned Bandcamp session is already open", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-bandcamp-provider-operator-session-")
+    );
+    const fixtureServer = await startBandcampFixtureServer({
+      releases: [
+        {
+          artistName: "DJ Sealer",
+          downloadOptions: [
+            {
+              body: "mp3 fixture payload\n",
+              contentType: "audio/mpeg",
+              fileName: "warehouse-tool.mp3",
+              formatKey: "mp3-320",
+              label: "MP3 320"
+            }
+          ],
+          durationSeconds: 392,
+          entitlement: "owned",
+          path: "/album/warehouse-tool-extended-mix",
+          title: "Warehouse Tool (Extended Mix)",
+          trackId: "bandcamp-track-111"
+        }
+      ],
+      searchResults: ["/album/warehouse-tool-extended-mix"]
+    });
+    const browserSessionService = new BrowserSessionService({ workspaceRoot });
+    const provider = createBandcampProvider({
+      baseUrl: fixtureServer.origin,
+      browserSessionService
+    });
+
+    try {
+      await seedAuthenticatedSession(browserSessionService);
+      const operatorSession = await browserSessionService.openSession({
+        owner: "operator",
+        sessionName: BANDCAMP_SESSION_NAME
+      });
+      const setupUrl = `${fixtureServer.origin}/album/warehouse-tool-extended-mix`;
+
+      await operatorSession.navigate({
+        url: setupUrl,
+        waitUntil: "load"
+      });
+
+      await expect(
+        provider.search({
+          track: canonicalizeTrack({
+            artistName: "DJ Sealer",
+            source: "spotify",
+            title: "Warehouse Tool (Extended Mix)"
+          })
+        })
+      ).resolves.toEqual({
+        outcome: "rejected",
+        rejection: {
+          detail:
+            "An operator-owned browser session is already open for Bandcamp. Finish or close it before background provider work can run.",
+          providerId: BANDCAMP_PROVIDER_ID,
+          providerName: BANDCAMP_PROVIDER_NAME,
+          reason: "provider-session-active",
+          retryable: true,
+          trackDecisionReason: undefined
+        }
+      });
+      await expect(operatorSession.withPage(async (page) => page.url())).resolves.toBe(
+        setupUrl
+      );
+
+      await operatorSession.close();
+    } finally {
+      await browserSessionService.shutdown();
+      await fixtureServer.close();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
 });
 
 type ReleaseEntitlement =

--- a/src/features/providers/bandcamp.ts
+++ b/src/features/providers/bandcamp.ts
@@ -4,12 +4,7 @@ import path from "node:path";
 
 import type { Page } from "playwright";
 
-import {
-  BrowserSessionService,
-  ExpiredBrowserSessionAuthStateError,
-  MissingBrowserSessionAuthStateError,
-  MissingBrowserSessionStateError
-} from "@/features/browser/browser-session-service";
+import { BrowserSessionService } from "@/features/browser/browser-session-service";
 import { canonicalizeTrack, type CanonicalTrack } from "@/features/tracks/canonical-track";
 
 import {
@@ -21,6 +16,7 @@ import {
   type ProviderCandidate,
   type ProviderSearchInput
 } from "./provider-registry";
+import { openAuthenticatedBackgroundProviderSession } from "./provider-browser-session";
 
 export const BANDCAMP_PROVIDER_ID = "bandcamp";
 export const BANDCAMP_PROVIDER_NAME = "Bandcamp";
@@ -331,36 +327,16 @@ async function openAuthenticatedSession(
   browserSessionService: BandcampProviderDependencies["browserSessionService"],
   sessionName: string
 ) {
-  try {
-    await browserSessionService.requireAuthenticatedSession(sessionName);
-  } catch (error) {
-    if (
-      error instanceof MissingBrowserSessionStateError ||
-      error instanceof MissingBrowserSessionAuthStateError
-    ) {
-      return buildProviderRejectedResult({
-        detail:
-          "An authenticated Bandcamp browser session is required before automatic downloads can run.",
-        providerId: BANDCAMP_PROVIDER_ID,
-        providerName: BANDCAMP_PROVIDER_NAME,
-        reason: "auth-required"
-      });
-    }
-
-    if (error instanceof ExpiredBrowserSessionAuthStateError) {
-      return buildProviderRejectedResult({
-        detail:
-          "The Bandcamp browser session expired and must be refreshed before automatic downloads can run.",
-        providerId: BANDCAMP_PROVIDER_ID,
-        providerName: BANDCAMP_PROVIDER_NAME,
-        reason: "provider-session-expired"
-      });
-    }
-
-    throw error;
-  }
-
-  return browserSessionService.openSession({ sessionName });
+  return openAuthenticatedBackgroundProviderSession({
+    authRequiredDetail:
+      "An authenticated Bandcamp browser session is required before automatic downloads can run.",
+    browserSessionService,
+    expiredDetail:
+      "The Bandcamp browser session expired and must be refreshed before automatic downloads can run.",
+    providerId: BANDCAMP_PROVIDER_ID,
+    providerName: BANDCAMP_PROVIDER_NAME,
+    sessionName
+  });
 }
 
 function buildSearchQuery(track: CanonicalTrack) {

--- a/src/features/providers/beatport.test.ts
+++ b/src/features/providers/beatport.test.ts
@@ -13,6 +13,8 @@ import path from "node:path";
 import { BrowserSessionService } from "@/features/browser/browser-session-service";
 
 import {
+  BEATPORT_PROVIDER_ID,
+  BEATPORT_PROVIDER_NAME,
   BEATPORT_SESSION_NAME,
   createBeatportProvider
 } from "./beatport";
@@ -203,6 +205,57 @@ describe("createBeatportProvider", () => {
       });
     } finally {
       await browserSessionService.shutdown();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects background Beatport search while an operator-owned session is already open", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-beatport-provider-operator-session-")
+    );
+    const fixtureServer = await startFixtureServer();
+    const browserSessionService = new BrowserSessionService({ workspaceRoot });
+
+    try {
+      await seedAuthenticatedSession(browserSessionService);
+      const operatorSession = await browserSessionService.openSession({
+        owner: "operator",
+        sessionName: BEATPORT_SESSION_NAME
+      });
+      const setupUrl = `${fixtureServer.baseUrl}/track/consciousness/1001`;
+
+      await operatorSession.navigate({
+        url: setupUrl,
+        waitUntil: "load"
+      });
+
+      await expect(
+        createBeatportProvider({
+          baseUrl: fixtureServer.baseUrl,
+          browserSessionService
+        }).search({
+          track: buildCanonicalTrack()
+        })
+      ).resolves.toEqual({
+        outcome: "rejected",
+        rejection: {
+          detail:
+            "An operator-owned browser session is already open for Beatport. Finish or close it before background provider work can run.",
+          providerId: BEATPORT_PROVIDER_ID,
+          providerName: BEATPORT_PROVIDER_NAME,
+          reason: "provider-session-active",
+          retryable: true,
+          trackDecisionReason: undefined
+        }
+      });
+      await expect(operatorSession.withPage(async (page) => page.url())).resolves.toBe(
+        setupUrl
+      );
+
+      await operatorSession.close();
+    } finally {
+      await browserSessionService.shutdown();
+      await fixtureServer.close();
       await rm(workspaceRoot, { force: true, recursive: true });
     }
   });

--- a/src/features/providers/beatport.ts
+++ b/src/features/providers/beatport.ts
@@ -4,12 +4,7 @@ import path from "node:path";
 
 import type { Page } from "playwright";
 
-import {
-  BrowserSessionService,
-  ExpiredBrowserSessionAuthStateError,
-  MissingBrowserSessionAuthStateError,
-  MissingBrowserSessionStateError
-} from "@/features/browser/browser-session-service";
+import { BrowserSessionService } from "@/features/browser/browser-session-service";
 import {
   canonicalizeTrack,
   type CanonicalTrack
@@ -23,6 +18,10 @@ import {
   type ProviderArtifactFormat,
   type ProviderCandidate
 } from "./provider-registry";
+import {
+  openAuthenticatedBackgroundProviderSession,
+  openBackgroundProviderSession
+} from "./provider-browser-session";
 
 export const BEATPORT_PROVIDER_ID = "beatport";
 export const BEATPORT_PROVIDER_NAME = "Beatport";
@@ -106,9 +105,15 @@ async function searchBeatport(input: {
   sessionName: string;
   track: CanonicalTrack;
 }) {
-  const session = await input.browserSessionService.openSession({
+  const session = await openBackgroundProviderSession({
+    browserSessionService: input.browserSessionService,
+    providerId: BEATPORT_PROVIDER_ID,
+    providerName: BEATPORT_PROVIDER_NAME,
     sessionName: input.sessionName
   });
+  if ("outcome" in session) {
+    return session;
+  }
   const searchQuery = buildBeatportSearchQuery(input.track);
 
   try {
@@ -425,38 +430,15 @@ async function openAuthenticatedSession(input: {
   candidate: ProviderCandidate;
   sessionName: string;
 }) {
-  try {
-    await input.browserSessionService.requireAuthenticatedSession(input.sessionName);
-  } catch (error) {
-    if (
-      error instanceof MissingBrowserSessionStateError ||
-      error instanceof MissingBrowserSessionAuthStateError
-    ) {
-      return buildProviderRejectedResult({
-        candidate: input.candidate,
-        detail:
-          "An authenticated Beatport browser session is required before owned downloads can be acquired.",
-        providerId: BEATPORT_PROVIDER_ID,
-        providerName: BEATPORT_PROVIDER_NAME,
-        reason: "auth-required"
-      });
-    }
-
-    if (error instanceof ExpiredBrowserSessionAuthStateError) {
-      return buildProviderRejectedResult({
-        candidate: input.candidate,
-        detail:
-          "The Beatport browser session expired and must be refreshed before owned downloads can be acquired.",
-        providerId: BEATPORT_PROVIDER_ID,
-        providerName: BEATPORT_PROVIDER_NAME,
-        reason: "provider-session-expired"
-      });
-    }
-
-    throw error;
-  }
-
-  return input.browserSessionService.openSession({
+  return openAuthenticatedBackgroundProviderSession({
+    authRequiredDetail:
+      "An authenticated Beatport browser session is required before owned downloads can be acquired.",
+    browserSessionService: input.browserSessionService,
+    candidate: input.candidate,
+    expiredDetail:
+      "The Beatport browser session expired and must be refreshed before owned downloads can be acquired.",
+    providerId: BEATPORT_PROVIDER_ID,
+    providerName: BEATPORT_PROVIDER_NAME,
     sessionName: input.sessionName
   });
 }

--- a/src/features/providers/provider-browser-session.ts
+++ b/src/features/providers/provider-browser-session.ts
@@ -1,0 +1,107 @@
+import {
+  BrowserSessionOwnershipConflictError,
+  ExpiredBrowserSessionAuthStateError,
+  MissingBrowserSessionAuthStateError,
+  MissingBrowserSessionStateError,
+  type BrowserSessionService
+} from "@/features/browser/browser-session-service";
+
+import {
+  buildProviderRejectedResult,
+  type ProviderCandidate
+} from "./provider-registry";
+
+type BackgroundProviderBrowserSessionService = Pick<
+  BrowserSessionService,
+  "openSession"
+>;
+
+type AuthenticatedBackgroundProviderBrowserSessionService = Pick<
+  BrowserSessionService,
+  "openSession" | "requireAuthenticatedSession"
+>;
+
+type ProviderSessionContext = {
+  candidate?: ProviderCandidate;
+  providerId: string;
+  providerName: string;
+  sessionName: string;
+};
+
+export async function openBackgroundProviderSession(
+  input: ProviderSessionContext & {
+    browserSessionService: BackgroundProviderBrowserSessionService;
+  }
+) {
+  try {
+    return await input.browserSessionService.openSession({
+      owner: "background",
+      sessionName: input.sessionName
+    });
+  } catch (error) {
+    if (error instanceof BrowserSessionOwnershipConflictError) {
+      return buildProviderRejectedResult({
+        candidate: input.candidate,
+        detail: buildOwnershipConflictDetail({
+          activeOwner: error.activeOwner,
+          providerName: input.providerName
+        }),
+        providerId: input.providerId,
+        providerName: input.providerName,
+        reason: "provider-session-active"
+      });
+    }
+
+    throw error;
+  }
+}
+
+export async function openAuthenticatedBackgroundProviderSession(
+  input: ProviderSessionContext & {
+    authRequiredDetail: string;
+    browserSessionService: AuthenticatedBackgroundProviderBrowserSessionService;
+    expiredDetail: string;
+  }
+) {
+  try {
+    await input.browserSessionService.requireAuthenticatedSession(input.sessionName);
+  } catch (error) {
+    if (
+      error instanceof MissingBrowserSessionStateError ||
+      error instanceof MissingBrowserSessionAuthStateError
+    ) {
+      return buildProviderRejectedResult({
+        candidate: input.candidate,
+        detail: input.authRequiredDetail,
+        providerId: input.providerId,
+        providerName: input.providerName,
+        reason: "auth-required"
+      });
+    }
+
+    if (error instanceof ExpiredBrowserSessionAuthStateError) {
+      return buildProviderRejectedResult({
+        candidate: input.candidate,
+        detail: input.expiredDetail,
+        providerId: input.providerId,
+        providerName: input.providerName,
+        reason: "provider-session-expired"
+      });
+    }
+
+    throw error;
+  }
+
+  return openBackgroundProviderSession(input);
+}
+
+function buildOwnershipConflictDetail(input: {
+  activeOwner: "background" | "operator";
+  providerName: string;
+}) {
+  if (input.activeOwner === "operator") {
+    return `An operator-owned browser session is already open for ${input.providerName}. Finish or close it before background provider work can run.`;
+  }
+
+  return `Another background browser session is already active for ${input.providerName}. Wait for it to finish before retrying provider work.`;
+}

--- a/src/features/providers/provider-registry.ts
+++ b/src/features/providers/provider-registry.ts
@@ -39,6 +39,7 @@ export type ProviderArtifactFormat = (typeof PROVIDER_ARTIFACT_FORMATS)[number];
 export const PROVIDER_REJECTION_REASONS = [
   "auth-required",
   "provider-session-expired",
+  "provider-session-active",
   "candidate-format-unavailable",
   "candidate-mix-rejected",
   "candidate-duration-too-short",
@@ -235,6 +236,7 @@ const IMPLEMENTATION_BUCKET_ORDER: Record<ProviderImplementationBucket, number> 
 const RETRYABLE_REJECTION_REASONS = new Set<ProviderRejectionReason>([
   "auth-required",
   "provider-session-expired",
+  "provider-session-active",
   "download-artifact-missing",
   "provider-error"
 ]);

--- a/src/features/providers/soundcloud-direct-downloads.test.ts
+++ b/src/features/providers/soundcloud-direct-downloads.test.ts
@@ -438,6 +438,79 @@ describe("createSoundCloudDirectDownloadsProvider", () => {
     }
   });
 
+  it("rejects background search while an operator-owned SoundCloud session is already open", async () => {
+    const workspaceRoot = await mkdtemp(
+      path.join(os.tmpdir(), "music-downloader-soundcloud-provider-operator-session-")
+    );
+    const fixtureServer = await startSoundCloudFixtureServer({
+      searchResults: ["/dj-sealer/warehouse-tool-extended-mix"],
+      tracks: [
+        {
+          artistName: "DJ Sealer",
+          download: {
+            body: "mp3 fixture payload\n",
+            contentType: "audio/mpeg",
+            fileName: "warehouse-tool.mp3"
+          },
+          durationSeconds: 392,
+          path: "/dj-sealer/warehouse-tool-extended-mix",
+          title: "Warehouse Tool (Extended Mix)",
+          trackId: "111"
+        }
+      ]
+    });
+    const browserSessionService = new BrowserSessionService({ workspaceRoot });
+    const provider = createSoundCloudDirectDownloadsProvider({
+      baseUrl: fixtureServer.origin,
+      browserSessionService
+    });
+
+    try {
+      await seedAuthenticatedSession(browserSessionService);
+      const operatorSession = await browserSessionService.openSession({
+        owner: "operator",
+        sessionName: SOUNDCLOUD_DIRECT_DOWNLOADS_SESSION_NAME
+      });
+      const setupUrl =
+        `${fixtureServer.origin}/dj-sealer/warehouse-tool-extended-mix`;
+
+      await operatorSession.navigate({
+        url: setupUrl,
+        waitUntil: "load"
+      });
+
+      await expect(
+        provider.search({
+          track: canonicalizeTrack({
+            artistName: "DJ Sealer",
+            source: "spotify",
+            title: "Warehouse Tool (Extended Mix)"
+          })
+        })
+      ).resolves.toEqual({
+        outcome: "rejected",
+        rejection: {
+          detail:
+            "An operator-owned browser session is already open for SoundCloud Direct Downloads. Finish or close it before background provider work can run.",
+          providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+          providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+          reason: "provider-session-active",
+          retryable: true,
+          trackDecisionReason: undefined
+        }
+      });
+      await expect(operatorSession.withPage(async (page) => page.url())).resolves.toBe(
+        setupUrl
+      );
+
+      await operatorSession.close();
+    } finally {
+      await browserSessionService.shutdown();
+      await fixtureServer.close();
+      await rm(workspaceRoot, { force: true, recursive: true });
+    }
+  });
+
   it(
     "acquires the original uploaded file and normalizes artifact metadata",
     async () => {

--- a/src/features/providers/soundcloud-direct-downloads.ts
+++ b/src/features/providers/soundcloud-direct-downloads.ts
@@ -4,12 +4,7 @@ import path from "node:path";
 
 import type { Page } from "playwright";
 
-import {
-  BrowserSessionService,
-  ExpiredBrowserSessionAuthStateError,
-  MissingBrowserSessionAuthStateError,
-  MissingBrowserSessionStateError
-} from "@/features/browser/browser-session-service";
+import { BrowserSessionService } from "@/features/browser/browser-session-service";
 import { canonicalizeTrack, type CanonicalTrack } from "@/features/tracks/canonical-track";
 
 import {
@@ -21,6 +16,7 @@ import {
   type ProviderCandidate,
   type ProviderSearchInput
 } from "./provider-registry";
+import { openAuthenticatedBackgroundProviderSession } from "./provider-browser-session";
 
 export const SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID = "soundcloud-direct-downloads";
 export const SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME =
@@ -307,36 +303,16 @@ async function openAuthenticatedSession(
   browserSessionService: SoundCloudDirectDownloadsProviderDependencies["browserSessionService"],
   sessionName: string
 ) {
-  try {
-    await browserSessionService.requireAuthenticatedSession(sessionName);
-  } catch (error) {
-    if (
-      error instanceof MissingBrowserSessionStateError ||
-      error instanceof MissingBrowserSessionAuthStateError
-    ) {
-      return buildProviderRejectedResult({
-        detail:
-          "An authenticated SoundCloud browser session is required before automatic downloads can run.",
-        providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
-        providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
-        reason: "auth-required"
-      });
-    }
-
-    if (error instanceof ExpiredBrowserSessionAuthStateError) {
-      return buildProviderRejectedResult({
-        detail:
-          "The SoundCloud browser session expired and must be refreshed before automatic downloads can run.",
-        providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
-        providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
-        reason: "provider-session-expired"
-      });
-    }
-
-    throw error;
-  }
-
-  return browserSessionService.openSession({ sessionName });
+  return openAuthenticatedBackgroundProviderSession({
+    authRequiredDetail:
+      "An authenticated SoundCloud browser session is required before automatic downloads can run.",
+    browserSessionService,
+    expiredDetail:
+      "The SoundCloud browser session expired and must be refreshed before automatic downloads can run.",
+    providerId: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_ID,
+    providerName: SOUNDCLOUD_DIRECT_DOWNLOADS_PROVIDER_NAME,
+    sessionName
+  });
 }
 
 function buildSearchQuery(track: CanonicalTrack) {


### PR DESCRIPTION
**@worker-03**

## Summary
- add browser-session ownership so background work cannot reuse an operator-owned provider session
- route SoundCloud, Bandcamp, and Beatport background session opens through a shared helper that turns ownership conflicts into retryable provider rejections
- add service-level and provider-level regressions proving queued provider work leaves the operator session untouched

## Verification
- `npm run test`
- `npm run lint`

## Issue
- Closes #103
